### PR TITLE
chore(doop): use npm deps for juno packages

### DIFF
--- a/doop/ui/jest.config.js
+++ b/doop/ui/jest.config.js
@@ -7,9 +7,7 @@ module.exports = {
   transform: { "\\.[jt]sx?$": "babel-jest" },
   testEnvironment: "jsdom",
   setupFilesAfterEnv: ["<rootDir>/setupTests.js"],
-  transformIgnorePatterns: [
-    // "node_modules/(?!(juno-ui-components|url-state-router|communicator|oauth|url-state-provider|messages-provider|policy-engine|utils)/)",
-  ],
+  transformIgnorePatterns: [],
   moduleNameMapper: {
     // Jest currently doesn't support resources with query parameters.
     // Therefore we add the optional query parameter matcher at the end

--- a/doop/ui/package-lock.json
+++ b/doop/ui/package-lock.json
@@ -8,6 +8,13 @@
       "name": "doop",
       "version": "2.2.6",
       "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudoperators/juno-communicator": "^2.2.11",
+        "@cloudoperators/juno-messages-provider": "^0.1.17",
+        "@cloudoperators/juno-ui-components": "^2.15.4",
+        "@cloudoperators/juno-url-state-provider": "^2.0.5",
+        "@cloudoperators/juno-utils": "^1.1.12"
+      },
       "devDependencies": {
         "@babel/core": "^7.20.2",
         "@babel/preset-env": "^7.20.2",
@@ -23,15 +30,12 @@
         "autoprefixer": "^10.4.2",
         "babel-jest": "^29.3.1",
         "babel-plugin-transform-import-meta": "^2.2.0",
-        "communicator": "https://assets.juno.global.cloud.sap/libs/communicator@2.2.5/package.tgz",
         "esbuild": "^0.17.19",
         "interweave": "^13.1.0",
         "jest": "^29.3.1",
         "jest-environment-jsdom": "^29.3.1",
         "jsdoc": "^4.0.2",
-        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.7/package.tgz",
         "luxon": "^3.0.0",
-        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
         "postcss": "^8.4.31",
         "postcss-url": "^10.1.3",
         "prop-types": "^15.8.1",
@@ -42,17 +46,12 @@
         "sass": "^1.77.5",
         "shadow-dom-testing-library": "^1.7.1",
         "tailwindcss": "^3.3.1",
-        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
-        "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
         "zustand": "^4.5.2"
       },
       "peerDependencies": {
-        "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.7/package.tgz",
-        "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
         "prop-types": "^15.8.1",
         "react": "18.2.0",
         "react-dom": "18.2.0",
-        "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
         "zustand": "^4.5.2"
       }
     },
