### PR TITLE
fix(opensearch): fix permissions, remove standard users, upgrade to 1.19.1

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -93,7 +93,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.dashboards.tls.generate | bool | `true` | generate certificate, if false secret must be provided |
 | cluster.cluster.dashboards.tls.secret | string | `nil` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.cluster.dashboards.tolerations | list | `[]` | dashboards pod tolerations |
-| cluster.cluster.dashboards.version | string | `"2.18.0"` | dashboards version |
+| cluster.cluster.dashboards.version | string | `"2.19.1"` | dashboards version |
 | cluster.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
 | cluster.cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
 | cluster.cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
@@ -103,9 +103,9 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.general.keystore | list | `[]` | Populate opensearch keystore before startup |
 | cluster.cluster.general.monitoring.enable | bool | `true` | Enable cluster monitoring |
 | cluster.cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
-| cluster.cluster.general.monitoring.pluginUrl | string | `"https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.18.0/prometheus-exporter-2.18.0.0.zip"` | Custom URL for the monitoring plugin |
+| cluster.cluster.general.monitoring.pluginUrl | string | `"https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip"` | Custom URL for the monitoring plugin |
 | cluster.cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |
-| cluster.cluster.general.monitoring.tlsConfig | object | `{}` | Override the tlsConfig of the generated ServiceMonitor |
+| cluster.cluster.general.monitoring.tlsConfig | object | `{"insecureSkipVerify":true}` | Override the tlsConfig of the generated ServiceMonitor |
 | cluster.cluster.general.pluginsList | list | `[]` | List of Opensearch plugins to install |
 | cluster.cluster.general.podSecurityContext | object | `{}` | Opensearch pod security context configuration |
 | cluster.cluster.general.securityContext | object | `{}` | Opensearch securityContext |
@@ -114,7 +114,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.general.setVMMaxMapCount | bool | `true` | Enable setVMMaxMapCount. OpenSearch requires the Linux kernel vm.max_map_count option to be set to at least 262144 |
 | cluster.cluster.general.snapshotRepositories | list | `[]` | Opensearch snapshot repositories configuration |
 | cluster.cluster.general.vendor | string | `"Opensearch"` |  |
-| cluster.cluster.general.version | string | `"2.18.0"` | Opensearch version |
+| cluster.cluster.general.version | string | `"2.19.1"` | Opensearch version |
 | cluster.cluster.ingress.dashboards.annotations | object | `{}` | dashboards ingress annotations |
 | cluster.cluster.ingress.dashboards.className | string | `""` | Ingress class name |
 | cluster.cluster.ingress.dashboards.enabled | bool | `false` | Enable ingress for dashboards service |
@@ -134,7 +134,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.nodePools | list | `[{"component":"main","diskSize":"30Gi","replicas":3,"resources":{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"roles":["cluster_manager"]},{"component":"data","diskSize":"30Gi","replicas":1,"resources":{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"roles":["data"]},{"component":"client","diskSize":"30Gi","replicas":1,"resources":{"limits":{"cpu":"500m","memory":"1Gi"},"requests":{"cpu":"500m","memory":"1Gi"}},"roles":["client"]}]` | Opensearch nodes configuration |
 | cluster.cluster.security.config.adminCredentialsSecret | object | `{}` | Secret that contains fields username and password to be used by the operator to access the opensearch cluster for node draining. Must be set if custom securityconfig is provided. |
 | cluster.cluster.security.config.adminSecret | object | `{}` | TLS Secret that contains a client certificate (tls.key, tls.crt, ca.crt) with admin rights in the opensearch cluster. Must be set if transport certificates are provided by user and not generated |
