### PR TITLE
fix(opensearch): fix crds scope and remove installCRDs toggle 

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.5
+version: 0.0.6
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchactiongroups.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchactiongroups.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchactiongroup
     singular: opensearchactiongroup
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchclusters.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchclusters.yaml
@@ -22,7 +22,7 @@ spec:
     - os
     - opensearch
     singular: opensearchcluster
-  scope: Cluster
+  scope: Namespaced
   versions:
   - additionalPrinterColumns:
     - jsonPath: .status.health

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchcomponenttemplates.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchcomponenttemplates.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchcomponenttemplate
     singular: opensearchcomponenttemplate
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchindextemplates.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchindextemplates.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchindextemplate
     singular: opensearchindextemplate
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchismpolicies.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchismpolicies.yaml
@@ -22,7 +22,7 @@ spec:
     - ismp
     - ismpolicy
     singular: opensearchismpolicy
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchroles.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchroles.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchrole
     singular: opensearchrole
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchtenants.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchtenants.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchtenant
     singular: opensearchtenant
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchuserrolebindings.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchuserrolebindings.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchuserrolebinding
     singular: opensearchuserrolebinding
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/chart/crds/opensearch.opster.io_opensearchusers.yaml
+++ b/opensearch/chart/crds/opensearch.opster.io_opensearchusers.yaml
@@ -21,7 +21,7 @@ spec:
     shortNames:
     - opensearchuser
     singular: opensearchuser
-  scope: Cluster
+  scope: Namespaced
   versions:
   - name: v1
     schema:

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,25 +6,20 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.5
+  version: 0.0.6
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.5
+    version: 0.0.6
   options:
     - name: operator.fullnameOverride
       description: "Override the full name of the operator. Use this to customize resource naming."
       default: "opensearch-operator"
       required: false
       type: string
-    - name: operator.installCRDs
-      description: "Enable or disable installation of the Custom Resource Definitions (CRDs) required by the operator."
-      default: false
-      required: false
-      type: bool
     - name: operator.kubeRbacProxy.enable
       description: "Toggle the kube-rbac-proxy to secure the operator's endpoints."
       default: true


### PR DESCRIPTION
## Pull Request Details

Switching the CRDs back to `Namespaced` ensures each CR has a valid `metadata.namespace`, which the operator relies on to scope all of its actions.

## Breaking Changes

None

## Issues Fixed

N/A
