### PR TITLE
fix(helm) update license header comment style in template folder

### DIFF
--- a/.github/ct.yaml
+++ b/.github/ct.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# See https://github.com/helm/chart-testing#configuration
+remote: origin
+target-branch: main
+validate-maintainers: false
+check-version-increment: false
+chart-dirs:
+  - alerts/charts
+  - cert-manager/charts/v1.11.0/cert-manager
+  - exposed-services/charts/v2.0.0/exposed-services
+  - kube-monitoring
+  - service-proxy/charts/1.0.0
+chart-repos:
+  - cert-manager=https://charts.jetstack.io
+  - alerts=https://prometheus-community.github.io/helm-charts
+  - kube-monitoring=https://prometheus-community.github.io/helm-charts

--- a/exposed-services/charts/v1.0.0/exposed-service/templates/deployment.yaml
+++ b/exposed-services/charts/v1.0.0/exposed-service/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/exposed-services/charts/v1.0.0/exposed-service/templates/service.yaml
+++ b/exposed-services/charts/v1.0.0/exposed-service/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/exposed-services/charts/v2.0.0/exposed-service/templates/deployment.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/exposed-services/charts/v2.0.0/exposed-service/templates/service.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/kubeconfig-generator/chart/templates/clusterrole.yaml
+++ b/kubeconfig-generator/chart/templates/clusterrole.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole

--- a/kubeconfig-generator/chart/templates/clusterrolebinding.yaml
+++ b/kubeconfig-generator/chart/templates/clusterrolebinding.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/kubeconfig-generator/chart/templates/configmap.yaml
+++ b/kubeconfig-generator/chart/templates/configmap.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ConfigMap

--- a/kubeconfig-generator/chart/templates/deployment.yaml
+++ b/kubeconfig-generator/chart/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/kubeconfig-generator/chart/templates/role.yaml
+++ b/kubeconfig-generator/chart/templates/role.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/kubeconfig-generator/chart/templates/rolebinding.yaml
+++ b/kubeconfig-generator/chart/templates/rolebinding.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/kubeconfig-generator/chart/templates/secret.yaml
+++ b/kubeconfig-generator/chart/templates/secret.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Secret

--- a/kubeconfig-generator/chart/templates/serviceaccount.yaml
+++ b/kubeconfig-generator/chart/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: ServiceAccount

--- a/service-proxy/charts/1.0.0/service-proxy/templates/deployment.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/deployment.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: apps/v1
 kind: Deployment

--- a/service-proxy/charts/1.0.0/service-proxy/templates/ingress.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/ingress.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- $fullName := include "service-proxy.fullname" . -}}
 {{- $svcPort := .Values.service.port -}}

--- a/service-proxy/charts/1.0.0/service-proxy/templates/role.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/role.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role

--- a/service-proxy/charts/1.0.0/service-proxy/templates/rolebinding.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/rolebinding.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/service-proxy/charts/1.0.0/service-proxy/templates/service.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/service.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 apiVersion: v1
 kind: Service

--- a/service-proxy/charts/1.0.0/service-proxy/templates/serviceaccount.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
+{{/* 
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
 
 {{- if .Values.serviceAccount.create -}}
 apiVersion: v1


### PR DESCRIPTION
@IvoGoman found out that the comment style `#` does not work for the files in `../templates/*.yaml`. The comment style has to be changed to `{{/* ... */}}` for helm to be able to template the files.