### PR TITLE
chore(logs): bumps OpenTelemetry-collector-contrib to v0.124.1

### DIFF
--- a/Dockerfile.otel-collector
+++ b/Dockerfile.otel-collector
@@ -3,7 +3,7 @@ RUN apt update  \
   && apt upgrade -y  \
   && apt autoremove -y \
   && apt install -y systemd libssl-dev
-FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.121.0
+FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.124.1
 LABEL source_repository="https://github.com/greenhouse-extensions"
 COPY --from=journal /lib/x86_64-linux-gnu/libc.so.6 /lib/x86_64-linux-gnu/libc.so.6
 COPY --from=journal /lib64/ld-linux-x86-64.so.2 /lib64/ld-linux-x86-64.so.2


### PR DESCRIPTION
This updates the Dockerfile for our customised openTelemetry-collector-contrib image. Changes are outlined here for core https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.124.0, and here for the upstream contrib https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.124.1.

---------

Signed off by: Simon Olander (simon.olander@sap.com)