### PR TITLE
fix(alerts-ui): make app public, remove stars from peerDependencies and some typos

### DIFF
--- a/alerts/ui/package-lock.json
+++ b/alerts/ui/package-lock.json
@@ -49,14 +49,14 @@
       "peerDependencies": {
         "@tanstack/react-query": "5.36.2",
         "custom-event-polyfill": "^1.0.7",
-        "juno-ui-components": "*",
+        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.8/package.tgz",
         "luxon": "^2.3.0",
-        "messages-provider": "*",
+        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
         "prop-types": "^15.8.1",
         "react": "18.2.0",
-        "react-dom": "^18.2.0",
-        "url-state-provider": "*",
-        "zustand": "4.3.7"
+        "react-dom": "18.2.0",
+        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
+        "zustand": "4.5.2"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/alerts/ui/package-lock.json
+++ b/alerts/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supernova",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "supernova",
-      "version": "0.9.13",
+      "version": "0.9.14",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.20.2",

--- a/alerts/ui/package.json
+++ b/alerts/ui/package.json
@@ -10,7 +10,7 @@
   "license": "Apache-2.0",
   "source": "src/index.js",
   "module": "build/index.js",
-  "private": true,
+  "private": false,
   "devDependencies": {
     "@babel/core": "^7.20.2",
     "@babel/preset-env": "^7.20.2",
@@ -52,17 +52,17 @@
   "peerDependencies": {
     "@tanstack/react-query": "5.36.2",
     "custom-event-polyfill": "^1.0.7",
-    "juno-ui-components": "*",
+    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.8/package.tgz",
     "luxon": "^2.3.0",
-    "messages-provider": "*",
+    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
     "prop-types": "^15.8.1",
     "react": "18.2.0",
-    "react-dom": "^18.2.0",
-    "url-state-provider": "*",
-    "zustand": "4.3.7"
+    "react-dom": "18.2.0",
+    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
+    "zustand": "4.5.2"
   },
   "importmapExtras": {
-    "zustand/middleware": "4.3.7"
+    "zustand/middleware": "4.5.2"
   },
   "scripts": {
     "start": "NODE_ENV=development node esbuild.config.js --port=$APP_PORT --serve --watch",
@@ -78,7 +78,7 @@
     "embedded": {
       "value": "false",
       "type": "optional",
-      "description": "Set to true if app is to be embedded in another existing app or page, like e.g. Elektra.  If set to true the app won't render a page header/footer and instead render only the content. The default value is false."
+      "description": "Set to true if app is to be embedded in another existing app or page.  If set to true the app won't render a page header/footer and instead render only the content. The default value is false."
     },
     "endpoint": {
       "value": "",

--- a/alerts/ui/package.json
+++ b/alerts/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supernova",
-  "version": "0.9.13",
+  "version": "0.9.14",
   "author": "UI-Team",
   "contributors": [
     "Esther Schmitz",


### PR DESCRIPTION
This PR contains:

- Set the MFE public
- Remove stars from the peerDependencies
- Set some peerDependencies version equal to the devDependencies
- Fixes some typos appProps description
- Patch version upgrade