### PR TITLE
fix: security context to allow disk writes

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.6.5
+version: 0.6.6
 # prometheus-operator app version
 appVersion: v0.71.2
 keywords:

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -218,6 +218,15 @@ kubeMonitoring:
         matchLabels:
           pluginconfig: "{{ $.Release.Name }}"
 
+      ## securityContext for pod-level security attributes
+      securityContext:
+        # runAsGroup: 2000
+        # runAsNonRoot: true
+        runAsUser: 0  # 1000
+        fsGroup: 0  # 2000
+        # seccompProfile:
+          # type: RuntimeDefault
+
 alerts:
   enabled: false
   alertmanagers:


### PR DESCRIPTION
current settings did not allow prometheus to write files. the folder was created correctly under /data but it then failed with missing write permissions

I am happy to start the discussion, whether there is a better way here or not, this however is working, the old settings weren't.