### PR TITLE
[CODEOWNERS] change name for otel repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -28,7 +28,7 @@ ct.yaml                   @cloudoperators/greenhouse-backend
 /kube-monitoring/         @richardtief @viennaa
 /kubeconfig-generator/    @Nuckal777 @ivogoman @uwe-mayer
 /logshipper/              @cloudoperators/greenhouse-backend
-/opentelemetry-collector  @timojohlo @Kuckkuck @richardtief @viennaa
+/opentelemetry-operator   @timojohlo @Kuckkuck @richardtief @viennaa
 /service-proxy/           @cloudoperators/greenhouse-backend @databus23 
 /teams2slack/             @cloudoperators/greenhouse-backend @voigts 
 ui/                       @cloudoperators/greenhouse-frontend


### PR DESCRIPTION
### Pull Request Details
Update Codeowners file after changing repository from /opentelemetry-collector to /opentelemetry-operator.