### PR TITLE
[opentelemetry-operator] temp add owner-info for pipeline

### DIFF
--- a/opentelemetry-collector/chart/Chart.yaml
+++ b/opentelemetry-collector/chart/Chart.yaml
@@ -18,3 +18,6 @@ dependencies:
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.56.0
+- name: owner-info
+  repository: https://charts.eu-de-2.cloud.sap
+  version: 0.2.0


### PR DESCRIPTION
## Pull Request Details

As the owner-info is currently mandatory for deploying via CI pipeline this is a temporary fix. Will be redacted soon.