### PR TITLE
feat(kubeconfig-generator): Use greenhousekubeconfig

### DIFF
--- a/kubeconfig-generator/chart/Chart.yaml
+++ b/kubeconfig-generator/chart/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
 type: application
 name: kubeconfig-generator
-version: 0.1.12
-appVersion: "980bb2db067ab3213c1568a815fa800a509608c5"
+version: 0.1.13
+appVersion: "97ce7e3908695171b780b33e1e4d09653b72474b"
 keywords:
 - operator
 - kubeconfig

--- a/kubeconfig-generator/plugindefinition.yaml
+++ b/kubeconfig-generator/plugindefinition.yaml
@@ -7,11 +7,11 @@ metadata:
   name: kubeconfig-generator
 spec:
   description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
-  version: 0.1.11
+  version: 0.1.13
   helmChart:
     name: kubeconfig-generator
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.12
+    version: 0.1.13
   options:
     - name: swift.authUrl
       description: Keystone endpoint to be used for authentication


### PR DESCRIPTION
This fixes panicking if the `.data.kubeconfig` entry is not present on the `Cluster` `Secret`. Which is the case for OIDC onboarded `Clusters` as they only contain the `greenhousekubeconfig`.
This field is always present. Since the Controller only extracts Server data, no change in functionality is made.
