### PR TITLE
Otel updates for scraping

### DIFF
--- a/opentelemetry/chart/Chart.yaml
+++ b/opentelemetry/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.108.0
 name: opentelemetry-operator
-version: 0.3.5
+version: 0.3.6
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry/chart/Chart.yaml
+++ b/opentelemetry/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.108.0
 name: opentelemetry-operator
-version: 0.3.6
+version: 0.3.7
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry/chart/Chart.yaml
+++ b/opentelemetry/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.108.0
 name: opentelemetry-operator
-version: 0.3.4
+version: 0.3.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry/chart/templates/smon-filelog.yaml
+++ b/opentelemetry/chart/templates/smon-filelog.yaml
@@ -9,7 +9,7 @@ metadata:
   annotations:
   name: opentelemetry-collector-logs
   labels:
-    prometheus: "{{ .Values.openTelemetry.prometheus }}"
+    plugin: "{{ .Values.openTelemetry.prometheus }}"
 spec:
   podMetricsEndpoints:
     - interval: 60s

--- a/opentelemetry/chart/values.yaml
+++ b/opentelemetry/chart/values.yaml
@@ -18,9 +18,7 @@ opentelemetry-operator:
     create: true
     certManager:
       enabled: true
-      duration: "17280h"
     autoGenerateCert:
-      enabled: false
       recreate: false
   manager:
     collectorImage:
@@ -47,10 +45,6 @@ openTelemetry:
   logsCollector:
     enabled: true
   prometheus:
-  podMonitor:
-    enabled: true
-  serviceMonitor:
-    enabled: false
 testFramework:
   enabled: true
   image:

--- a/opentelemetry/chart/values.yaml
+++ b/opentelemetry/chart/values.yaml
@@ -17,14 +17,15 @@ opentelemetry-operator:
     failurePolicy: 'Ignore'
     create: true
     certManager:
-      enabled: false
-    autoGenerateCert:
       enabled: true
+      duration: "17280h"
+    autoGenerateCert:
+      enabled: false
       recreate: false
   manager:
     collectorImage:
       repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib
-      tag: sha256-bb7f1d2135e7e5b26d6888fd8a7971b4dc07d81b4c4dad257fffae1e21eb8fcf.sig
+      tag: "4072695"
     deploymentAnnotations:
       vpa-butler.cloud.sap/update-mode: Auto
     prometheusRule:
@@ -44,10 +45,10 @@ openTelemetry:
   cluster:
   region:
   logsCollector:
-    enabled: false
+    enabled: true
   prometheus:
   podMonitor:
-    enabled: false
+    enabled: true
   serviceMonitor:
     enabled: false
 testFramework:

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry
 spec:
-    version: 0.3.6
+    version: 0.3.7
     displayName: OpenTelemetry
     description: Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.3.6
+        version: 0.3.7
     options:
         - default: true
           description: Activates the standard configuration for logs

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry
 spec:
-    version: 0.3.5
+    version: 0.3.6
     displayName: OpenTelemetry
     description: Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.3.5
+        version: 0.3.6
     options:
         - default: true
           description: Activates the standard configuration for logs

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry
 spec:
-    version: 0.3.4
+    version: 0.3.5
     displayName: OpenTelemetry
     description: Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.3.4
+        version: 0.3.5
     options:
         - default: true
           description: Activates the standard configuration for logs


### PR DESCRIPTION
- bump version
- different label for prometheus scraping
- fixed version for otel-contrib
- 2 years for certs
- enable podMonitor