### PR TITLE
docs: exposing named ports

### DIFF
--- a/exposed-services/README.md
+++ b/exposed-services/README.md
@@ -4,9 +4,16 @@ title: Service exposure test
 
 This Plugin is just providing a simple exposed service for manual testing.
 
-By adding the label `greenhouse.expose: "true"` to a service it will become accessible from the central greenhouse system via a service proxy.
+By adding the following label to a service it will become accessible from the central greenhouse system via a service proxy:
+
+```greenhouse.sap/expose: "true"```
 
 This plugin create an nginx deployment with an exposed service for testing.
 
 # Configuration
- No configuration possible at this point.
+
+## Specific port
+
+By default expose would always use the first port. If you need another port, you've got to specify it by name:
+
+```greenhouse.sap/exposeNamedPort: YOURPORTNAME```


### PR DESCRIPTION

## Pull Request Details

add documentation of how to specify a named port to be exposed.
To be merged after https://github.com/cloudoperators/greenhouse/pull/308

## Breaking Changes

None

## Issues Fixed

Knowledge of how to specify a named port to be exposed

## Other Relevant Information



