### PR TITLE
chore(opentelemetry): revise prometheus monitoring 

### DIFF
--- a/opentelemetry/chart/Chart.yaml
+++ b/opentelemetry/chart/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.110.0
 name: opentelemetry-operator
-version: 0.4.1
+version: 0.4.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry/chart/ci/test-values.yaml
+++ b/opentelemetry/chart/ci/test-values.yaml
@@ -36,16 +36,10 @@ openTelemetry:
     password: test
   cluster: test
   region: test
-  logsCollector:
-    enabled: true
-  metricsCollector:
-    enabled: false
-  podMonitor:
-    enabled: false
   prometheus:
     additionalLabels:
-      testkey1: test1
-      testkey2: test2
+      key1: value1
+      key2: value2
 testFramework:
   enabled: false
   image:

--- a/opentelemetry/chart/templates/logs-collector.yaml
+++ b/opentelemetry/chart/templates/logs-collector.yaml
@@ -38,7 +38,7 @@ spec:
   envFrom:
     - secretRef:
          name: otel-basic-auth
-{{- if .Values.openTelemetry.podMonitor.enabled }}
+{{- if .Values.openTelemetry.prometheus.podMonitor.enabled }}
   ports:
     - name: prometheus
       port: 9999
@@ -71,7 +71,7 @@ spec:
             field: resource["container.runtime"]
             value: "containerd"
 
-{{- if .Values.openTelemetry.podMonitor.enabled }}
+{{- if .Values.openTelemetry.prometheus.podMonitor.enabled }}
       prometheus/internal:
         config:
           scrape_configs:
@@ -87,7 +87,7 @@ spec:
         timeout: 5s
         send_batch_size : 10
 
-{{- if .Values.openTelemetry.podMonitor.enabled }}
+{{- if .Values.openTelemetry.prometheus.podMonitor.enabled }}
       attributes/prometheus:
         actions:
           - action: insert
@@ -353,7 +353,7 @@ spec:
     service:
       extensions:
         - basicauth
-{{- if .Values.openTelemetry.podMonitor.enabled }}
+{{- if .Values.openTelemetry.prometheus.podMonitor.enabled }}
       telemetry:
         metrics:
           address: 127.0.0.1:8888
@@ -372,7 +372,7 @@ spec:
           receivers: [journald]
           processors: [attributes/cluster,transform/journal,batch]
           exporters: [opensearch/logs]
-{{- if .Values.openTelemetry.podMonitor.enabled }}
+{{- if .Values.openTelemetry.prometheus.podMonitor.enabled }}
         metrics/prometheus:
           receivers: [prometheus/internal]
           processors: [attributes/prometheus]

--- a/opentelemetry/chart/templates/pmon-filelog.yaml
+++ b/opentelemetry/chart/templates/pmon-filelog.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
-{{- if .Values.openTelemetry.podMonitor.enabled }}
+{{- if and Capabilities.APIVersions.Has "monitoring.coreos.com/v1" .Values.openTelemetry.prometheus.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/opentelemetry/chart/templates/smon.yaml
+++ b/opentelemetry/chart/templates/smon.yaml
@@ -2,7 +2,7 @@
 SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
-{{- if index .Values "opentelemetry-operator" "manager" "serviceMonitor" "enabled" }}
+{{- if and Capabilities.APIVersions.Has "monitoring.coreos.com/v1" .Values.openTelemetry.prometheus.serviceMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/opentelemetry/chart/values.yaml
+++ b/opentelemetry/chart/values.yaml
@@ -54,9 +54,15 @@ openTelemetry:
   region:
   logsCollector:
     enabled: true
+  metricsCollector:
+    enabled: false
   prometheus:
+    serviceMonitor:
+      enabled: true
+    podMonitor:
+      enabled: true
     ## Label selectors for the Prometheus resources to be picked up by prometheus-operator.
-    additionalLabels:
+    additionalLabels: {}
     # plugin: kube-monitoring
     # prometheus: infra
 testFramework:

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry
 spec:
-    version: 0.4.1
+    version: 0.4.2
     displayName: OpenTelemetry
     description: Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.4.1
+        version: 0.4.2
     options:
         - default: true
           description: Activates the standard configuration for logs
@@ -45,15 +45,20 @@ spec:
           name: openTelemetry.cluster
           required: false
           type: string
+        - default: false
+          description: Activates the pod-monitoring for the Logs Collector
+          name: openTelemetry.prometheus.podMonitor.enabled
+          required: false
+          type: bool
+        - default: false
+          description: Activates the service-monitoring for the Logs Collector
+          name: openTelemetry.prometheus.serviceMonitor.enabled
+          required: false
+          type: bool
         - description: Label for Prometheus Service Monitoring
           name: openTelemetry.prometheus.additionalLabels
           required: false
           type: map
-        - default: false
-          description: Activates the pod-monitoring for the Logs Collector
-          name: openTelemetry.podMonitor.enabled
-          required: false
-          type: bool
         - default: false
           description: Activate to use the CertManager for generating self-signed certificates
           name: opentelemetry-operator.admissionWebhooks.certManager.enabled

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -55,7 +55,7 @@ spec:
           name: openTelemetry.prometheus.serviceMonitor.enabled
           required: false
           type: bool
-        - description: Label for Prometheus Service Monitoring
+        - description: Label selector for Prometheus resources to be picked-up by the operator
           name: openTelemetry.prometheus.additionalLabels
           required: false
           type: map


### PR DESCRIPTION
- grouped the prometheus-related values into one directive
- PodMonitor and ServiceMonitor are enabled by default
- Added indication whether `monitoring.coreos.com/v1` is available on the cluster
- plugindefinition updated
