### PR TITLE
[opentelemetry-operator] add CRDs flags to values, rm wrong license, …

### DIFF
--- a/opentelemetry-operator/chart/Chart.yaml
+++ b/opentelemetry-operator/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.0.5
+version: 0.0.6
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry-operator/chart/crds/crd-smon.yaml
+++ b/opentelemetry-operator/chart/crds/crd-smon.yaml
@@ -1,7 +1,5 @@
-{{/* 
-SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-SPDX-License-Identifier: Apache-2.0
-*/}}
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
 
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/opentelemetry-operator/chart/values.yaml
+++ b/opentelemetry-operator/chart/values.yaml
@@ -1,7 +1,10 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-installCRDs: true
+installInstrumentation: true
+installCollector: true
+installOpAmpBridges: true
+installSmon: true
 
 opentelemetry-operator:
   admissionWebhooks:


### PR DESCRIPTION
---

## Pull Request Details

Currently the OpenTelemetry Operator only allows to install all CRDs or no CRD at all. With the availability of the OpenTelemetry Plugin in Greenhouse, users should be able to opt-in/opt-out on each CRD individually, so they can decide what exporter to use, what collector to use etc.

## Breaking Changes

None

## Issues Fixed

None

## Other Relevant Information

Adapting changes after #202 
