### PR TITLE
OTEL Logs collector Dockerfile 0.105.0 -> 0.107.0

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,6 +10,8 @@
 
 Makefile                  @cloudoperators/greenhouse-backend
 ct.yaml                   @cloudoperators/greenhouse-backend
+Dockerfile.otel-collector @cloudoperators/greenhouse-observability
+Dockerfile.integration-tests @cloudoperators/greenhouse-core @cloudoperators/greenhouse-observability
 
 /docs/                    @cloudoperators/greenhouse-core
 /hack/                    @cloudoperators/greenhouse-backend

--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -1,4 +1,4 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:12.6 as journal
+FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:12.6 AS journal
 RUN apt update  \
   && apt upgrade -y  \
   && apt autoremove -y \

--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -39,6 +39,7 @@ COPY --from=journal /lib/x86_64-linux-gnu/libzstd.so.1 /lib/x86_64-linux-gnu/lib
 COPY --from=journal /lib/x86_64-linux-gnu/libcrypto.so.3 /lib/x86_64-linux-gnu/libcrypto.so.3
 COPY --from=journal /lib/x86_64-linux-gnu/libcrypt.so.1 /lib/x86_64-linux-gnu/libcrypt.so.1
 COPY --from=journal /lib/x86_64-linux-gnu/libcap-ng.so.0 /lib/x86_64-linux-gnu/libcap-ng.so.0
+COPY --from=journal /usr/lib/x86_64-linux-gnu/libcap-ng.so.0.0.0 /lib/x86_64-linux-gnu/libcap-ng.so.0.0.0
 COPY --from=journal /usr/bin/journalctl /usr/bin/journalctl
 
 ARG USER_UID=0

--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -1,9 +1,9 @@
-FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:latest as journal
+FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:12.6 as journal
 RUN apt update  \
   && apt upgrade -y  \
   && apt autoremove -y \
   && apt install -y systemd libssl-dev
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.107.0
 LABEL source_repository="https://github.com/greenhouse-extensions"
 COPY --from=journal /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=journal /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
Dockerfile update for fixed versions Debian and Otel-collector and not latest anymore.

Upgrade from 0.105.0 -> 0.107.0

Update needed for clean image and grok parsing:

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34037
