### PR TITLE
fix: exclude docs/catalog.md from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,6 +15,7 @@ Dockerfile.otel-collector @cloudoperators/greenhouse-observability
 Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/greenhouse-observability
 
 /docs/                    @cloudoperators/greenhouse-core
+/docs/catalog.md
 /hack/                    @cloudoperators/greenhouse-backend
 
 # The following paths are owned by the respective maintainers


### PR DESCRIPTION
## Pull Request Details

Keep the `/docs/` folder owned by @cloudoperators/greenhouse-core, but exclude `catalog.md` so that anyone can update version numbers without requiring code owner approval.

## Breaking Changes

None

## Issues Fixed

None
