### PR TITLE
feat(opensearch): add labels for ServiceMonitor

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -102,6 +102,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
 | cluster.cluster.general.keystore | list | `[]` | Populate opensearch keystore before startup |
 | cluster.cluster.general.monitoring.enable | bool | `true` | Enable cluster monitoring |
+| cluster.cluster.general.monitoring.labels | object | `{}` | ServiceMonitor labels |
 | cluster.cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
 | cluster.cluster.general.monitoring.pluginUrl | string | `"https://github.com/Virtimo/prometheus-exporter-plugin-for-opensearch/releases/download/v2.19.1/prometheus-exporter-2.19.1.0.zip"` | Custom URL for the monitoring plugin |
 | cluster.cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.7
+version: 0.0.8
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -208,6 +208,9 @@ cluster:
         tlsConfig:
           insecureSkipVerify: true
 
+        # -- ServiceMonitor labels
+        labels: {}
+
       # -- List of Opensearch plugins to install
       pluginsList: []
 

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,45 +6,29 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.7
+  version: 0.0.8
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.7
+    version: 0.0.8
   options:
     - name: operator.fullnameOverride
-      description: "Override the full name of the operator. Use this to customize resource naming."
+      description: "Specifies a custom name for the OpenSearch operator. Use this to override the default naming convention for operator-managed resources."
       default: "opensearch-operator"
       required: false
       type: string
-    - name: operator.kubeRbacProxy.enable
-      description: "Toggle the kube-rbac-proxy to secure the operator's endpoints."
-      default: true
-      required: false
-      type: bool
-    - name: opensearchOperator.serviceAccount.create
-      description: "Determine whether a new service account should be created for the OpenSearch operator."
-      default: true
-      required: false
-      type: bool
-    - name: opensearchOperator.serviceAccount.name
-      description: "Specify the name of the service account used by the OpenSearch operator. Only change if creating a new account."
-      default: "opensearch-operator-controller-manager"
-      required: false
-      type: string
     - name: cluster.fullnameOverride
-      description: "Override the full name of the OpenSearch cluster. Defaults to the release name if left blank."
+      description: "Specifies a custom name for the OpenSearch cluster. If left blank, the release name will be used as the default."
       required: false
       type: string
-    - name: cluster.serviceAccount.create
-      description: "Control whether to create a service account for the OpenSearch cluster. Set to false to use an existing account."
-      default: false
-      required: false
-      type: bool
-    - name: cluster.monitoring.pluginUrl
-      description: "Provide a custom URL for the monitoring plugin. Leave blank to use the default monitoring configuration."
+    - name: cluster.cluster.general.monitoring.pluginUrl
+      description: "Defines a custom URL for the monitoring plugin. Leave blank to use the default monitoring configuration."
       required: false
       type: string
+    - name: cluster.cluster.general.monitoring.labels
+      description: "Specifies custom labels for the ServiceMonitor to expose OpenSearch metrics to Prometheus."
+      required: false
+      type: map


### PR DESCRIPTION
## Pull Request Details

Allow to set custom labels for the ServiceMonitor to expose OpenSearch metrics to Prometheus.

## Breaking Changes

None

## Issues Fixed

N/A
