### PR TITLE
fix(thanos) disable ruler-svc

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.2.0
+version: 0.2.1
 # thanos-release
 appVersion: v0.37.2
 keywords:

--- a/thanos/charts/templates/ruler/ruler-svc.yaml
+++ b/thanos/charts/templates/ruler/ruler-svc.yaml
@@ -1,6 +1,4 @@
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
-
+{{ if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.thanos.ruler.enabled (not .Values.thanos.query.standalone) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,3 +25,4 @@ spec:
     targetPort: http
   selector:
     app.kubernetes.io/name: thanos-ruler
+{{ end}}

--- a/thanos/charts/templates/tests/test-permissions.yaml
+++ b/thanos/charts/templates/tests/test-permissions.yaml
@@ -34,7 +34,7 @@ rules:
     resources: ["pods", "persistentvolumeclaims", "services", "configmaps"]
     verbs: ["get", "list"]
   - apiGroups: ["monitoring.coreos.com"]
-    resources: ["servicemonitors"]
+    resources: ["servicemonitors","thanosrulers"]
     verbs: ["get", "list"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/thanos/charts/templates/tests/test-thanos-config.yaml
+++ b/thanos/charts/templates/tests/test-thanos-config.yaml
@@ -48,9 +48,16 @@ data:
     {{ if and .Values.thanos.ruler.enabled (not .Values.thanos.query.standalone) }}
     @test "Verify succesful creation, running status and rulefiles population of Thanos Ruler" {
       verify "there is 1 statefulset named 'thanos-ruler-{{ .Release.Name }}'"
-      verify "there is 1 service named 'thanos-ruler-operated'"
+      verify "there is 1 service named '{{ .Release.Name }}-ruler'"
+      verify "there is 1 thanosruler named '{{ .Release.Name }}'"
       try "at most 3 times every 5s to get pods named 'thanos-ruler-{{ .Release.Name }}' and verify that '.status.phase' is 'running'"
       try "at most 3 times every 5s to get configmaps named '.*(ruler)+.*(rulefiles)+.*' and verify that '.data' matches '.*yaml.*'"
+    }
+    {{ else }}
+    @test "Verify that no Thanos Ruler ressource is created" {
+      verify "there is 0 statefulset named 'thanos-ruler-{{ .Release.Name }}'"
+      verify "there is 0 thanosruler named '{{ .Release.Name }}'"
+      verify "there is 0 service named '{{ .Release.Name }}-ruler'"
     }
     {{ end }}
 

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
     name: thanos
 spec:
-    version: 0.3.0
+    version: 0.3.1
     description: thanos
     helmChart:
         name: thanos
         repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-        version: 0.2.0
+        version: 0.2.1
     options:
         - default: null
           description: CLI param for Thanos Query


### PR DESCRIPTION
Ruler service is deployed when `thanos.ruler.enabled` is _**false**_

Adding flow control on `ruler-svc.yaml` to avoid that