### PR TITLE
fix(kube-monitoring): remove secret reference

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.24.1
+version: 0.24.2
 # prometheus-operator app version
 appVersion: v0.79.2
 keywords:

--- a/kube-monitoring/charts/ci/test-values.yaml
+++ b/kube-monitoring/charts/ci/test-values.yaml
@@ -1,2 +1,0 @@
-alerts:
-  dummySecret: true

--- a/kube-monitoring/charts/templates/_alertmanager-config.yaml.tpl
+++ b/kube-monitoring/charts/templates/_alertmanager-config.yaml.tpl
@@ -2,13 +2,8 @@
   scheme: https
 {{- if and .Values.alerts.enabled .Values.alerts.alertmanagers.hosts }}
   tls_config:
-{{- if and .Values.alerts.alertmanagers.tlsConfig.cert .Values.alerts.alertmanagers.tlsConfig.key }} 
     cert_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Name }}/tls.crt
     key_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Name }}/tls.key
-{{- else }}
-    cert_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Namespace }}/tls.crt
-    key_file: /etc/prometheus/secrets/tls-prometheus-{{ .Release.Namespace }}/tls.key
-{{- end }}
   static_configs:
     - targets:
 {{ toYaml .Values.alerts.alertmanagers.hosts | indent 8 }}

--- a/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
+++ b/kube-monitoring/charts/templates/alertmanager-tls-secret.yaml
@@ -2,21 +2,9 @@ apiVersion: v1
 kind: Secret
 type: Opaque
 metadata:
-  name: tls-prometheus-{{ .Release.Name }}-cert
+  name: tls-prometheus-{{ .Release.Name }}
   labels:
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 data:
   tls.crt: {{ .Values.alerts.alertmanagers.tlsConfig.cert | b64enc | quote }}
   tls.key: {{ .Values.alerts.alertmanagers.tlsConfig.key | b64enc | quote }}
-
-{{- if .Values.alerts.dummySecret }}
----
-apiVersion: v1
-kind: Secret
-type: Opaque
-metadata:
-  name: tls-prometheus-{{ .Release.Namespace }}
-data:
-  tls.crt: ""
-  tls.key: ""
-{{- end }}

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -300,8 +300,7 @@ kubeMonitoring:
       ## reflected in the running Pods. To change the secrets mounted into the Prometheus Pods, the object must be deleted and recreated
       ## with the new list of secrets.
       secrets:
-        - "tls-prometheus-{{ .Release.Name }}-cert"
-        - "tls-prometheus-{{ .Release.Namespace }}"
+        - "tls-prometheus-{{ .Release.Name }}"
 
       storageSpec:
         volumeClaimTemplate:
@@ -357,8 +356,6 @@ kubernetes-operations:
 ## Configures Prometheus Alertmanager
 alerts:
   enabled: false
-  # Creates a dummy Secret to ensure standalone testing
-  dummySecret: false
   alertmanagers:
     hosts: []
     ## Overrides tls certificate to authenticate with Alertmanager

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 2.11.0
+  version: 2.11.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.24.1
+    version: 0.24.2
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
The secret expected to mount is living in the central cluster. The option values still apply.