-| cluster.cluster.security.config.securityConfigSecret | object | `{"name":""}` | Secret that contains the differnt yml files of the opensearch-security config (config.yml, internal_users.yml, etc) |
+| cluster.cluster.security.config.securityConfigSecret | object | `{}` | Secret that contains the differnt yml files of the opensearch-security config (config.yml, internal_users.yml, etc) |
 | cluster.cluster.security.tls.http.caSecret | object | `{}` | Optional, secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields |
 | cluster.cluster.security.tls.http.generate | bool | `true` | If set to true the operator will generate a CA and certificates for the cluster to use, if false - secrets with existing certificates must be supplied |
 | cluster.cluster.security.tls.http.secret | object | `{}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
@@ -149,13 +149,13 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.indexTemplates | list | `[]` | List of OpensearchIndexTemplate. Check values.yaml file for examples. |
 | cluster.ismPolicies | list | `[]` | List of OpenSearchISMPolicy. Check values.yaml file for examples. |
 | cluster.nameOverride | string | `""` |  |
-| cluster.roles | list | `[{"clusterPermissions":["cluster_composite_ops","cluster_monitor"],"indexPermissions":[{"allowedActions":["index","read"],"indexPatterns":["logs*"]}],"name":"logs"},{"clusterPermissions":["*"],"indexPermissions":[{"allowedActions":["index","read"],"indexPatterns":["*"]}],"name":"admin"}]` | List of OpensearchRole. Check values.yaml file for examples. |
+| cluster.roles | list | `[{"clusterPermissions":["cluster_monitor","cluster_composite_ops","cluster:admin/ingest/pipeline/put","cluster:admin/ingest/pipeline/get","indices:admin/template/get","cluster_manage_index_templates"],"indexPermissions":[{"allowedActions":["indices:admin/template/get","indices:admin/template/put","indices:admin/mapping/put","indices:admin/create","indices:data/write/bulk*","indices:data/write/index","indices:data/read*","indices:monitor*","indices_all"],"indexPatterns":["logs*"]}],"name":"logs-role"}]` | List of OpensearchRole. Check values.yaml file for examples. |
 | cluster.serviceAccount.annotations | object | `{}` | Service Account annotations |
 | cluster.serviceAccount.create | bool | `false` | Create Service Account |
 | cluster.serviceAccount.name | string | `""` | Service Account name. Set `general.serviceAccount` to use this Service Account for the Opensearch cluster |
 | cluster.tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
-| cluster.users | list | `[{"backendRoles":["logs"],"name":"logs","password":"","secretKey":"password","secretName":"logs-credentials"},{"backendRoles":["admin"],"name":"admin","password":"","secretKey":"password","secretName":"admin-credentials"},{"backendRoles":[],"name":"kibanaserver","password":"","secretKey":"password","secretName":"kibanaserver-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
-| cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs"],"users":["logs"]},{"name":"admin-access","roles":["admin"],"users":["admin"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
+| cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"password":"","secretKey":"password","secretName":"logs-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
+| cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |
 | operator.kubeRbacProxy.enable | bool | `true` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.1
+version: 0.0.2
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -418,8 +418,8 @@ cluster:
   #       name: "secret-name"
 
         # -- Secret that contains the differnt yml files of the opensearch-security config (config.yml, internal_users.yml, etc)
-        securityConfigSecret:
-          name: ""
+        securityConfigSecret: {}
+  #       name: ""
 
       # Configure tls usage for transport and http interface
       tls:
@@ -514,81 +514,52 @@ cluster:
 
   # -- List of OpensearchRole. Check values.yaml file for examples.
   roles:
-    - name: "logs"
+    - name: "logs-role"
       clusterPermissions:
-        - cluster_composite_ops
-        - cluster_monitor
+        - "cluster_monitor"
+        - "cluster_composite_ops"
+        - "cluster:admin/ingest/pipeline/put"
+        - "cluster:admin/ingest/pipeline/get"
+        - "indices:admin/template/get"
+        - "cluster_manage_index_templates"
       indexPermissions:
         - indexPatterns:
-            - logs*
+            - "logs*"
           allowedActions:
-            - index
-            - read
-    - name: "admin"
-      clusterPermissions:
-        - "*"
-      indexPermissions:
-        - indexPatterns:
-            - "*"
-          allowedActions:
-            - index
-            - read
+            - "indices:admin/template/get"
+            - "indices:admin/template/put"
+            - "indices:admin/mapping/put"
+            - "indices:admin/create"
+            - "indices:data/write/bulk*"
+            - "indices:data/write/index"
+            - "indices:data/read*"
+            - "indices:monitor*"
+            - "indices_all"
 
-  #  - name: "example-role"
+  #  - name: "admin-role"
   #    clusterPermissions:
-  #      - cluster_composite_ops
-  #      - cluster_monitor
-  #    allowedActions:
-  #      - index
-  #      - read
-  #  - name: "example-role-for-index-pattern"
-  #    clusterPermissions:
-  #      - cluster_composite_ops
-  #      - cluster_monitor
+  #      - "*"
   #    indexPermissions:
   #      - indexPatterns:
-  #          - logs*
+  #          - "*"
   #        allowedActions:
-  #          - index
-  #          - read
-  #  - name: "example-role-with-tenant-scope"
-  #    clusterPermissions:
-  #      - cluster_composite_ops
-  #      - cluster_monitor
-  #    allowedActions:
-  #      - index
-  #      - read
-  #    tenantPermissions:
-  #      allowedActions:
-  #        - "*"
-  #      tenantPatterns:
-  #        - "*"
+  #          - "*"
 
   # -- List of OpensearchUser. Check values.yaml file for examples.
   users:
     - name: "logs"
-      password: ""
+      password: "" # If not set, a random password will be generated
       secretName: "logs-credentials"
       secretKey: "password"
-      backendRoles:
-        - "logs"
-#      opendistroSecurityRoles:
-#        - "logs"
-    - name: "admin"
-      password: ""
-      secretName: "admin-credentials"
-      secretKey: "password"
-      backendRoles:
-        - "admin"
-#      opendistroSecurityRoles:
-#        - "admin"
-    - name: "kibanaserver"
-      password: ""
-      secretName: "kibanaserver-credentials"
-      secretKey: "password"
       backendRoles: []
-#      opendistroSecurityRoles:
-#        - "kibanaserver"
+      opendistroSecurityRoles:
+        - "logs-role"
+  #  - name: "admin"
+  #    password: "admin" # If not set, a random password will be generated
+  #    secretName: "admin-credentials"
+  #    secretKey: "password"
+  #    opendistroSecurityRoles:
+  #      - "admin-role"
 
   # -- Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role
   # Check values.yaml file for examples.
@@ -597,21 +568,12 @@ cluster:
       users:
         - "logs"
       roles:
-        - "logs"
-    - name: "admin-access"
-      users:
-        - "admin"
-      roles:
-        - "admin"
-  #  - name: admin_access
+        - "logs-role"
+  #  - name: "admin-access"
   #    users:
-  #      - example-user
-  #      - example-user2
+  #      - "admin"
   #    roles:
-  #      - example-role
-  #    backendRoles:
-  #      - example-backend-role
-
+  #      - "admin-role"
 
   # -- List of additional tenants. Check values.yaml file for examples.
   tenants: []

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -199,14 +199,14 @@ cluster:
         monitoringUserSecret: ""
 
         # -- Custom URL for the monitoring plugin
-        pluginUrl: "https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.18.0/prometheus-exporter-2.18.0.0.zip"
+        pluginUrl: "https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip"
 
         # -- How often to scrape metrics
         scrapeInterval: 30s
 
         # -- Override the tlsConfig of the generated ServiceMonitor
-        tlsConfig: {}
-  #        insecureSkipVerify: true
+        tlsConfig:
+          insecureSkipVerify: true
 
       # -- List of Opensearch plugins to install
       pluginsList: []
@@ -238,7 +238,7 @@ cluster:
       vendor: Opensearch
 
       # -- Opensearch version
-      version: 2.18.0
+      version: 2.19.1
 
     # OpenSearchCluster boostrap pod configuration
     bootstrap:
@@ -349,7 +349,7 @@ cluster:
       tolerations: []
 
       # -- dashboards version
-      version: 2.18.0
+      version: 2.19.1
 
     # initHelper configuration
     initHelper:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -548,7 +548,7 @@ cluster:
   # -- List of OpensearchUser. Check values.yaml file for examples.
   users:
     - name: "logs"
-      password: "" # If not set, a random password will be generated
+      password: ""  # If not set, a random password will be generated
       secretName: "logs-credentials"
       secretKey: "password"
       backendRoles: []

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -8,7 +8,7 @@ metadata:
 spec:
   version: 0.0.1
   displayName: OpenSearch
-  description: Search and observability suite that brings order to unstructured data at scale.
+  description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch


### PR DESCRIPTION
## Pull Request Details

This PR addresses several issues with the OpenSearch plugin configuration:
- Removes the admin and kibanaserver users from plugin configuration as they conflict with internally created standard users
- Adjusts permissions and roles for the logs user to ensure proper access
- Updates the plugin to version 1.19.1 for compatibility with latest OpenSearch
- Fixes ServiceMonitor configuration to properly enable metrics collection

## Breaking Changes

No

## Issues Fixed

X

## Other Relevant Information

X
