### PR TITLE
feat(opensearch): support cert-manager certs and disable self-signed

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -90,8 +90,8 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.dashboards.service.type | string | `"ClusterIP"` | dashboards service type |
 | cluster.cluster.dashboards.tls.caSecret | object | `{}` | Secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields |
 | cluster.cluster.dashboards.tls.enable | bool | `false` | Enable HTTPS for dashboards |
-| cluster.cluster.dashboards.tls.generate | bool | `true` | generate certificate, if false secret must be provided |
-| cluster.cluster.dashboards.tls.secret | string | `nil` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
+| cluster.cluster.dashboards.tls.generate | bool | `false` | generate certificate, if false secret must be provided |
+| cluster.cluster.dashboards.tls.secret | object | `{"name":"opensearch-http-cert"}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.cluster.dashboards.tolerations | list | `[]` | dashboards pod tolerations |
 | cluster.cluster.dashboards.version | string | `"2.19.1"` | dashboards version |
 | cluster.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
@@ -137,14 +137,14 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.security.config.adminSecret | object | `{}` | TLS Secret that contains a client certificate (tls.key, tls.crt, ca.crt) with admin rights in the opensearch cluster. Must be set if transport certificates are provided by user and not generated |
 | cluster.cluster.security.config.securityConfigSecret | object | `{}` | Secret that contains the differnt yml files of the opensearch-security config (config.yml, internal_users.yml, etc) |
 | cluster.cluster.security.tls.http.caSecret | object | `{}` | Optional, secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields |
-| cluster.cluster.security.tls.http.generate | bool | `true` | If set to true the operator will generate a CA and certificates for the cluster to use, if false - secrets with existing certificates must be supplied |
-| cluster.cluster.security.tls.http.secret | object | `{}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
+| cluster.cluster.security.tls.http.generate | bool | `false` | If set to true the operator will generate a CA and certificates for the cluster to use, if false - secrets with existing certificates must be supplied |
+| cluster.cluster.security.tls.http.secret | object | `{"name":"opensearch-admin-cert"}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.cluster.security.tls.transport.adminDn | list | `[]` | DNs of certificates that should have admin access, mainly used for securityconfig updates via securityadmin.sh, only used when existing certificates are provided |
 | cluster.cluster.security.tls.transport.caSecret | object | `{}` | Optional, secret that contains the ca certificate as ca.crt. If this and generate=true is set the existing CA cert from that secret is used to generate the node certs. In this case must contain ca.crt and ca.key fields |
-| cluster.cluster.security.tls.transport.generate | bool | `true` | If set to true the operator will generate a CA and certificates for the cluster to use, if false secrets with existing certificates must be supplied |
+| cluster.cluster.security.tls.transport.generate | bool | `false` | If set to true the operator will generate a CA and certificates for the cluster to use, if false secrets with existing certificates must be supplied |
 | cluster.cluster.security.tls.transport.nodesDn | list | `[]` | Allowed Certificate DNs for nodes, only used when existing certificates are provided |
-| cluster.cluster.security.tls.transport.perNode | bool | `true` | Separate certificate per node |
-| cluster.cluster.security.tls.transport.secret | object | `{}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
+| cluster.cluster.security.tls.transport.perNode | bool | `false` | Separate certificate per node |
+| cluster.cluster.security.tls.transport.secret | object | `{"name":"opensearch-transport-cert"}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.componentTemplates | list | `[]` | List of OpensearchComponentTemplate. Check values.yaml file for examples. |
 | cluster.fullnameOverride | string | `""` |  |
 | cluster.indexTemplates | list | `[]` | List of OpensearchIndexTemplate. Check values.yaml file for examples. |
@@ -158,6 +158,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
 | cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"password":"","secretKey":"password","secretName":"logs-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
 | cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
+| global.greenhouse.baseDomain | string | `nil` |  |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |
 | operator.kubeRbacProxy.enable | bool | `true` |  |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -159,6 +159,9 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"password":"","secretKey":"password","secretName":"logs-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
 | cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
 | global.certManager.enable | bool | `true` |  |
+| global.certManager.issuerRef.group | string | `"certmanager.cloud.sap"` |  |
+| global.certManager.issuerRef.kind | string | `"DigicertIssuer"` |  |
+| global.certManager.issuerRef.name | string | `"digicert-issuer"` |  |
 | global.greenhouse.baseDomain | string | `nil` |  |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -158,6 +158,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
 | cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"password":"","secretKey":"password","secretName":"logs-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
 | cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
+| global.certManager.enable | bool | `true` |  |
 | global.greenhouse.baseDomain | string | `nil` |  |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.8
+version: 0.0.9
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+{{- if .Values.global.certManager.enable }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -77,3 +78,4 @@ spec:
     - key encipherment
     - server auth
     - client auth
+{{- end }}

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -15,9 +15,7 @@ spec:
   - opensearch.{{ .Release.Namespace }}.svc
   - opensearch.{{ .Release.Namespace }}.svc.cluster.local
   issuerRef:
-    group: certmanager.cloud.sap
-    kind: DigicertIssuer
-    name: digicert-issuer
+  {{- toYaml .Values.global.certManager.issuerRef | nindent 4 }}
   privateKey:
     algorithm: RSA
     encoding: PKCS8
@@ -37,9 +35,7 @@ spec:
   commonName: admin
   duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
   issuerRef:
-    group: certmanager.cloud.sap
-    kind: DigicertIssuer
-    name: digicert-issuer
+  {{- toYaml .Values.global.certManager.issuerRef | nindent 4 }}
   privateKey:
     algorithm: RSA
     encoding: PKCS8
@@ -65,9 +61,7 @@ spec:
   - {{ printf "*.%s" .Values.global.greenhouse.baseDomain | quote }}
 {{- end }}
   issuerRef:
-    group: certmanager.cloud.sap
-    kind: DigicertIssuer
-    name: digicert-issuer
+  {{- toYaml .Values.global.certManager.issuerRef | nindent 4 }}
   privateKey:
     algorithm: RSA
     encoding: PKCS8

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -1,0 +1,79 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: opensearch-transport-cert
+spec:
+  duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
+  dnsNames:
+  - opensearch
+  - opensearch-discovery
+  - opensearch.{{ .Release.Namespace }}
+  - opensearch.{{ .Release.Namespace }}.svc
+  - opensearch.{{ .Release.Namespace }}.svc.cluster.local
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: DigicertIssuer
+    name: digicert-issuer
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  secretName: opensearch-transport-cert
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: opensearch-admin-cert
+spec:
+  commonName: admin
+  duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: DigicertIssuer
+    name: digicert-issuer
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  secretName: opensearch-admin-cert
+  usages:
+    - digital signature
+    - key encipherment
+    - client auth
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: opensearch-http-cert
+spec:
+  duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
+  dnsNames:
+  - opensearch
+  - opensearch.{{ .Release.Namespace }}
+  - opensearch.{{ .Release.Namespace }}.svc
+  - opensearch.{{ .Release.Namespace }}.svc.cluster.local
+{{- if .Values.global.greenhouse.baseDomain }}
+  - {{ printf "*.%s" .Values.global.greenhouse.baseDomain | quote }}
+{{- end }}
+  issuerRef:
+    group: certmanager.cloud.sap
+    kind: DigicertIssuer
+    name: digicert-issuer
+  privateKey:
+    algorithm: RSA
+    encoding: PKCS8
+    size: 2048
+  secretName: opensearch-http-cert
+  usages:
+    - digital signature
+    - key encipherment
+    - server auth
+    - client auth

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -7,6 +7,8 @@ global:
   greenhouse:
     # base domain of the greenhouse organisation
     baseDomain:
+  certManager:
+    enable: true
 
 operator:
   namespace: ""

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -1,6 +1,13 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+global:
+  ## common greenhouse values to use
+  ##
+  greenhouse:
+    # base domain of the greenhouse organisation
+    baseDomain:
+
 operator:
   namespace: ""
   nameOverride: ""
@@ -340,12 +347,12 @@ cluster:
         enable: false
 
         # -- generate certificate, if false secret must be provided
-        generate: true
+        generate: false
 
         # -- Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different
         # secret provide it via the caSecret field
         secret:
-          # name: "
+          name: "opensearch-http-cert"
 
       # -- dashboards pod tolerations
       tolerations: []
@@ -433,12 +440,12 @@ cluster:
 
           # -- If set to true the operator will generate a CA and certificates for the cluster to use,
           # if false - secrets with existing certificates must be supplied
-          generate: true
+          generate: false
 
           # -- Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a
           # different secret provide it via the caSecret field
-          secret: {}
-  #            name: "secret-name"
+          secret:
+            name: "opensearch-admin-cert"
 
         transport:
           # -- DNs of certificates that should have admin access, mainly used for securityconfig updates via securityadmin.sh,
@@ -452,18 +459,18 @@ cluster:
 
           # -- If set to true the operator will generate a CA and certificates for the cluster to use,
           # if false secrets with existing certificates must be supplied
-          generate: true
+          generate: false
 
           # --  Allowed Certificate DNs for nodes, only used when existing certificates are provided
           nodesDn: []
 
           # -- Separate certificate per node
-          perNode: true
+          perNode: false
 
           # -- Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a
           # different secret provide it via the caSecret field
-          secret: {}
-  #            name: "secret-name"
+          secret:
+            name: "opensearch-transport-cert"
 
     # Opensearch Ingress configuration
     ingress:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -9,6 +9,10 @@ global:
     baseDomain:
   certManager:
     enable: true
+    issuerRef:
+      group: certmanager.cloud.sap
+      kind: DigicertIssuer
+      name: digicert-issuer
 
 operator:
   namespace: ""

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.8
+  version: 0.0.9
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.8
+    version: 0.0.9
   options:
     - name: operator.fullnameOverride
       description: "Specifies a custom name for the OpenSearch operator. Use this to override the default naming convention for operator-managed resources."

--- a/opensearch/test-dependencies.yaml
+++ b/opensearch/test-dependencies.yaml
@@ -1,0 +1,3 @@
+dependencies:
+  - kube-monitoring
+  - cert-manager


### PR DESCRIPTION
## Pull Request Details

This change:
- Disables the operators automatic generation of self-signed certificates
- Creates three new certificates:
  - `opensearch-http-cert` for the REST API
  - `opensearch-transport-cert` for node-to-node communication
  - `opensearch-admin-cert` for admin operations

## Breaking Changes

N/A

## Issues Fixed

N/A
