### PR TITLE
test(thanos) check for thanos sidecar availability e2e

### DIFF
--- a/thanos/charts/templates/tests/test-thanos-config.yaml
+++ b/thanos/charts/templates/tests/test-thanos-config.yaml
@@ -62,4 +62,11 @@ data:
       verify "there is 1 servicemonitor named '{{ .Release.Name }}'"
     }
     {{ end }}
+
+    {{ if not .Values.thanos.query.standalone }}
+    @test "Verify prometheus sidecar is running" {
+      try "at most 3 times every 5s to get pods named '.*kube-monitoring.*' and verify that '.status.containerStatuses[2].ready' is 'true'"
+    }
+    {{ end }}
+
 {{- end -}}


### PR DESCRIPTION
we had a case where a user deployed kube-monitoring without sidecar, then deployed thanos.

thanos plugin status was ready even though there is no sidecar and no data being written to long term storage

adding helm test to check that sidecar container is present

closing
https://github.com/cloudoperators/greenhouse-extensions/issues/725

