### PR TITLE
chore(kube-monitoring): remove prometheus-operator appVersion

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,9 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.24.2
-# prometheus-operator app version
-appVersion: v0.79.2
+version: 0.25.0
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 2.11.1
+  version: 2.12.0
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.24.2
+    version: 0.25.0
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
This will take the image version from the kube-prometheus-stack.

Upgrades prometheus-operator to `v0.80.0`

https://github.com/prometheus-operator/prometheus-operator/releases/tag/v0.80.0
