### PR TITLE
[opentelemetry-operator] add webhook config to crd

### DIFF
--- a/opentelemetry-operator/chart/Chart.yaml
+++ b/opentelemetry-operator/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.1.2
+version: 0.1.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry-operator/chart/crds/crd-opentelemetrycollector.yaml
+++ b/opentelemetry-operator/chart/crds/crd-opentelemetrycollector.yaml
@@ -12,6 +12,19 @@ metadata:
   labels:
     app.kubernetes.io/managed-by: Helm
 spec:
+  conversion:
+    strategy: Webhook
+    webhook:
+      clientConfig:
+        service:
+          name: opentelemetry-operator-webhook
+          namespace: {{ .Release.Namespace }}
+          path: /convert
+          port: {{ .Values.admissionWebhooks.servicePort }}
+  {{ if .caBundle }}{{ cat "caBundle:" .caBundle | indent 8 }}{{ end }}
+      conversionReviewVersions:
+      - v1alpha1
+      - v1beta1
   group: opentelemetry.io
   names:
     kind: OpenTelemetryCollector

--- a/opentelemetry-operator/plugindefinition.yaml
+++ b/opentelemetry-operator/plugindefinition.yaml
@@ -6,13 +6,13 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry-operator
 spec:
-    version: 0.1.2
+    version: 0.1.3
     description: opentelemetry-operator
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry-operator/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.2
+        version: 0.1.3
     options:
         - description: open_telemetry.opensearch_logs.username
           name: open_telemetry.opensearch_logs.username


### PR DESCRIPTION
## Pull Request Details

Currently the deployment runs into `failed to create resource: Internal error occurred: Internal error occurred: conversion webhook for opentelemetry.io/v1alpha1`. This PR includes the missing webhook configuration for the CRD resource. 