### PR TITLE
fix(heureka) : Add error boundry to the app

### DIFF
--- a/heureka/ui/package-lock.json
+++ b/heureka/ui/package-lock.json
@@ -48,7 +48,6 @@
         "zustand": "4.5.2"
       },
       "peerDependencies": {
-        "@tanstack/react-query": "5.36.2",
         "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.8/package.tgz",
         "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
         "prop-types": "^15.8.1",

--- a/heureka/ui/package-lock.json
+++ b/heureka/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heureka",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heureka",
-      "version": "2.1.9",
+      "version": "2.1.10",
       "license": "Apache-2.0",
       "devDependencies": {
         "@babel/core": "^7.20.2",
@@ -38,6 +38,7 @@
         "prop-types": "^15.8.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-error-boundary": "^4.0.13",
         "react-test-renderer": "18.2.0",
         "sass": "^1.77.5",
         "shadow-dom-testing-library": "^1.7.1",
@@ -8799,6 +8800,18 @@
       },
       "peerDependencies": {
         "react": "^18.2.0"
+      }
+    },
+    "node_modules/react-error-boundary": {
+      "version": "4.0.13",
+      "resolved": "https://registry.npmjs.org/react-error-boundary/-/react-error-boundary-4.0.13.tgz",
+      "integrity": "sha512-b6PwbdSv8XeOSYvjt8LpgpKrZ0yGdtZokYwkwV2wlcZbxgopHX/hgPl5VgpnoVOWd868n1hktM8Qm4b+02MiLQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "peerDependencies": {
+        "react": ">=16.13.1"
       }
     },
     "node_modules/react-is": {

--- a/heureka/ui/package.json
+++ b/heureka/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heureka",
-  "version": "2.1.9",
+  "version": "2.1.10",
   "author": "UI-Team",
   "contributors": [
     "Hoda Noori, Arturo Reuschenbach Pucernau"
@@ -40,6 +40,7 @@
     "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-error-boundary": "^4.0.13",
     "react-test-renderer": "18.2.0",
     "sass": "^1.77.5",
     "shadow-dom-testing-library": "^1.7.1",

--- a/heureka/ui/package.json
+++ b/heureka/ui/package.json
@@ -55,7 +55,6 @@
     "build": "NODE_ENV=production node esbuild.config.js"
   },
   "peerDependencies": {
-    "@tanstack/react-query": "5.36.2",
     "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.8/package.tgz",
     "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
     "prop-types": "^15.8.1",

--- a/heureka/ui/src/App.js
+++ b/heureka/ui/src/App.js
@@ -5,14 +5,33 @@
 
 import React, { useEffect } from "react"
 import styles from "./styles.scss"
-import { AppShell, AppShellProvider } from "juno-ui-components"
+import { AppShell, AppShellProvider, CodeBlock } from "juno-ui-components"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 import { MessagesProvider } from "messages-provider"
 import AsyncWorker from "./components/AsyncWorker"
 import StoreProvider, { useActions } from "./components/StoreProvider"
 import TabContext from "./components/tabs/TabContext"
+import { ErrorBoundary } from "react-error-boundary"
 
 const App = (props) => {
+  const preErrorClasses = `
+  custom-error-pre
+  border-theme-error
+  border
+  h-full
+  w-full
+  `
+
+  const fallbackRender = ({ error }) => {
+    return (
+      <div className="w-1/2">
+        <CodeBlock className={preErrorClasses} copy={false}>
+          {error?.message || error?.toString() || "An error occurred"}
+        </CodeBlock>
+      </div>
+    )
+  }
+
   // Create a client
   const queryClient = new QueryClient({
     defaultOptions: {
@@ -32,7 +51,9 @@ const App = (props) => {
         pageHeader="Converged Cloud | Heureka"
         embedded={props.embedded === "true" || props.embedded === true}
       >
-        <TabContext />
+        <ErrorBoundary fallbackRender={fallbackRender}>
+          <TabContext />
+        </ErrorBoundary>
       </AppShell>
     </QueryClientProvider>
   )


### PR DESCRIPTION
## Pull Request Details

- Add error boundry codeblock to the app.js
- Extend fetchFromAPI func to cover the errors which occur in graphql api.
- Remove react-query pkg from peerDependencies to solve the following error loading heureka with black screen in greenhouse dashboard:
`es-module-shims.js:780 Uncaught (in promise) Error: Unsupported Content-Type "application/octet-stream" loading https://assets.juno.qa-de-1.cloud.sap/externals/@tanstack/react-query@5.36.2/build/legacy/index.cjs imported from https://assets.juno.qa-de-1.cloud.sap/apps/heureka@latest/build/App-AOJYYGXT.js. Modules must be served with a valid MIME type like application/javascript.
    at fetchModule (es-module-shims.js:780:13)
    at async es-module-shims.js:825:40`
