### PR TITLE
fix(alerts): quote dnsNames starting with asterisk

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.19.0
+version: 0.19.1
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/charts/ci/test-values.yaml
+++ b/alerts/charts/ci/test-values.yaml
@@ -1,7 +1,8 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 global:
-  baseDomain: example.com
+  greenhouse:
+    baseDomain: example.com
 
 alerts:
   alertmanager:

--- a/alerts/charts/ci/test-values.yaml
+++ b/alerts/charts/ci/test-values.yaml
@@ -1,5 +1,8 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+global:
+  baseDomain: example.com
+
 alerts:
   alertmanager:
     ingress:

--- a/alerts/charts/templates/certmanager.yaml
+++ b/alerts/charts/templates/certmanager.yaml
@@ -80,6 +80,6 @@ spec:
     {{- end }}
   dnsNames:
 {{- if .Values.global.greenhouse.baseDomain }}
-    - {{ printf "*.s%" .Values.global.greenhouse.baseDomain }}
+  - {{ printf "*.%s" .Values.global.greenhouse.baseDomain | quote }}
 {{- end }}
 {{- end -}}

--- a/alerts/charts/values.yaml
+++ b/alerts/charts/values.yaml
@@ -24,7 +24,7 @@ alerts:
       duration: ""  # default to be 5y
     admissionCert:
       duration: ""  # default to be 1y
-    issuerRef:
+    issuerRef: {}
     #   name: "issuer"
     #   kind: "ClusterIssuer"
 

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 2.7.0
+  version: 2.7.1
   weight: 0
   displayName: Alerts
   description: The Alerts Plugin consists of both Prometheus Alertmanager and Supernova, the holistic alert management UI
@@ -15,7 +15,7 @@ spec:
   helmChart:
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.19.0
+    version: 0.19.1
   uiApplication:
     name: supernova
     version: "latest"


### PR DESCRIPTION
YAML treats strings starting with asterisk in a special way - that's why the dnsNames with wildcards like *.example.local breaks on helm install
