### PR TITLE
[logs] rm duplicated exposed metrics endpoints

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.124.1
 name: logs-operator
-version: 0.9.0
+version: 0.9.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -334,11 +334,11 @@ spec:
         metrics:
           level: detailed
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: 0.0.0.0
-                  port: 8888
+          #- pull:
+          #    exporter:
+          #      prometheus:
+          #        host: 0.0.0.0
+          #        port: 8888
 {{- end }}
       pipelines:
         logs/forward:

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -334,11 +334,6 @@ spec:
         metrics:
           level: detailed
           readers:
-          #- pull:
-          #    exporter:
-          #      prometheus:
-          #        host: 0.0.0.0
-          #        port: 8888
 {{- end }}
       pipelines:
         logs/forward:

--- a/logs/charts/templates/metrics-collector.yaml
+++ b/logs/charts/templates/metrics-collector.yaml
@@ -52,9 +52,9 @@ spec:
         metrics:
           level: detailed
           readers:
-          - pull:
-              exporter:
-                prometheus:
-                  host: 0.0.0.0
-                  port: 8888
+          #- pull:
+          #    exporter:
+          #      prometheus:
+          #        host: 0.0.0.0
+          #        port: 8888
 {{- end }}

--- a/logs/charts/templates/metrics-collector.yaml
+++ b/logs/charts/templates/metrics-collector.yaml
@@ -52,9 +52,4 @@ spec:
         metrics:
           level: detailed
           readers:
-          #- pull:
-          #    exporter:
-          #      prometheus:
-          #        host: 0.0.0.0
-          #        port: 8888
 {{- end }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: logs
 spec:
-    version: 0.9.0
+    version: 0.9.1
     displayName: Logs
     description: Observability framework for instrumenting, generating, collecting, and exporting logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
     helmChart:
         name: logs-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.9.0
+        version: 0.9.1
     options:
         - default: true
           description: Activates the standard configuration for logs


### PR DESCRIPTION
## Pull Request Details

The metrics are align with the default values for metrics. By removing the section we ensure the exposing does not happen twice. This behavior can be tested locally with:

- Created a kind cluster
- Installed cert-manager
- Installed the 0.79.0 version of the helm chart for the operator:  ```helm upgrade --install otel-operator open-- telemetry/opentelemetry-operator --version 0.79.0 --set manager.collectorImage.repository=otel/opentelemetry-collector-contrib```
- Created an OpenTelemetry Collector instance:
  ```
  apiVersion: opentelemetry.io/v1alpha1
  kind: OpenTelemetryCollector
  metadata:
    name: test
  spec:
    mode: deployment
    config: |
      receivers:
        otlp:
          protocols:
            grpc: {}
            http: {}
  
      processors:
  
      exporters:
        debug: {}
  
      extensions:
  
      service:
        pipelines:
          metrics:
            receivers: [otlp]
            processors: []
            exporters: [debug]
  ```
  - The config is applied properly:
```
        telemetry:
          metrics:
            address: 0.0.0.0:8888
```
- If we change the config with the new metrics settings:
```
      telemetry:
        metrics:
          readers:
          - pull:
              exporter:
                prometheus:
                  host: 0.0.0.0
                  port: 8888
```
- ...And upgrade the operator with ```helm upgrade --install otel-operator open-telemetry/opentelemetry-operator --version 0.86.1 --set manager.collectorImage.repository=otel/opentelemetry-collector-contrib```, the metrics settings will be applied twice for the config, leading to a CrashLoop of the respective pod.
```
      telemetry:
        metrics:
          readers:
          - pull:
              exporter:
                prometheus:
                  host: 0.0.0.0
                  port: 8888
          - pull:
              exporter:
                prometheus:
                  host: 0.0.0.0
                  port: 8888
```