### PR TITLE
chore(alerts): move ca-bundle secret to helm release

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.19.3
+version: 0.19.4
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/charts/templates/caBundle-secret.yaml
+++ b/alerts/charts/templates/caBundle-secret.yaml
@@ -9,11 +9,6 @@ metadata:
   name: {{ $.Release.Namespace }}-ca-bundle
   labels:
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
-  annotations:
-    "helm.sh/hook": post-install,post-upgrade
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-    ## Ensure this is run before release installation and upgrade
-    "helm.sh/hook-weight": "-5"
 data:
   ca.crt: {{ printf "%s%s" $extCABundle $intCABundle | b64enc | quote }}
 {{- end }}

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 2.7.3
+  version: 2.7.4
   weight: 0
   displayName: Alerts
   description: The Alerts Plugin consists of both Prometheus Alertmanager and Supernova, the holistic alert management UI
@@ -15,7 +15,7 @@ spec:
   helmChart:
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.19.3
+    version: 0.19.4
   uiApplication:
     name: supernova
     version: "latest"


### PR DESCRIPTION
It is not necessary to create these before installing or upgrading the version. 