### PR TITLE
fix(thanos) Ruler AM auth - add plugindefinition options

### DIFF
--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -84,4 +84,9 @@ spec:
           name: thanos.query.web.routePrefix
           required: false
           type: string
-    version: 0.2.3
+        - default: false
+          description: Thanos ruler Alertmanager auth toggle
+          name: thanos.ruler.alertmanagers.authentication.enabled
+          required: false
+          type: string
+    version: 0.2.4

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -88,5 +88,13 @@ spec:
           description: Thanos ruler Alertmanager auth toggle
           name: thanos.ruler.alertmanagers.authentication.enabled
           required: false
-          type: string
+          type: bool
+        - name: thanos.ruler.alertmanagers.authentication.ssoCert
+          description: TLS certificate for communication with Alertmanager
+          required: false
+          type: secret
+        - name: thanos.ruler.alertmanagers.authentication.ssoKey
+          description: TLS key for communication with Alertmanager
+          required: false
+          type: secret
     version: 0.2.4


### PR DESCRIPTION
## Pull Request Details

Provide details about your pull request and what it adds, fixes, or changes.

updating Thanos plugindefinition to enable Alertmanager configuration
adding AM Auth toggle to Thanos plugindefinition

## Breaking Changes

Describe what features are broken by this pull request and why, if any.

/

## Issues Fixed

Enter the issue numbers resolved by this pull request below, if any.

message: 'Helm template failed: execution error at (thanos/templates/ruler/alertmanager-sso-secret.yaml:8:14): .Values.thanos.ruler.alertmanagers.authentication.ssoCert missing'

## Other Relevant Information

Provide any other important details below.

/