@@ -1890,6 +1889,75 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "node_modules/@cloudoperators/juno-communicator": {
+      "version": "2.2.11",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-communicator/-/juno-communicator-2.2.11.tgz",
+      "integrity": "sha512-dDoqKw3nZuuNMkdmwYDG/l7Uw7a4rDF3RtteuEW9yUhMypocsGmbcgRhaZjUWpL21OPbFDVNi58r3+KO7IN2Ug==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@cloudoperators/juno-messages-provider": {
+      "version": "0.1.17",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-messages-provider/-/juno-messages-provider-0.1.17.tgz",
+      "integrity": "sha512-ZECrpMVr3jx25YdcyayFUSXMHDRp9hjDLLbUSvQqcJLxtscpE14WEqGffelAMfr0Q6AqOi0DlEoSMVFlh7fYZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@cloudoperators/juno-ui-components": "*"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "zustand": "^4.5.2"
+      }
+    },
+    "node_modules/@cloudoperators/juno-ui-components": {
+      "version": "2.15.4",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-ui-components/-/juno-ui-components-2.15.4.tgz",
+      "integrity": "sha512-lyziFGjtasxqiiZ86Yfn9EtJFtZ/72So1GmCsMdZCOt3WQnv/TcvQMnXCHe5Zg1fXZ/qNQWIac5rH6YbVS75yg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
+      },
+      "peerDependencies": {
+        "prop-types": "15.8.1",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0"
+      }
+    },
+    "node_modules/@cloudoperators/juno-url-state-provider": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-url-state-provider/-/juno-url-state-provider-2.0.5.tgz",
+      "integrity": "sha512-kV+jylwPDr9dU5+1jzJxWRyWE6WtwmK/Y6cebpEf77sdQk6CHCux9KkVsko/e/mD1tfTz6nb7gvuy+KSvgJDqA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "juri": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
+      }
+    },
+    "node_modules/@cloudoperators/juno-utils": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-utils/-/juno-utils-1.1.12.tgz",
+      "integrity": "sha512-thUgU/Kg7gmjhIZ6yALZSLCTKycBZ5y/LwwgSpinAVNbVebK8AassEcqloTgayTn6J3rAryDdSptfqnrzbuFLA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20.0.0 <21.0.0",
+        "npm": ">=10.0.0 <11.0.0"
+      },
+      "peerDependencies": {
+        "react": "^18.2.0"
+      }
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.19",
@@ -3957,13 +4025,13 @@
       "version": "15.7.12",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.12.tgz",
       "integrity": "sha512-5zvhXYtRNRluoE/jAp4GVsSduVUzNWKkOZrCDBWYtE7biZywwdC2AcEzg+cSMLFRfVgeAFqpfNabiPjxFddV1Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/react": {
       "version": "18.2.74",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.74.tgz",
       "integrity": "sha512-9AEqNZZyBx8OdZpxzQlaFEVCSFUM2YXJH46yPOiOpm078k6ZLOCcuAzGum/zK8YBwY+dbahVNbHrbgrAwIRlqw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.0.2"
@@ -4809,12 +4877,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/communicator": {
-      "version": "2.2.5",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/communicator@2.2.5/package.tgz",
-      "integrity": "sha512-zvRMST9RF2Bo5BKIwqO3wMYLtWaVnPKivqOqPQEEPBEUEdLQ3t8mc/gpZToEtuHD6TG68XwRJCxfdyo1ikI3iA==",
-      "dev": true
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -5035,7 +5097,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/cuint": {
       "version": "0.2.2",
@@ -8288,8 +8350,7 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -8426,23 +8487,11 @@
         "node": ">=6"
       }
     },
-    "node_modules/juno-ui-components": {
-      "version": "2.13.7",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.7/package.tgz",
-      "integrity": "sha512-MFWVb0DYfLUx2jGx86NNJk/hm0+L8CP54FVuMiRp5FZSYTYfr60h208wnjt3k0HiceSoSxHhV3VE5uHdASngXQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "prop-types": "15.8.1",
-        "react": "18.2.0",
-        "react-dom": "18.2.0"
-      }
-    },
     "node_modules/juri": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/juri/-/juri-1.0.3.tgz",
       "integrity": "sha512-ARxzFFY6FnmMtTejPKLfcHSVV+AN11xquK4aNaWBA/5adTAiSKxs5lIYhft2vxHH6M1HGXTY17PA462sX0zN7g==",
-      "dev": true
+      "license": "MIT"
     },
     "node_modules/klaw": {
       "version": "3.0.0",
@@ -8533,7 +8582,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -8861,18 +8909,6 @@
       "dev": true,
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/messages-provider": {
-      "version": "0.1.12",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
-      "integrity": "sha512-8XVowXV8wxBJ10FBEAO2AGMpdaf6C6UKQCAjJELJnJHYwPDBYOnMa4nOwHCwzurH6rh0QTmbAeFz4HpD8Yglrw==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "juno-ui-components": "*",
-        "react": "18.2.0",
-        "zustand": "4.5.2"
       }
     },
     "node_modules/micromark": {
@@ -9518,7 +9554,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10079,7 +10114,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -10089,8 +10123,7 @@
     "node_modules/prop-types/node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-      "dev": true
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/property-information": {
       "version": "6.5.0",
@@ -10163,7 +10196,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -10175,7 +10207,6 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -10530,7 +10561,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-CtuThmgHNg7zIZWAXi3AsyIzA3n4xx7aNyjwC2VJldO2LMVDhFK+63xGqq6CsJH4rTAt6/M+N4GhZiDYPx9eUw==",
-      "dev": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
@@ -11327,21 +11357,10 @@
         "requires-port": "^1.0.0"
       }
     },
