### PR TITLE
fix(action) cleanup charts in a PR with label

### DIFF
--- a/.github/workflows/ci-pr-build.yaml
+++ b/.github/workflows/ci-pr-build.yaml
@@ -103,7 +103,7 @@ jobs:
         - name: Delete PR container image tag
           uses: dataaxiom/ghcr-cleanup-action@v1
           with:
-            tags: pr-${{ env.PR_NUMBER }}
+            tags: ${{ env.PR_NUMBER }}-pr
             packages: ${{ github.repository }}/charts/*
             expand-packages: true
             token: ${{ secrets.CLOUDOPERATOR_REPO_WRITE_DELETE_TOKEN }}


### PR DESCRIPTION
## Pull Request Details

The label `pr-build-chart` will create the package with the tag `${{ env.PR_NUMBER }}-pr`
accordingly the label should look for the tag in a same way, example for a failed action here:  https://github.com/cloudoperators/greenhouse-extensions/pull/575