### PR TITLE
fix(doop): update plutono link

### DIFF
--- a/doop/ui/src/components/Header.jsx
+++ b/doop/ui/src/components/Header.jsx
@@ -33,7 +33,7 @@ const Header = () => (
       <br />
       To see historical trends, check out the{" "}
       <a
-        href="https://grafana.global.cloud.sap/d/doop-overview/doop-overview?orgId=1"
+        href="https://plutono.global.cloud.sap/d/doop-overview/doop-overview?orgId=1"
         target="_blank"
       >
         Grafana dashboard.

--- a/doop/ui/src/components/Header.jsx
+++ b/doop/ui/src/components/Header.jsx
@@ -36,7 +36,7 @@ const Header = () => (
         href="https://plutono.global.cloud.sap/d/doop-overview/doop-overview?orgId=1"
         target="_blank"
       >
-        Grafana dashboard.
+        Plutono dashboard.
       </a>
     </p>
   </IntroBox>


### PR DESCRIPTION
This updates the DOOP UI, as the previous link to `grafana` now has invalid certs