-    "node_modules/url-state-provider": {
-      "version": "1.3.2",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
-      "integrity": "sha512-+6ID9hl4YIFiRd4EWy7oZlvFmevBNsIXa8KTZ0+HCj/f48s4NNZKXWooSakXeCmeFCzkcnP/Wv4jYD3RyWFAjg==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "juri": "^1.0.3"
-      }
-    },
     "node_modules/use-sync-external-store": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
       "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "dev": true,
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
@@ -11364,16 +11383,6 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
-    },
-    "node_modules/utils": {
-      "version": "1.1.6",
-      "resolved": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
-      "integrity": "sha512-EJY8lT7jRzwlOmHA4YLKdSA8caLVoR4m8giN0+A6wQ2tUFYkBKRbF+pC6On5557tZyi4M2/IHanY0gpwydH3MA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react": "^18.2.0"
-      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.2.0",
@@ -11757,7 +11766,6 @@
       "version": "4.5.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.2.tgz",
       "integrity": "sha512-2cN1tPkDVkwCy5ickKrI7vijSjPksFRfqS6237NzT0vqSsztTNnQdHw9mmN7uBdk3gceVXU0a+21jFzFzAc9+g==",
-      "dev": true,
       "dependencies": {
         "use-sync-external-store": "1.2.0"
       },

--- a/doop/ui/package-lock.json
+++ b/doop/ui/package-lock.json
@@ -12,7 +12,7 @@
         "@cloudoperators/juno-communicator": "^2.2.11",
         "@cloudoperators/juno-messages-provider": "^0.1.17",
         "@cloudoperators/juno-ui-components": "^2.15.4",
-        "@cloudoperators/juno-url-state-provider": "^2.0.5",
+        "@cloudoperators/juno-url-state-provider-v1": "^1.3.2",
         "@cloudoperators/juno-utils": "^1.1.12"
       },
       "devDependencies": {
@@ -1933,17 +1933,13 @@
         "react-dom": "^18.2.0"
       }
     },
