### PR TITLE
fix(logshipper): ensures k8s metadata is added

### DIFF
--- a/logshipper/chart/Chart.yaml
+++ b/logshipper/chart/Chart.yaml
@@ -6,7 +6,7 @@ name: logshipper
 description: A Helm chart for deploying fluent-bit with custom config
 
 type: application
-version: 0.2.3
+version: 0.3.0
 appVersion: 3.0.4
 
 dependencies:

--- a/logshipper/chart/templates/fluent-bit-configmap.yaml
+++ b/logshipper/chart/templates/fluent-bit-configmap.yaml
@@ -27,7 +27,7 @@ data:
           Name             tail
           Path             /var/log/containers/*.log
           Parser           {{ default "cri" ( index .Values "fluent-bit" "parser" ) }}
-          Tag              default_kube
+          Tag              default_kube.*
           Refresh_Interval 5
           Mem_Buf_Limit    50MB
           Skip_Long_Lines  Off
@@ -37,7 +37,7 @@ data:
       [INPUT]
           Name           systemd
           Path           /var/log/journal
-          Tag            default_systemd
+          Tag            default_systemd.*
           Mem_Buf_Limit  5MB
           Read_From_Tail On
           DB             /var/log/fluent-bit-journal.pos.db
@@ -82,10 +82,12 @@ data:
       [FILTER]
           Name               kubernetes
           Match              default_kube.*
-          Kube_Tag_Prefix    kube.var.log.containers.
+          Kube_Tag_Prefix    default_kube.var.log.containers.
           Kube_URL           https://kubernetes.default.svc:443
           Kube_CA_File       /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
           Kube_Token_File    /var/run/secrets/kubernetes.io/serviceaccount/token
+          Labels             Off
+          Annotations        Off
           Merge_Log          On
           Merge_Log_Trim     On
 

--- a/logshipper/plugindefinition.yaml
+++ b/logshipper/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logshipper
 spec:
-  version: 0.2.3
+  version: 0.3.0
   displayName: Fluent-bit Logshipper
   description: Logshipping of container logs and systemd with fluent-bit
   icon: https://raw.githubusercontent.com/fluent/fluent-bit/master/fluentbit_logo.png
   helmChart:
     name: logshipper
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.3
+    version: 0.3.0
   options:
     - name: fluent-bit.parser
       description: Parser used for container logs. [docker|cri]


### PR DESCRIPTION
## Pull Request Details

labels and annotations are not added to the logline

## Breaking Changes

None.

## Issues Fixed

Enter the issue numbers resolved by this pull request below, if any.

1. Kubernetes Metadata is added to container logs again
2. Kubernetes Labels & Annotations are not added to the logs

## Other Relevant Information

Provide any other important details below.

:question:
