### PR TITLE
fix(opensearch): Change label and scope for opensearch crds

### DIFF
--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -16,5 +16,5 @@ This following table provides an overview of the currently available Plugins in 
 | ingress-nginx|Ingress NGINX controller|1.1.0|
 | kube-monitoring|Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.|1.3.4|
 | logs|This Plugin is intended for ingesting, generating, collecting, and exporting logs.|0.8.0|
-| opensearch|The OpenSearch plugin sets up an OpenSearch environment using the OpenSearch Operator, automating deployment, provisioning, management, and orchestration of OpenSearch clusters and dashboards.|0.0.1|
+| opensearch|The OpenSearch plugin sets up an OpenSearch environment using the OpenSearch Operator, automating deployment, provisioning, management, and orchestration of OpenSearch clusters and dashboards.|0.0.4|
 | teams2slack|Manage Slack handles and channels based on Greenhouse teams and their members|1.1.0|

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.3
+version: 0.0.4
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchactiongroups.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchactiongroups.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchactiongroups.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchactiongroup
     singular: opensearchactiongroup
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchclusters.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchclusters.opensearch.opster.io
@@ -22,7 +22,7 @@ spec:
     - os
     - opensearch
     singular: opensearchcluster
-  scope: Namespaced
+  scope: Cluster
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.health

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchcomponenttemplates.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchcomponenttemplates.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchcomponenttemplates.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchcomponenttemplate
     singular: opensearchcomponenttemplate
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchindextemplates.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchindextemplates.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchindextemplates.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchindextemplate
     singular: opensearchindextemplate
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchismpolicies.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchismpolicies.opensearch.opster.io
@@ -22,7 +22,7 @@ spec:
     - ismp
     - ismpolicy
     singular: opensearchismpolicy
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchroles.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchroles.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchroles.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchrole
     singular: opensearchrole
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchtenants.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchtenants.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchtenants.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchtenant
     singular: opensearchtenant
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchuserrolebindings.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchuserrolebindings.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchuserrolebindings.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchuserrolebinding
     singular: opensearchuserrolebinding
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchusers.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchusers.yaml
@@ -8,7 +8,7 @@ metadata:
   annotations:
     controller-gen.kubebuilder.io/version: v0.14.0
     meta.helm.sh/release-name: opensearch
-    meta.helm.sh/release-namespace: demo
+    meta.helm.sh/release-namespace: opensearch
   labels:
     app.kubernetes.io/managed-by: Helm
   name: opensearchusers.opensearch.opster.io
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchuser
     singular: opensearchuser
-  scope: Namespaced
+  scope: Cluster
   versions:
   - name: v1
     schema:

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.3
+  version: 0.0.4
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.3
+    version: 0.0.4
   options:
     - name: operator.fullnameOverride
       description: "Override the full name of the operator. Use this to customize resource naming."


### PR DESCRIPTION
## Pull Request Details

This PR updates the OpenSearch CRDs to:
- Use the standard opensearch namespace label instead of the demo-specific demo label
- Change the scope from `Namespaced` to `Cluster` to support use in multiple namespaces

## Breaking Changes

None. 

## Issues Fixed

Currently the plugin cannot be deployed because demo namespace is protected.
