### PR TITLE
chore(thanos): fixing security context indent

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos 
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.0.8
+version: 0.0.9
 # thanos-release
 appVersion: v0.35.0
 keywords:

--- a/thanos/charts/templates/compactor.yaml
+++ b/thanos/charts/templates/compactor.yaml
@@ -68,10 +68,6 @@ spec:
           readOnly: true
         - mountPath: /data
           name: data-volume
-        securityContext:
-          runAsUser: 1000
-          runAsGroup: 3000
-          fsGroup: 2000
       initContainers:
         - name: init-permissions
           image: busybox
@@ -79,6 +75,10 @@ spec:
           volumeMounts:
           - mountPath: /data
             name: data-volume
+      securityContext:
+        runAsUser: 1000
+        runAsGroup: 3000
+        fsGroup: 2000
       dnsPolicy: ClusterFirst
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
wrong indent caused helm diff to fail
