### PR TITLE
feat(exposed-service): Bump dependencies and version

### DIFF
--- a/exposed-services/charts/v2.0.0/exposed-service/Chart.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/Chart.yaml
@@ -18,14 +18,14 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0
+version: 2.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "2.0.0"
+appVersion: "2.1.0"
 dependencies:
   - name: owner-info
-    repository: https://charts.eu-de-2.cloud.sap
-    version: 0.2.0
+    repository: ghcr.io/sapcc/helm-charts
+    version: 1.0.0

--- a/exposed-services/plugindefinition.yaml
+++ b/exposed-services/plugindefinition.yaml
@@ -7,8 +7,8 @@ metadata:
   name: exposed-service
 spec:
   description: A test plugin for validating service exposure via Greenhouse
-  version: "2.0.0"
+  version: "2.1.0"
   helmChart:
     name: exposed-service
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 2.0.0
+    version: 2.1.0


### PR DESCRIPTION
# Submit a pull request

This bumps the version of the exposed-service Plugin with the new reference to `owner-info`