### PR TITLE
feat(renovate) dockerfile versions

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -150,6 +150,19 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "grpc-ecosystem/grpc-health-probe",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump yq version in integration-test Dockerfile",
+      "fileMatch": [
+        "^Dockerfile(\\.integration-test)?$"
+      ],
+      "matchStrings": [
+        "ARG YQ_VERSION=(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "mikefarah/yq",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,6 +5,10 @@
     "config:recommended",
     "helpers:pinGitHubActionDigests"
   ],
+  "docker": {
+    "enabled": true,
+    "pinDigests": true
+  },
   "customManagers": [
     {
       "customType": "regex",
@@ -120,6 +124,32 @@
       "datasourceTemplate": "github-tags",
       "depNameTemplate": "norwoodj/helm-docs",
       "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump kubectl version in integration-test Dockerfile",
+      "fileMatch": [
+        "^Dockerfile(\\.integration-test)?$"
+      ],
+      "matchStrings": [
+        "ARG KUBECTL_VERSION=(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "kubernetes/kubernetes",
+      "extractVersionTemplate": "^v(?<version>.*)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump grpc-health-probe version in integration-test Dockerfile",
+      "fileMatch": [
+        "^Dockerfile(\\.integration-test)?$"
+      ],
+      "matchStrings": [
+        "ARG GRPC_HEALTH_PROBE_VERSION=(?<currentValue>v[0-9]+\\.[0-9]+\\.[0-9]+)"
+      ],
+      "datasourceTemplate": "github-tags",
+      "depNameTemplate": "grpc-ecosystem/grpc-health-probe",
+      "extractVersionTemplate": "^v(?<version>.*)$"
     }
   ],
   "packageRules": [
@@ -184,6 +214,14 @@
       "ignorePaths": [
         "**/cert-manager/charts/**"
       ]
+    },
+    {
+      "matchDatasources": ["docker"],
+      "matchPackageNames": [
+        "debian",
+        "ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib"
+      ],
+      "groupName": "OTEL docker base images"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION
automatic PR creation for 
https://github.com/cloudoperators/greenhouse-extensions/blob/main/Dockerfile.integration-test
```
ARG KUBECTL_VERSION=v1.30.3
ARG GRPC_HEALTH_PROBE_VERSION=v0.4.37
```

https://github.com/cloudoperators/greenhouse-extensions/blob/main/Dockerfile.otel-collector
```
FROM --platform=${BUILDPLATFORM:-linux/amd64} debian:12.10 AS journal
FROM --platform=${BUILDPLATFORM:-linux/amd64} ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:0.124.1
```

UDPATE
```
ARG YQ_VERSION=v4.45.1
```