### PR TITLE
fix(kubecfg-gen): map CRoleBinding to CRole, change registry

### DIFF
--- a/kubeconfig-generator/chart/Chart.yaml
+++ b/kubeconfig-generator/chart/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
 type: application
 name: kubeconfig-generator
-version: 0.1.1
+version: 0.1.2
 appVersion: "608ca9c2d3cf9b8400c629e9e0989a3d62c31669"
 keywords:
 - operator

--- a/kubeconfig-generator/chart/templates/clusterrolebinding.yaml
+++ b/kubeconfig-generator/chart/templates/clusterrolebinding.yaml
@@ -6,11 +6,11 @@ SPDX-License-Identifier: Apache-2.0
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: kubeconfig-generator
+  name: kubeconfig-generator-{{ .Release.Namespace }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: kubeconfig-generator
+  name: kubeconfig-generator-{{ .Release.Namespace }}
 subjects:
 - kind: ServiceAccount
   name: kubeconfig-generator

--- a/kubeconfig-generator/chart/templates/configmap.yaml
+++ b/kubeconfig-generator/chart/templates/configmap.yaml
@@ -15,6 +15,6 @@ data:
       region: {{ .Values.swift.region | quote }}
       username: {{ .Values.swift.username | quote }}
       password: ${SWIFT_PASSWORD}
-      domainName: {{ .Values.swift.doaminName | quote }}
+      domainName: {{ .Values.swift.domainName | quote }}
       projectId: {{ .Values.swift.projectId | quote }}
       container: {{ .Values.swift.container | quote }}

--- a/kubeconfig-generator/plugin.yaml
+++ b/kubeconfig-generator/plugin.yaml
@@ -10,8 +10,8 @@ spec:
   version: 0.1.1
   helmChart:
     name: kubeconfig-generator
-    repository: oci://ghcr.io/sapcc/helm-charts
-    version: 0.1.1
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions
+    version: 0.1.2
   options:
     - name: swift.authUrl
       description: Keystone endpoint to be used for authentication


### PR DESCRIPTION
I have renamed the _ClusterRoleBinding_ to ensure no name-clashes if the _Plugin_ is deployed by different organizations.
The registry was changed to have the upload work with the existing CI piplines to upload the chart to our OCI registry.