### PR TITLE
[openTelemetry] Bumps version to v0.114.0

### DIFF
--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -3,7 +3,7 @@ RUN apt update  \
   && apt upgrade -y  \
   && apt autoremove -y \
   && apt install -y systemd libssl-dev
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.110.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.114.0
 LABEL source_repository="https://github.com/greenhouse-extensions"
 COPY --from=journal /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=journal /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2

--- a/opentelemetry/chart/Chart.yaml
+++ b/opentelemetry/chart/Chart.yaml
@@ -2,9 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-appVersion: v0.113.0
+appVersion: v0.114.0
 name: opentelemetry-operator
-version: 0.6.0
+version: 0.6.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/opentelemetry/chart/ci/test-values.yaml
+++ b/opentelemetry/chart/ci/test-values.yaml
@@ -15,7 +15,7 @@ opentelemetry-operator:
   manager:
     collectorImage:
       repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib
-      tag: "4072695"
+      tag: main
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
       tag: v0.114.1

--- a/opentelemetry/chart/ci/test-values.yaml
+++ b/opentelemetry/chart/ci/test-values.yaml
@@ -18,7 +18,7 @@ opentelemetry-operator:
       tag: "4072695"
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-      tag: v0.108.0
+      tag: v0.114.1
     deploymentAnnotations:
       vpa-butler.cloud.sap/update-mode: Auto
     prometheusRule:

--- a/opentelemetry/chart/values.yaml
+++ b/opentelemetry/chart/values.yaml
@@ -23,7 +23,7 @@ opentelemetry-operator:
   manager:
     collectorImage:
       repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib
-      tag: "4072695"
+      tag: main
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
       tag: v0.114.1

--- a/opentelemetry/chart/values.yaml
+++ b/opentelemetry/chart/values.yaml
@@ -26,7 +26,7 @@ opentelemetry-operator:
       tag: "4072695"
     image:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
-      tag: v0.110.0
+      tag: v0.114.1
     deploymentAnnotations:
       vpa-butler.cloud.sap/update-mode: Auto
     serviceMonitor:

--- a/opentelemetry/plugindefinition.yaml
+++ b/opentelemetry/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: opentelemetry
 spec:
-    version: 0.6.0
+    version: 0.6.1
     displayName: OpenTelemetry
     description: Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opentelemetry/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.6.0
+        version: 0.6.1
     options:
         - default: true
           description: Activates the standard configuration for logs


### PR DESCRIPTION
- **chore(openTelemetry): bumps version of charts to v.114.0**
- **fix(openTelemetry): changes default tag for collectorImage to be 'main'**
