### PR TITLE
[thanos] add thanos ruler svc for service discovery

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.1.5
+version: 0.1.6
 # thanos-release
 appVersion: v0.35.0
 keywords:

--- a/thanos/charts/templates/ruler/ruler-svc.yaml
+++ b/thanos/charts/templates/ruler/ruler-svc.yaml
@@ -1,0 +1,30 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v1
+kind: Service
+metadata:
+  {{- if .Values.thanos.ruler.annotations }}
+  annotations:
+    {{ toYaml .Values.thanos.ruler.annotations | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "plugin.labels" . | nindent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
+    {{- if .Values.thanos.ruler.serviceLabels }}
+    {{ toYaml .Values.thanos.ruler.serviceLabels | nindent 4 }}
+    {{- end }}
+  name: {{ include "release.name" . }}-ruler
+spec:
+  ports:
+  - name: grpc
+    port: 10901
+    protocol: TCP
+    targetPort: grpc
+  - name: http
+    port: 10902
+    protocol: TCP
+    targetPort: http
+  selector:
+    app.kubernetes.io/managed-by: {{ include "release.name" . }}
+    app.kubernetes.io/name: ruler

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -122,11 +122,17 @@ thanos:
   ruler:
     enabled: true
 
+    annotations:
+
+    externalPrefix: /ruler
+
     labels:
 
     alertLabels:
 
     matchLabel:
+
+    serviceLabels:
 
     alertmanagers:
       enabled: true

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -10,7 +10,7 @@ spec:
     helmChart:
         name: thanos
         repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-        version: 0.1.5
+        version: 0.1.6
     options:
         - default: null
           description: CLI param for Thanos Query
@@ -103,4 +103,4 @@ spec:
           description: TLS key for communication with Alertmanager
           required: false
           type: secret
-    version: 0.2.5
+    version: 0.2.6

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -60,7 +60,7 @@ spec:
         - default: 
             greenhouse.sap/expose: "true"
             greenhouse.sap/exposeNamedPort: "http"
-          description: Needed for exposing Thanos to the service proxy. UI is accessible via http, exposing this particular port.
+          description: Needed for exposing Thanos Query to the service proxy. UI is accessible via http, exposing this particular port.
           name: thanos.query.serviceLabels
           required: false
           type: map
@@ -84,6 +84,12 @@ spec:
           name: thanos.query.web.routePrefix
           required: false
           type: string
+        - default: 
+            greenhouse.sap/expose: "true"
+          description: Needed for exposing Thanos Ruler to the service proxy. UI is accessible via http, exposing this particular port.
+          name: thanos.ruler.serviceLabels
+          required: false
+          type: map
         - default: false
           description: Thanos ruler Alertmanager auth toggle
           name: thanos.ruler.alertmanagers.authentication.enabled


### PR DESCRIPTION
## Pull Request Details

New Thanos Ruler Service resource to allow to add custom labels to it for Proxy server discovery

## Breaking Changes

None

## Issues Fixed

Allows proxy server discovery

## Other Relevant Information

issue about not being apple to add labels to governed thanos service 
[/prometheus-operator/issues/7317](https://github.com/prometheus-operator/prometheus-operator/issues/7317)

Potential solution will just to specify a serviceName so when thanos operator tries to reconcile. if it doesn't finds the right service name reconcile fails
