### PR TITLE
feat(cert-manager): reduce timeout for webhooks

### DIFF
--- a/cert-manager/plugindefinition.yaml
+++ b/cert-manager/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: cert-manager
 spec:
-  version: 1.17.1
+  version: 1.17.2
   displayName: Certificate manager
   description: Automated TLS certificate management
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/cert-manager/README.md
@@ -45,3 +45,8 @@ spec:
       description: Group of the cert-manager issuer to use for TLS certificates
       required: false
       type: string
+    - name: cert-manager.webhook.timeoutSeconds
+      description: Timeout in seconds for the CertManager webhook
+      default: 15
+      required: false
+      type: int


### PR DESCRIPTION
the timeout was increased when we updated cert-manager gardener clusters do not allow timeouts with >15s
this reduces the timeout to 15s

# Submit a pull request

Thank you for submitting a pull request!  
To speed up the review process, please ensure that everything below
is true:

1. This is not a duplicate of an existing Plugin.
2. No existing features have been broken without good reason.
3. The Documentation has been updated to reflect your changes.
4. Tests have been added or updated to reflect your changes.
5. All tests pass.

---

Replace any ":question:" below with information about your pull request.

## Pull Request Details

Provide details about your pull request and what it adds, fixes, or changes.

:question:

## Breaking Changes

Describe what features are broken by this pull request and why, if any.

:question:

## Issues Fixed

Enter the issue numbers resolved by this pull request below, if any.

1. :question:

## Other Relevant Information

Provide any other important details below.

:question:
