### PR TITLE
chore(doop,alerts,heureka): Update app versions because of renovate patch dependecies update

### DIFF
--- a/alerts/ui/package-lock.json
+++ b/alerts/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "supernova",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "supernova",
-      "version": "0.10.1",
+      "version": "0.10.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-communicator": "^2.2.11",

--- a/alerts/ui/package.json
+++ b/alerts/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "supernova",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "author": "UI-Team",
   "contributors": [
     "Esther Schmitz",

--- a/doop/ui/package-lock.json
+++ b/doop/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "doop",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "doop",
-      "version": "2.2.7",
+      "version": "2.2.8",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-communicator": "^2.2.11",

--- a/doop/ui/package.json
+++ b/doop/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "doop",
-  "version": "2.2.7",
+  "version": "2.2.8",
   "author": "UI-Team",
   "contributors": [
     "Andreas Pfau",

--- a/heureka/ui/package-lock.json
+++ b/heureka/ui/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "heureka",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "heureka",
-      "version": "2.4.2",
+      "version": "2.4.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudoperators/juno-communicator": "^2.2.11",

--- a/heureka/ui/package.json
+++ b/heureka/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "heureka",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "author": "UI-Team",
   "contributors": [
     "Hoda Noori, Arturo Reuschenbach Pucernau"


### PR DESCRIPTION

## Pull Request Details
 Apps versions are updated as the renovate PR which includes patch update of testing library is merged recently.

Here is the commit related to the update with renovate:
https://github.com/cloudoperators/greenhouse-extensions/commit/d2ee9efb46f4c34101456c863c1f334d82e9bf79
