### PR TITLE
[opentelemetry] add testing for plugin

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -18,6 +18,7 @@ header:
     - 'kube-monitoring/charts/**' # ignore the license for the kube-monitoring charts
     - 'plutono/charts/**' # ignore the license for the plutono charts
     - 'thanos/charts/templates/tests/**' # ignore the license for this file
+    - 'opentelemetry/chart/templates/tests/**' # ignore the license for this file
     - '**/*.md'
     - 'LICENSE'
     - 'NOTICE'

--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -18,7 +18,7 @@ header:
     - 'kube-monitoring/charts/**' # ignore the license for the kube-monitoring charts
     - 'plutono/charts/**' # ignore the license for the plutono charts
     - 'thanos/charts/templates/tests/**' # ignore the license for this file
-    - 'opentelemetry/chart/templates/tests/**' # ignore the license for this file
+    - 'opentelemetry/chart/templates/tests/**' # ignore the license for the tests of the opentelemetry chart
     - '**/*.md'
     - 'LICENSE'
     - 'NOTICE'

--- a/opentelemetry/chart/Chart.yaml
+++ b/opentelemetry/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.104.0
 name: opentelemetry-operator
-version: 0.2.8
+version: 0.3.0
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.testFramework.enabled -}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels:
+    type: integration-test 
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+data:
+  run.sh: |-
+
+    #!/usr/bin/env bats
+    
+    load "/usr/lib/bats/bats-detik/utils"
+    load "/usr/lib/bats/bats-detik/detik"
+    
+    DETIK_CLIENT_NAME="kubectl"
+    
+    @test "Verify successful deployment and running status of the {{ .Release.Name }}-operator pod" {
+        verify "there is 1 deployment named '{{ .Release.Name }}-operator'"
+        try "at most 4 times every 5s to get pods named '{{ .Release.Name }}-operator' and verify that '.status.phase' is 'running'" 
+    }
+
+    @test "Verify successful deployment of the {{ .Release.Name }}-operator service" {
+        verify "there is 1 service named '^{{ .Release.Name }}-operator$'"
+    }
+    {{- if .Values.openTelemetry.logsCollector.enabled }}
+    @test "Verify successful deployment and running status of the logs-collector" {
+        try "at most 5 times every 10s to get pods named 'logs-collector' and verify that '.status.phase' is 'running'"
+    }
+    {{- end -}}
+
+    {{- if .Values.openTelemetry.metricsCollector.enabled }}
+    @test "Verify successful deployment and running status of the metrics-collector" {
+        try "at most 5 times every 10s to get pods named 'metrics-collector' and verify that '.status.phase' is 'running'"
+    }
+    {{- end -}}
+    @test "Verify creation of custom resource definitions (CRDs) for {{ .Release.Name }}" {
+        verify "there is 1 customresourcedefinition named 'instrumentations.opentelemetry.io'"
+        verify "there is 1 customresourcedefinition named 'opampbridges.opentelemetry.io'"
+        verify "there is 1 customresourcedefinition named 'opentelemetrycollectors.opentelemetry.io'"
+    }
+{{- end -}}
+    

--- a/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
@@ -14,6 +14,9 @@ data:
   run.sh: |-
 
     #!/usr/bin/env bats
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
     
     load "/usr/lib/bats/bats-detik/utils"
     load "/usr/lib/bats/bats-detik/detik"

--- a/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
@@ -48,4 +48,3 @@ data:
         verify "there is 1 customresourcedefinition named 'opentelemetrycollectors.opentelemetry.io'"
     }
 {{- end -}}
-    

--- a/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
@@ -17,6 +17,9 @@ data:
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
     
     load "/usr/lib/bats/bats-detik/utils"
     load "/usr/lib/bats/bats-detik/detik"

--- a/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry-config.yaml
@@ -1,4 +1,6 @@
 {{- if .Values.testFramework.enabled -}}
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -14,13 +16,7 @@ data:
   run.sh: |-
 
     #!/usr/bin/env bats
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
 
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
-
-    
     load "/usr/lib/bats/bats-detik/utils"
     load "/usr/lib/bats/bats-detik/detik"
     
@@ -45,7 +41,7 @@ data:
         try "at most 5 times every 10s to get pods named 'metrics-collector' and verify that '.status.phase' is 'running'"
     }
     {{- end -}}
