### PR TITLE
feat(opensearch): add manual service for dashboards

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -78,7 +78,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.dashboards.image | string | `"docker.io/opensearchproject/opensearch-dashboards"` | dashboards image |
 | cluster.cluster.dashboards.imagePullPolicy | string | `"IfNotPresent"` | dashboards image pull policy |
 | cluster.cluster.dashboards.imagePullSecrets | list | `[]` | dashboards image pull secrets |
-| cluster.cluster.dashboards.labels | object | `{"greenhouse.sap/expose":"true"}` | dashboards labels |
+| cluster.cluster.dashboards.labels | object | `{}` | dashboards labels |
 | cluster.cluster.dashboards.nodeSelector | object | `{}` | dashboards pod node selectors |
 | cluster.cluster.dashboards.opensearchCredentialsSecret | object | `{}` | Secret that contains fields username and password for dashboards to use to login to opensearch, must only be supplied if a custom securityconfig is provided |
 | cluster.cluster.dashboards.pluginsList | list | `[]` | List of dashboards plugins to install |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.6
+version: 0.0.7
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/dashboard-service.yaml
+++ b/opensearch/chart/templates/dashboard-service.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.cluster.cluster.dashboards.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.cluster.cluster.name | default .Release.Name }}-dashboards-expose
+  labels:
+    opensearch.cluster.dashboards: {{ .Values.cluster.cluster.name | default .Release.Name }}
+    greenhouse.sap/expose: "true"
+spec:
+  type: {{ .Values.cluster.cluster.dashboards.service.type }}
+  ports:
+    - name: http
+      port: 5601
+      targetPort: 5601
+      protocol: TCP
+  selector:
+    opensearch.cluster.dashboards: {{ .Values.cluster.cluster.name | default .Release.Name }}
+{{- end }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -296,8 +296,7 @@ cluster:
       imagePullSecrets: []
 
       # -- dashboards labels
-      labels:
-        greenhouse.sap/expose: "true"
+      labels: {}
 
       # -- dashboards pod node selectors
       nodeSelector: {}

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.6
+  version: 0.0.7
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.6
+    version: 0.0.7
   options:
     - name: operator.fullnameOverride
       description: "Override the full name of the operator. Use this to customize resource naming."


### PR DESCRIPTION
## Pull Request Details

Adds a manual `Service` resource for OpenSearch Dashboards to be used for service proxy with the proper labeling. This is a temporary solution until [opensearch-k8s-operator PR #1002](https://github.com/opensearch-project/opensearch-k8s-operator/pull/1002) is merged, which will introduce native support for labels on service resources.

## Breaking Changes

None

## Issues Fixed

None