### PR TITLE
chore(workflow): activate build&push step, sign image and scan for vulnerabilities

### DIFF
--- a/.github/workflows/build-push-supernova-image.yaml
+++ b/.github/workflows/build-push-supernova-image.yaml
@@ -99,10 +99,52 @@ jobs:
         with:
           context: ${{ env.PACKAGE_PATH }}
           file: ${{ env.PACKAGE_PATH }}/docker/Dockerfile
-          # change to true to push
-          push: false
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: |
             linux/amd64
             linux/arm64
+
+      # This will only write to the public Rekor transparency log when the Docker
+      # repository is public to avoid leaking data.  If you would like to publish
+      # transparency data even for private images, pass --force to cosign below.
+      # https://github.com/sigstore/cosign
+      - name: Sign the published Docker image
+        env:
+          # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable
+          TAGS: ${{ steps.meta.outputs.tags }}
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        # This step uses the identity token to provision an ephemeral certificate
+        # against the sigstore community Fulcio instance.
+        run: echo "${TAGS}" | xargs -I {} cosign sign --yes {}@${DIGEST}
+
+  vulnerability-scan:
+    permissions:
+      contents: read
+      packages: read
+      security-events: write
+
+    name: Vulnerability Scan
+    needs: build-and-push
+    runs-on: [default]
+    steps:
+      - name: Read Docker image version
+        id: read_version
+        run: echo "IMAGE_VERSION=$(cat ${{ env.PACKAGE_PATH }}/docker/VERSION)" >> $GITHUB_ENV
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        if: success()
+        with:
+          image-ref: ${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ env.IMAGE_NAME }}:${{ env.IMAGE_VERSION }}
+          ignore-unfixed: true
+          format: "sarif"
+          output: "trivy-results.sarif"
+          severity: "CRITICAL,HIGH"
+
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif

--- a/.github/workflows/build-push-supernova-image.yaml
+++ b/.github/workflows/build-push-supernova-image.yaml
@@ -6,7 +6,7 @@
 #  WORKFLOW_DISPATCH
 #     `act workflow_dispatch  --container-architecture linux/amd64 -P default=catthehacker/ubuntu:act-latest -W .github/workflows/build-push-supernova-image.yaml`
 
-name: Supernova UI Image
+name: Build Supernova UI Image
 
 on:
   workflow_dispatch: {}


### PR DESCRIPTION
## Summary
This pull request includes several updates to the CI/CD pipeline for Docker image management. The following key changes are made:

1. Activate the build&push Step

The previously deactivated build&push step has been reactivated. This step was temporarily disabled for testing purposes, and it is now restored to ensure that Docker images are built and pushed to the registry as part of the CI process.

2. Sign the Published Docker Image

Implemented Cosign to sign the Docker images after they are successfully built and pushed. Signing the images ensures their authenticity and integrity, providing an additional layer of security to our deployment process.

3. Run Trivy Vulnerability Scanner

Added Trivy to scan the published Docker images for vulnerabilities. This step helps identify and mitigate potential security issues by automatically scanning the images after they are built and pushed to the registry.
