### PR TITLE
fix(heureka): point helmchart to correct repository

### DIFF
--- a/heureka/plugindefinition.yaml
+++ b/heureka/plugindefinition.yaml
@@ -14,7 +14,7 @@ spec:
     version: "latest"
   helmChart:
     name: heureka
-    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    repository: oci://ghcr.io/cloudoperators/heureka/charts
     version: 0.3.0
   options:
     - name: apiEndpoint


### PR DESCRIPTION
The repository used in the PluginDefinition did not exist.
I see that the exact version exists here: https://github.com/cloudoperators/heureka/pkgs/container/heureka%2Fcharts%2Fheureka
