### PR TITLE
fix(logshipper): default output did not match

### DIFF
--- a/logshipper/chart/Chart.yaml
+++ b/logshipper/chart/Chart.yaml
@@ -6,7 +6,7 @@ name: logshipper
 description: A Helm chart for deploying fluent-bit with custom config
 
 type: application
-version: 0.2.1
+version: 0.2.2
 appVersion: 3.0.4
 
 dependencies:

--- a/logshipper/chart/templates/fluent-bit-configmap.yaml
+++ b/logshipper/chart/templates/fluent-bit-configmap.yaml
@@ -27,7 +27,7 @@ data:
           Name             tail
           Path             /var/log/containers/*.log
           Parser           {{ default "cri" ( index .Values "fluent-bit" "parser" ) }}
-          Tag              default_kube.*
+          Tag              default_kube
           Refresh_Interval 5
           Mem_Buf_Limit    50MB
           Skip_Long_Lines  Off
@@ -37,7 +37,7 @@ data:
       [INPUT]
           Name           systemd
           Path           /var/log/journal
-          Tag            default_systemd.*
+          Tag            default_systemd
           Mem_Buf_Limit  5MB
           Read_From_Tail On
           DB             /var/log/fluent-bit-journal.pos.db
@@ -105,7 +105,7 @@ data:
 {{ if index .Values "fluent-bit" "backend" "opensearch" "enabled" }}
       [OUTPUT]
           Name  opensearch
-          Match default.*
+          Match default_*
           Host  {{ index .Values "fluent-bit" "backend" "opensearch" "host" }}
           Port  {{ index .Values "fluent-bit" "backend" "opensearch" "port" }}
           Logstash_Format On

--- a/logshipper/plugindefinition.yaml
+++ b/logshipper/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logshipper
 spec:
-  version: 0.2.1
+  version: 0.2.2
   displayName: Fluent-bit Logshipper
   description: Logshipping of container logs and systemd with fluent-bit
   icon: https://raw.githubusercontent.com/fluent/fluent-bit/master/fluentbit_logo.png
   helmChart:
     name: logshipper
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.1
+    version: 0.2.2
   options:
     - name: fluent-bit.parser
       description: Parser used for container logs. [docker|cri]


### PR DESCRIPTION
The introduction of the `default_` prefix broke the log routing to the output.