### PR TITLE
feat(kube-monitoring): ensure unique secret names based on the release

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.24.0
+version: 0.24.1
 # prometheus-operator app version
 appVersion: v0.79.2
 keywords:

--- a/kube-monitoring/charts/ci/test-values.yaml
+++ b/kube-monitoring/charts/ci/test-values.yaml
@@ -1,0 +1,2 @@
+alerts:
+  dummySecret: true

--- a/kube-monitoring/charts/templates/_alertmanager-config.yaml.tpl
+++ b/kube-monitoring/charts/templates/_alertmanager-config.yaml.tpl
@@ -2,8 +2,13 @@
   scheme: https
 {{- if and .Values.alerts.enabled .Values.alerts.alertmanagers.hosts }}
   tls_config:
-    cert_file: /etc/prometheus/secrets/tls-prometheus-alertmanager-auth/tls.crt
-    key_file: /etc/prometheus/secrets/tls-prometheus-alertmanager-auth/tls.key
+{{- if and .Values.alerts.alertmanagers.tlsConfig.cert .Values.alerts.alertmanagers.tlsConfig.key }} 
+    cert_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Name }}/tls.crt
+    key_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Name }}/tls.key
+{{- else }}
+    cert_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Namespace }}/tls.crt
+    key_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Namespace }}/tls.key
+{{- end }}
   static_configs:
     - targets:
 {{ toYaml .Values.alerts.alertmanagers.hosts | indent 8 }}

--- a/kube-monitoring/charts/templates/alertmanager-config.yaml
+++ b/kube-monitoring/charts/templates/alertmanager-config.yaml
@@ -2,10 +2,10 @@ apiVersion: v1
 kind: Secret
 
 metadata:
-  name: kube-monitoring-alertmanager-config
+  name: {{ .Release.Name }}-alertmanager-config
   labels:
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 
 data:
-  config.yaml: {{ include (print $.Template.BasePath "/_alertmanager-config.yaml.tpl") . | b64enc }}
+  config.yaml: {{ tpl (include (print $.Template.BasePath "/_alertmanager-config.yaml.tpl") .) . | b64enc }}
   relabelConfig.yaml: {{ include "kubeMonitoring.defaultRelabelConfig" . | b64enc }}

--- a/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
+++ b/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: tls-prometheus-{{ .Release.Name }}
+  name: tls-prometheus-{{ .Release.Name }}-cert
   labels:
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 data:

--- a/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
+++ b/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
@@ -9,3 +9,14 @@ data:
   tls.crt: {{ .Values.alerts.alertmanagers.tlsConfig.cert | b64enc | quote }}
   tls.key: {{ .Values.alerts.alertmanagers.tlsConfig.key | b64enc | quote }}
 
+{{- if .Values.alerts.dummySecret }}
+---
+apiVersion: v1
+kind: Secret
+type: Opaque
+metadata:
+  name: tls-prometheus-{{ .Release.Namespace }}
+data:
+  tls.crt: ""
+  tls.key: ""
+{{- end }}

--- a/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
+++ b/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: tls-prometheus-alertmanager-auth
+  name: tls-prometheus-{{ .Release.Name }}
   labels:
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 data:

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -357,6 +357,7 @@ kubernetes-operations:
 ## Configures Prometheus Alertmanager
 alerts:
   enabled: false
+  # Creates a dummy Secret to ensure standalone testing
   dummySecret: false
   alertmanagers:
     hosts: []

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -262,7 +262,7 @@ kubeMonitoring:
     ingress:
       enabled: false
 
-      ## By default, a ca-bundle is deployed to enable tls between Prometheus and Alertmanager
+      ## By default, the alerts plugin deploys a ca-bundle to enable tls between Prometheus and Alertmanager
       annotations:
         disco: "true"
         kubernetes.io/tls-acme: "true"
@@ -284,7 +284,7 @@ kubeMonitoring:
       ## Expected values are the secret name and key
       ## Cannot be used with additionalAlertManagerConfigs
       additionalAlertManagerConfigsSecret:
-        name: kube-monitoring-alertmanager-config
+        name: "{{ $.Release.Name }}-alertmanager-config"
         key: config.yaml
 
       ## If additional alert relabel configurations are already deployed in a single secret, or you want to manage
@@ -292,7 +292,7 @@ kubeMonitoring:
       ## Expected values are the secret name and key
       ## Cannot be used with additionalAlertRelabelConfigs
       additionalAlertRelabelConfigsSecret:
-        name: kube-monitoring-alertmanager-config
+        name: "{{ $.Release.Name }}-alertmanager-config"
         key: relabelConfig.yaml
 
       ## Secrets is a list of Secrets in the same namespace as the Prometheus object, which shall be mounted into the Prometheus Pods.
@@ -300,7 +300,8 @@ kubeMonitoring:
       ## reflected in the running Pods. To change the secrets mounted into the Prometheus Pods, the object must be deleted and recreated
       ## with the new list of secrets.
       secrets:
-        - tls-prometheus-alertmanager-auth
+        - "tls-prometheus-{{ .Release.Name }}"
+        - "tls-prometheus-{{ .Release.Namespace }}"
 
       storageSpec:
         volumeClaimTemplate:
@@ -353,11 +354,12 @@ kubernetes-operations:
       - name: plugin
         value: "{{ $.Release.Name }}"
 
-
+## Configures Prometheus Alertmanager
 alerts:
   enabled: false
   alertmanagers:
     hosts: []
+    ## Overrides tls certificate to authenticate with Alertmanager
     tlsConfig:
       cert: ""
       key: ""

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -300,7 +300,7 @@ kubeMonitoring:
       ## reflected in the running Pods. To change the secrets mounted into the Prometheus Pods, the object must be deleted and recreated
       ## with the new list of secrets.
       secrets:
-        - "tls-prometheus-{{ .Release.Name }}"
+        - "tls-prometheus-{{ .Release.Name }}-cert"
         - "tls-prometheus-{{ .Release.Namespace }}"
 
       storageSpec:

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -357,6 +357,7 @@ kubernetes-operations:
 ## Configures Prometheus Alertmanager
 alerts:
   enabled: false
+  dummySecret: false
   alertmanagers:
     hosts: []
     ## Overrides tls certificate to authenticate with Alertmanager

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 2.10.1
+  version: 2.11.0
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.23.1
+    version: 0.24.1
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
To enable multiple deployments in the same namespace. Foundation to: #142 