### PR TITLE
[opentelemetry-operator] hard-wire collector image

### DIFF
--- a/opentelemetry-operator/chart/values.yaml
+++ b/opentelemetry-operator/chart/values.yaml
@@ -5,6 +5,9 @@ opentelemetry-operator:
   admissionWebhooks:
     failurePolicy: 'Ignore'
   manager:
+    collectorImage:
+      repository: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib
+      tag: 0.104.0
     deploymentAnnotations:
       vpa-butler.cloud.sap/update-mode: Auto
     prometheusRule:


### PR DESCRIPTION
## Pull Request Details

Currently the collectors image (+tag) is provided through the PluginDefinition. When checking for the image via`kubectl otelcol` the image is missing. This is a attempt to check if hard-wiring the image will fix the issue. Test worked in test env. 