### PR TITLE
Add workflow for building and publishing integration test Docker image

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -10,6 +10,7 @@ header:
 
   paths-ignore:
     - '.github/**'
+    - '*Dockerfile*'
     - '.reuse/dep5'
     - 'LICENSES/*.txt'
     - 'cert-manager/charts/**' # ignore the license for the cert-manager charts

--- a/.github/workflows/integration-test-build-publish.yaml
+++ b/.github/workflows/integration-test-build-publish.yaml
@@ -17,7 +17,7 @@ env:
 jobs:
   build-and-push:
     name: Build and push Docker image
-    runs-on: ubuntu-latest
+    runs-on: [default]
     permissions:
       contents: read
       packages: write
@@ -85,7 +85,7 @@ jobs:
       security-events: write
     name: Vulnerability Scan
     needs: build-and-push
-    runs-on: ubuntu-latest
+    runs-on: [default]
     steps:
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@0.20.0

--- a/.github/workflows/integration-test-build-publish.yaml
+++ b/.github/workflows/integration-test-build-publish.yaml
@@ -88,7 +88,7 @@ jobs:
     runs-on: [default]
     steps:
       - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@0.20.0
+        uses: aquasecurity/trivy-action@0.24.0
         with:
           image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
           ignore-unfixed: true

--- a/.github/workflows/integration-test-build-publish.yaml
+++ b/.github/workflows/integration-test-build-publish.yaml
@@ -1,0 +1,103 @@
+name: Build and Publish Integration Test Docker Image
+
+on:
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+    paths:
+      - Dockerfile.integration-test
+    tags:
+      - v*.*.*
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: greenhouse-extensions-integration-test
+
+jobs:
+  build-and-push:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@v3.5.0
+        with:
+          cosign-release: "v2.2.3"
+      - name: Set up QEMU # For multi-platform builds
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx # For multi-platform builds
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=moby/buildkit:latest
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{major}},enable=${{ !startsWith(github.ref, 'refs/tags/v0.') }},prefix=v
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=schedule
+            type=raw,value=${{ github.sha }}
+            type=sha,enable=true,format=short,prefix=
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.integration-test
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm64
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  vulnerability-scan:
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+    name: Vulnerability Scan
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@0.20.0
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+          ignore-unfixed: true
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,14 +1,14 @@
-FROM bats/bats:1.11.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} bats/bats:1.11.0
 
 ARG KUBECTL_VERSION=v1.30.2
 
 # Add packages
-RUN apk upgrade --no-cache --no-progress \
-&& apk --no-cache --no-progress add curl git bash \
+RUN apk upgrade --no-cache --no-progress \  
+&& apk --no-cache --no-progress add curl git bash \  
 && apk del --no-cache --no-progress apk-tools alpine-keys
 
 # Install kubectl binary
-RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/${BUILDPLATFORM:-linux/amd64}/kubectl" && \
 	chmod +x kubectl && \
 	mv kubectl /usr/local/bin/
 	

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -11,3 +11,4 @@ RUN apk upgrade --no-cache --no-progress \
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
 	chmod +x kubectl && \
 	mv kubectl /usr/local/bin/
+	

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,12 +1,11 @@
-FROM bats/bats:latest
+FROM bats/bats:1.11.0
 
-ARG KUBECTL_VERSION=v1.29.2
+ARG KUBECTL_VERSION=v1.30.2
 
 # Add packages
-RUN apk --no-cache add \
-    curl \
-    git \
-    bash
+RUN apk upgrade --no-cache --no-progress \
+&& apk --no-cache --no-progress add curl git bash \
+&& apk del --no-cache --no-progress apk-tools alpine-keys
 
 # Install kubectl binary
 RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \

--- a/Dockerfile.integration-test
+++ b/Dockerfile.integration-test
@@ -1,0 +1,14 @@
+FROM bats/bats:latest
+
+ARG KUBECTL_VERSION=v1.29.2
+
+# Add packages
+RUN apk --no-cache add \
+    curl \
+    git \
+    bash
+
+# Install kubectl binary
+RUN curl -LO "https://storage.googleapis.com/kubernetes-release/release/$KUBECTL_VERSION/bin/linux/amd64/kubectl" && \
+	chmod +x kubectl && \
+	mv kubectl /usr/local/bin/


### PR DESCRIPTION
This pull request adds a new workflow for building and publishing an integration test Docker image. The workflow is triggered when there is a change in `Docker.integration-test` file and when a tag matching the pattern "v*.*.*" is pushed. It builds the Docker image using the Dockerfile.integration-test file and pushes it to the registry. Additionally, a vulnerability scan step is included to scan the image for vulnerabilities using Trivy and upload the scan results to the GHAS. 

I have already tested this workflow in my [personal github repository](https://github.com/ibakshay/k8s-infra/pkgs/container/greenhouse-extensions-integration-test).