-    @test "Verify creation of custom resource definitions (CRDs) for {{ .Release.Name }}" {
+    @test "Verify presence of custom resource definitions (CRDs) for {{ .Release.Name }}" {
         verify "there is 1 customresourcedefinition named 'instrumentations.opentelemetry.io'"
         verify "there is 1 customresourcedefinition named 'opampbridges.opentelemetry.io'"
         verify "there is 1 customresourcedefinition named 'opentelemetrycollectors.opentelemetry.io'"

--- a/opentelemetry/chart/templates/tests/test-opentelemetry.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry.yaml
@@ -1,7 +1,6 @@
+{{- if .Values.testFramework.enabled -}}
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
-
-{{- if .Values.testFramework.enabled -}}
 apiVersion: v1
 kind: Pod
 metadata: 

--- a/opentelemetry/chart/templates/tests/test-opentelemetry.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.testFramework.enabled -}}
+apiVersion: v1
+kind: Pod
+metadata: 
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    type: integration-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+spec:
+  serviceAccountName: {{ .Release.Name }}-test
+  containers: 
+    - name: bats-test
+      image: "{{ .Values.testFramework.image.registry}}/{{ .Values.testFramework.image.repository}}:{{ .Values.testFramework.image.tag }}"
+      imagePullPolicy: {{ .Values.testFramework.image.pullPolicy }}
+      command: ["bats", "-t", "/tests/run.sh"]
+      volumeMounts: 
+        - name: tests
+          mountPath: /tests
+          readOnly: true
+  volumes: 
+    - name: tests
+      configMap: 
+        name: {{ .Release.Name }}-test
+  restartPolicy: Never
+{{- end -}}

--- a/opentelemetry/chart/templates/tests/test-opentelemetry.yaml
+++ b/opentelemetry/chart/templates/tests/test-opentelemetry.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.testFramework.enabled -}}
 apiVersion: v1
 kind: Pod

--- a/opentelemetry/chart/templates/tests/test-permissions.yaml
+++ b/opentelemetry/chart/templates/tests/test-permissions.yaml
@@ -1,7 +1,6 @@
+{{- if .Values.testFramework.enabled -}}
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
-
-{{- if .Values.testFramework.enabled -}}
 apiVersion: v1
 kind: ServiceAccount 
 metadata:
@@ -31,9 +30,6 @@ rules:
     verbs: ["get", "list"]
   - apiGroups: [""]
     resources: ["pods", "persistentvolumeclaims", "services"]
-    verbs: ["get", "list"]
-  - apiGroups: ["monitoring.coreos.com"]
-    resources: ["prometheuses"]
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/opentelemetry/chart/templates/tests/test-permissions.yaml
+++ b/opentelemetry/chart/templates/tests/test-permissions.yaml
@@ -1,0 +1,89 @@
+{{- if .Values.testFramework.enabled -}}
+apiVersion: v1
+kind: ServiceAccount 
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    type: integration-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    type: integration-test  
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+  - apiGroups: ["apps"]
+    resources: ["deployments", "statefulsets"]
+    verbs: ["get", "list"]
+  - apiGroups: [""]
+    resources: ["pods", "persistentvolumeclaims", "services"]
+    verbs: ["get", "list"]
+  - apiGroups: ["monitoring.coreos.com"]
+    resources: ["prometheuses"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ .Release.Name }}-test
+  namespace: {{ .Release.Namespace }}
+  labels: 
+    type: integration-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-test
+    namespace: {{ .Release.Namespace }}
+roleRef:
+    kind: Role
+    name: {{ .Release.Name }}-test
+    apiGroup: rbac.authorization.k8s.io
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-test
+  labels: 
+    type: integration-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+rules:
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["get", "list"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-test
+  labels: 
+    type: integration-test
+  annotations:
+    "helm.sh/hook": test
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": "before-hook-creation,hook-succeeded"
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-test
+    namespace: {{ .Release.Namespace }}
+roleRef:
+    kind: ClusterRole
+    name: {{ .Release.Name }}-test
+    apiGroup: rbac.authorization.k8s.io
+{{- end -}}

--- a/opentelemetry/chart/templates/tests/test-permissions.yaml
+++ b/opentelemetry/chart/templates/tests/test-permissions.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 {{- if .Values.testFramework.enabled -}}
 apiVersion: v1
 kind: ServiceAccount 

--- a/opentelemetry/chart/values.yaml
+++ b/opentelemetry/chart/values.yaml
@@ -25,7 +25,10 @@ opentelemetry-operator:
       enabled: true
   kubeRBACProxy:
     enabled: false
-  testFramework:
-    image:
-      repository: busybox
-      tag: latest
+testFramework:
+  enabled: true
+  image:
+    registry: ghcr.io
+    repository: cloudoperators/greenhouse-extensions-integration-test
+    tag: main
+  imagePullPolicy: IfNotPresent

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry
 spec:
-    version: 0.2.8
+    version: 0.3.0
     displayName: OpenTelemetry
     description: Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
-    icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry-operator/logo.png
+    icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.8
+        version: 0.3.0
     options:
         - default: true
           description: Activates the standard configuration for logs


### PR DESCRIPTION
## Pull Request Details

- added basic chart testing for core components

## References
[[opentelemetry] make opentelemetry plugin production-ready](https://github.com/cloudoperators/greenhouse-extensions/issues/244)