### PR TITLE
fix(logshipper): wrong indentation for additonalValues & opensearch

### DIFF
--- a/logshipper/chart/Chart.yaml
+++ b/logshipper/chart/Chart.yaml
@@ -6,7 +6,7 @@ name: logshipper
 description: A Helm chart for deploying fluent-bit with custom config
 
 type: application
-version: 0.2.0
+version: 0.2.1
 appVersion: 3.0.4
 
 dependencies:

--- a/logshipper/chart/ci/test-values.yaml
+++ b/logshipper/chart/ci/test-values.yaml
@@ -4,6 +4,9 @@
 fluent-bit:
   backend:
     opensearch:
+      enabled: true
+      host: "my.log.sink"
+      port: 9200
       http_user: top-secret
       http_password: top-secret
     audit:

--- a/logshipper/chart/templates/fluent-bit-configmap.yaml
+++ b/logshipper/chart/templates/fluent-bit-configmap.yaml
@@ -97,12 +97,12 @@ data:
       [FILTER]
           Name record_modifier
           Match *
-{{- range index .Values "fluent-bit" "filter" "additionalValues" -}}
+{{- range index .Values "fluent-bit" "filter" "additionalValues" }}
           Record {{ .key }} {{ .value }}
-{{- end -}}
-{{- end -}}
+{{- end }}
+{{- end }}
 
-{{- if index .Values "fluent-bit" "backend" "opensearch" "enabled" -}}
+{{ if index .Values "fluent-bit" "backend" "opensearch" "enabled" }}
       [OUTPUT]
           Name  opensearch
           Match default.*
@@ -118,7 +118,7 @@ data:
           tls {{ index .Values "fluent-bit" "backend" "opensearch" "tls" "enabled"}}
           tls.verify {{ index .Values "fluent-bit" "backend" "opensearch" "tls" "verify"}}
           tls.debug {{ index .Values "fluent-bit" "backend" "opensearch" "tls" "debug"}}
-{{- end }}
+{{ end }}
 
 {{ if ((index .Values "fluent-bit" "customConfig").outputs) }}
       @INCLUDE custom-outputs.conf

--- a/logshipper/plugindefinition.yaml
+++ b/logshipper/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logshipper
 spec:
-  version: 0.2.0
+  version: 0.2.1
   displayName: Fluent-bit Logshipper
   description: Logshipping of container logs and systemd with fluent-bit
   icon: https://raw.githubusercontent.com/fluent/fluent-bit/master/fluentbit_logo.png
   helmChart:
     name: logshipper
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.0
+    version: 0.2.1
   options:
     - name: fluent-bit.parser
       description: Parser used for container logs. [docker|cri]


### PR DESCRIPTION
Wrong indentation not caught by missing test values