### PR TITLE
chore(thanos): bump version

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos 
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.1.0
+version: 0.1.1
 # thanos-release
 appVersion: v0.35.0
 keywords:

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -10,7 +10,7 @@ spec:
     helmChart:
         name: thanos
         repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-        version: 0.1.0
+        version: 0.1.1
     options:
         - default: null
           description: CLI param for Thanos Query


### PR DESCRIPTION
the license headers borked the current version, creating a new one
