### PR TITLE
[kube-monitoring] Bump the kube-monitoring Plugindefinition version

### DIFF
--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 1.8.0
+  version: 1.9.0
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.9.0
+    version: 0.10.0
   options:
     - name: kubeMonitoring.prometheus.ingress.enabled
       description: Ingress exposes prometheus outside the cluster


### PR DESCRIPTION
This Pull Request, 
- bumps the `kube-monitoring` Plugindefiniton version
- bumps the helm chart version of `kube-monitoring`