### PR TITLE
fix(kubecfg-gen): quote cluster.name, typo for clientSecretRef

### DIFF
--- a/kubeconfig-generator/chart/Chart.yaml
+++ b/kubeconfig-generator/chart/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
 type: application
 name: kubeconfig-generator
-version: 0.1.3
+version: 0.1.4
 appVersion: "e95c43319aad8914e40fa6a5e2e026f1ecb359f9"
 keywords:
 - operator

--- a/kubeconfig-generator/chart/templates/configmap.yaml
+++ b/kubeconfig-generator/chart/templates/configmap.yaml
@@ -22,13 +22,13 @@ data:
     {{- if .Values.cluster }}
     cluster:
       {{- range .Values.cluster }}
-    - name: {{ .name }}
+    - name: {{ .name | quote }}
       namespace: {{ $.Release.Namespace }}
       clientIdRef:
         name: {{ .clientIdRef.name }}
         key: {{ .clientIdRef.key }}
       clientSecretRef:
         name: {{ .clientSecretRef.name }}
-        key: {{ .clientSecretRef.name }}
+        key: {{ .clientSecretRef.key }}
       {{- end }}
     {{- end }}

--- a/kubeconfig-generator/plugin.yaml
+++ b/kubeconfig-generator/plugin.yaml
@@ -7,11 +7,11 @@ metadata:
   name: kubeconfig-generator
 spec:
   description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
-  version: 0.1.2
+  version: 0.1.3
   helmChart:
     name: kubeconfig-generator
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions
-    version: 0.1.3
+    version: 0.1.4
   options:
     - name: swift.authUrl
       description: Keystone endpoint to be used for authentication


### PR DESCRIPTION
Controller does not parse Config if the `.cluster.name` is _*_  and not quoted.