-    "node_modules/@cloudoperators/juno-url-state-provider": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-url-state-provider/-/juno-url-state-provider-2.0.5.tgz",
-      "integrity": "sha512-kV+jylwPDr9dU5+1jzJxWRyWE6WtwmK/Y6cebpEf77sdQk6CHCux9KkVsko/e/mD1tfTz6nb7gvuy+KSvgJDqA==",
+    "node_modules/@cloudoperators/juno-url-state-provider-v1": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@cloudoperators/juno-url-state-provider-v1/-/juno-url-state-provider-v1-1.3.2.tgz",
+      "integrity": "sha512-DVFzP/5actNs6fkfA93U7jUm9rY0/kPzFWrfGof6SGvhNx+WffQ9BBGQA/p9S7M3brgwxtxgHBnRvTDyA7fMDA==",
       "license": "Apache-2.0",
       "dependencies": {
         "juri": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=20.0.0 <21.0.0",
-        "npm": ">=10.0.0 <11.0.0"
       }
     },
     "node_modules/@cloudoperators/juno-utils": {

--- a/doop/ui/package.json
+++ b/doop/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doop",
-  "version": "2.2.6",
+  "version": "2.2.7",
   "author": "UI-Team",
   "contributors": [
     "Andreas Pfau",

--- a/doop/ui/package.json
+++ b/doop/ui/package.json
@@ -26,15 +26,12 @@
     "autoprefixer": "^10.4.2",
     "babel-jest": "^29.3.1",
     "babel-plugin-transform-import-meta": "^2.2.0",
-    "communicator": "https://assets.juno.global.cloud.sap/libs/communicator@2.2.5/package.tgz",
     "esbuild": "^0.17.19",
     "interweave": "^13.1.0",
     "jest": "^29.3.1",
     "jest-environment-jsdom": "^29.3.1",
     "jsdoc": "^4.0.2",
-    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.7/package.tgz",
     "luxon": "^3.0.0",
-    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
     "postcss": "^8.4.31",
     "postcss-url": "^10.1.3",
     "prop-types": "^15.8.1",
@@ -45,18 +42,20 @@
     "sass": "^1.77.5",
     "shadow-dom-testing-library": "^1.7.1",
     "tailwindcss": "^3.3.1",
-    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
-    "utils": "https://assets.juno.global.cloud.sap/libs/utils@1.1.6/package.tgz",
     "zustand": "^4.5.2"
   },
   "peerDependencies": {
-    "juno-ui-components": "https://assets.juno.global.cloud.sap/libs/juno-ui-components@2.13.7/package.tgz",
-    "messages-provider": "https://assets.juno.global.cloud.sap/libs/messages-provider@0.1.12/package.tgz",
     "prop-types": "^15.8.1",
     "react": "18.2.0",
     "react-dom": "18.2.0",
-    "url-state-provider": "https://assets.juno.global.cloud.sap/libs/url-state-provider@1.3.2/package.tgz",
     "zustand": "^4.5.2"
+  },
+  "dependencies": {
+    "@cloudoperators/juno-communicator": "^2.2.11",
+    "@cloudoperators/juno-messages-provider": "^0.1.17",
+    "@cloudoperators/juno-ui-components": "^2.15.4",
+    "@cloudoperators/juno-url-state-provider": "^2.0.5",
+    "@cloudoperators/juno-utils": "^1.1.12"
   },
   "scripts": {
     "test": "jest",

--- a/doop/ui/package.json
+++ b/doop/ui/package.json
@@ -54,7 +54,7 @@
     "@cloudoperators/juno-communicator": "^2.2.11",
     "@cloudoperators/juno-messages-provider": "^0.1.17",
     "@cloudoperators/juno-ui-components": "^2.15.4",
-    "@cloudoperators/juno-url-state-provider": "^2.0.5",
+    "@cloudoperators/juno-url-state-provider-v1": "^1.3.2",
     "@cloudoperators/juno-utils": "^1.1.12"
   },
   "scripts": {

--- a/doop/ui/src/App.jsx
+++ b/doop/ui/src/App.jsx
@@ -5,16 +5,19 @@
 
 import React, { useEffect, useMemo, useLayoutEffect } from "react"
 
-import { AppShellProvider, ContentHeading } from "juno-ui-components"
+import {
+  AppShellProvider,
+  ContentHeading,
+} from "@cloudoperators/juno-ui-components"
 import AppContent from "./components/AppContent"
 import styles from "./styles.scss"
 import AuthProvider from "./components/AuthProvider"
-import { MessagesProvider } from "messages-provider"
+import { MessagesProvider } from "@cloudoperators/juno-messages-provider"
 import StoreProvider from "./components/StoreProvider"
 import AsyncWorker from "./components/AsyncWorker"
-import { AppShell } from "juno-ui-components"
+import { AppShell } from "@cloudoperators/juno-ui-components"
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query"
-import { fetchProxyInitDB } from "utils"
+import { fetchProxyInitDB } from "@cloudoperators/juno-utils"
 import db from "../db.json"
 import { useGlobalsActions } from "./components/StoreProvider"
 

--- a/doop/ui/src/components/AppContent.jsx
+++ b/doop/ui/src/components/AppContent.jsx
@@ -4,10 +4,10 @@
  */
 
 import React, { useEffect } from "react"
-import { Container } from "juno-ui-components"
-import { Messages } from "messages-provider"
+import { Container } from "@cloudoperators/juno-ui-components"
+import { Messages } from "@cloudoperators/juno-messages-provider"
 
-import { useActions } from "messages-provider"
+import { useActions } from "@cloudoperators/juno-messages-provider"
 import { useDataActions } from "./StoreProvider"
 import Header from "./Header"
 import HintLoading from "./shared/HintLoading"
@@ -16,7 +16,7 @@ import { fetchData } from "../lib/apiClient"
 import { parseError } from "../lib/helpers"
 import Highlighter from "./Highlighter"
 import Violations from "./violations/violations"
-import { fetchProxy } from "utils"
+import { fetchProxy } from "@cloudoperators/juno-utils"
 import { useGlobalsMock, useGlobalsEndpoint } from "./StoreProvider"
 
 const AppContent = ({ id, showDebugSeverities }) => {

--- a/doop/ui/src/components/AuthProvider.jsx
+++ b/doop/ui/src/components/AuthProvider.jsx
@@ -4,7 +4,12 @@
  */
 
 import React from "react"
-import { Stack, Button, Spinner, Message } from "juno-ui-components"
+import {
+  Stack,
+  Button,
+  Spinner,
+  Message,
+} from "@cloudoperators/juno-ui-components"
 
 import {
   useAuthError,

--- a/doop/ui/src/components/Header.jsx
+++ b/doop/ui/src/components/Header.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { IntroBox, Container } from "juno-ui-components"
+import { IntroBox, Container } from "@cloudoperators/juno-ui-components"
 
 const Header = () => (
   <IntroBox>

--- a/doop/ui/src/components/filters/FilterPills.jsx
+++ b/doop/ui/src/components/filters/FilterPills.jsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 
-import { Pill, Stack } from "juno-ui-components"
+import { Pill, Stack } from "@cloudoperators/juno-ui-components"
 import { useFiltersActive, useFiltersActions } from "../StoreProvider"
 import { valueToLabel } from "../../lib/helpers"
 

--- a/doop/ui/src/components/filters/FilterSelect.jsx
+++ b/doop/ui/src/components/filters/FilterSelect.jsx
@@ -12,7 +12,7 @@ import {
   Select,
   SelectOption,
   Stack,
-} from "juno-ui-components"
+} from "@cloudoperators/juno-ui-components"
 
 import {
   useFiltersActions,

--- a/doop/ui/src/components/filters/Filters.jsx
+++ b/doop/ui/src/components/filters/Filters.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { Stack } from "juno-ui-components"
+import { Stack } from "@cloudoperators/juno-ui-components"
 import FilterSelect from "./FilterSelect"
 import FilterPills from "./FilterPills"
 

--- a/doop/ui/src/components/shared/FilterPill.jsx
+++ b/doop/ui/src/components/shared/FilterPill.jsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 import { useFiltersActions } from "../StoreProvider"
-import { Pill } from "juno-ui-components"
+import { Pill } from "@cloudoperators/juno-ui-components"
 
 const FilterPill = ({ name, value, nameLabel, valueLabel }) => {
   const { add: addFilter } = useFiltersActions()

--- a/doop/ui/src/components/shared/HintLoading.jsx
+++ b/doop/ui/src/components/shared/HintLoading.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { Stack, Spinner } from "juno-ui-components"
+import { Stack, Spinner } from "@cloudoperators/juno-ui-components"
 
 const HintLoading = ({ text, className }) => {
   return (

--- a/doop/ui/src/components/shared/HintNotFound.jsx
+++ b/doop/ui/src/components/shared/HintNotFound.jsx
@@ -4,7 +4,7 @@
  */
 
 import React from "react"
-import { Stack } from "juno-ui-components"
+import { Stack } from "@cloudoperators/juno-ui-components"
 
 const HintNotFound = ({ text }) => {
   return (

--- a/doop/ui/src/components/violations/ViolationDetails.jsx
+++ b/doop/ui/src/components/violations/ViolationDetails.jsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useState, useEffect, Suspense, useLayoutEffect } from "react"
-import { Panel, PanelBody, Message } from "juno-ui-components"
+import { Panel, PanelBody, Message } from "@cloudoperators/juno-ui-components"
 import {
   useDataDetailsViolationGroupKind,
   useDataActions,

--- a/doop/ui/src/components/violations/ViolationDetailsList.jsx
+++ b/doop/ui/src/components/violations/ViolationDetailsList.jsx
@@ -5,7 +5,7 @@
 
 import React from "react"
 import { capitalize } from "../../lib/helpers"
-import { useEndlessScrollList } from "utils"
+import { useEndlessScrollList } from "@cloudoperators/juno-utils"
 import {
   DataGrid,
   DataGridRow,
@@ -14,7 +14,7 @@ import {
   Stack,
   Icon,
   Message,
-} from "juno-ui-components"
+} from "@cloudoperators/juno-ui-components"
 // import { useGlobalsDetailsViolationItems } from "../StoreProvider"
 import { useDataDetailsViolationGroup } from "../StoreProvider"
 import ReactMarkdown from "react-markdown"

--- a/doop/ui/src/components/violations/ViolationDetailsPills.jsx
+++ b/doop/ui/src/components/violations/ViolationDetailsPills.jsx
@@ -6,7 +6,7 @@
 import React from "react"
 import FilterPill from "../shared/FilterPill"
 import { valueToLabel } from "../../lib/helpers"
-import { Stack } from "juno-ui-components"
+import { Stack } from "@cloudoperators/juno-ui-components"
 
 const ViolationDetailsPills = ({ violation }) => {
   if (!violation?.object_identity) return null

--- a/doop/ui/src/components/violations/ViolationSeverity.jsx
+++ b/doop/ui/src/components/violations/ViolationSeverity.jsx
@@ -9,7 +9,7 @@ import {
   Tooltip,
   TooltipTrigger,
   TooltipContent,
-} from "juno-ui-components"
+} from "@cloudoperators/juno-ui-components"
 import { useDataSeverityWeights } from "../StoreProvider"
 
 // data to be used for severity while rendering

--- a/doop/ui/src/components/violations/ViolationsList.jsx
+++ b/doop/ui/src/components/violations/ViolationsList.jsx
@@ -10,7 +10,7 @@ import {
   DataGridHeadCell,
   DataGridRow,
   Icon,
-} from "juno-ui-components"
+} from "@cloudoperators/juno-ui-components"
 import { useDataFilteredItems } from "../StoreProvider"
 import ViolationsListItem from "./ViolationsListItem"
 

--- a/doop/ui/src/components/violations/ViolationsListItem.jsx
+++ b/doop/ui/src/components/violations/ViolationsListItem.jsx
@@ -10,7 +10,7 @@ import {
   DataGridRow,
   DataGridCell,
   Icon,
-} from "juno-ui-components"
+} from "@cloudoperators/juno-ui-components"
 import {
   useDataDetailsViolationGroupKind,
   useDataActions,

--- a/doop/ui/src/hooks/useCommunication.js
+++ b/doop/ui/src/hooks/useCommunication.js
@@ -4,7 +4,7 @@
  */
 
 import { useEffect } from "react"
-import { broadcast, get, watch } from "communicator"
+import { broadcast, get, watch } from "@cloudoperators/juno-communicator"
 
 import {
   useAuthAppLoaded,

--- a/doop/ui/src/hooks/useUrlState.js
+++ b/doop/ui/src/hooks/useUrlState.js
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect } from "react"
-import { registerConsumer } from "@cloudoperators/juno-url-state-provider"
+import { registerConsumer } from "@cloudoperators/juno-url-state-provider-v1"
 import {
   useDataDetailsViolationGroupKind,
   useDataActions,

--- a/doop/ui/src/hooks/useUrlState.js
+++ b/doop/ui/src/hooks/useUrlState.js
@@ -4,7 +4,7 @@
  */
 
 import { useState, useEffect } from "react"
-import { registerConsumer } from "url-state-provider"
+import { registerConsumer } from "@cloudoperators/juno-url-state-provider"
 import {
   useDataDetailsViolationGroupKind,
   useDataActions,

--- a/doop/ui/tailwind.config.js
+++ b/doop/ui/tailwind.config.js
@@ -18,7 +18,7 @@ function withOpacity(variableName) {
 
 module.exports = {
   presets: [
-    require("juno-ui-components/build/lib/tailwind.config"), // important, do not change
+    require("@cloudoperators/juno-ui-components/build/lib/tailwind.config"), // important, do not change
   ],
   prefix: "", // important, do not change
   content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],


### PR DESCRIPTION
# Submit a pull request

this PR switches dependencies from assets server to npm registry for doop UI.

## Pull Request Details

- Change all imports regarding juno packages using a prefix `@cloudoperators/juno-`
e.g. `import ... from "communicator"` ->  `import ... from "@cloudoperators/juno-communicator"` 
- Move juno package from devDependencies to dependencies using the new naming schema.
 
## Chackes
- [x] I have performed a self-review of my code.
- [x] New and existing unit tests pass locally with my changes.
- [x] My changes generate no new warnings or errors.