### PR TITLE
fix(alerts): avoid reconciliation loop

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.15.3
+version: 0.15.4
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/charts/templates/ca-secret-issuer-cert.yaml
+++ b/alerts/charts/templates/ca-secret-issuer-cert.yaml
@@ -1,5 +1,7 @@
 {{- if and .Values.alerts.alertmanager.enabled .Values.alerts.alertmanager.ingress.enabled }}
-{{- if not (lookup "v1" "Secret" $.Release.Namespace (printf "%s-%s" $.Release.Namespace "monitoring-ca")) }}
+{{- $caSecret := (lookup "v1" "Secret" $.Release.Namespace (printf "%s-%s" $.Release.Namespace "monitoring-ca")) }}
+{{- if not $caSecret }}
+{{- $ca := genCA (printf "%s-%s" $.Release.Name "custom-ca") 3650 }}
 apiVersion: v1
 kind: Secret
 type: Opaque
@@ -11,12 +13,11 @@ metadata:
   annotations:
     "helm.sh/hook": pre-install, pre-upgrade
 data:
-{{- $ca := genCA (printf "%s-%s" $.Release.Name "custom-ca") 3650 }}
   tls.crt: {{ $ca.Cert | b64enc | quote }}
   tls.key: {{ $ca.Key | b64enc | quote }}
 ---
 {{- end }}
-{{ if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
+{{- if .Capabilities.APIVersions.Has "cert-manager.io/v1" }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 2.3.3
+  version: 2.3.4
   weight: 0
   displayName: Alerts
   description: The Alerts Plugin consists of both Prometheus Alertmanager and Supernova, the holistic alert management UI
@@ -15,7 +15,7 @@ spec:
   helmChart:
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.15.3
+    version: 0.15.4
   uiApplication:
     name: supernova
     version: "latest"


### PR DESCRIPTION
The *-monitoring-ca should not be regenerated on every deploy.

fixes #546 