### PR TITLE
fix(audit-logs): adds missing 'auditLogs.prometheus*' values to pluginDefinitions, values

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -78,7 +78,14 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.openSearchLogs.failover_username_a | string | `nil` | Username for OpenSearch endpoint |
 | auditLogs.openSearchLogs.failover_username_b | string | `nil` | Second Username (as a failover) for OpenSearch endpoint |
 | auditLogs.openSearchLogs.index | string | `nil` | Name for OpenSearch index |
+| auditLogs.prometheus.additionalLabels | object | `{}` | Label selectors for the Prometheus resources to be picked up by prometheus-operator. |
 | auditLogs.prometheus.podMonitor | object | `{"enabled":false}` | Activates the service-monitoring for the Logs Collector. |
+| auditLogs.prometheus.rules | object | `{"additionalRuleLabels":null,"annotations":{},"create":true,"disabled":[],"labels":{}}` | Default rules for monitoring the opentelemetry components. |
+| auditLogs.prometheus.rules.additionalRuleLabels | string | `nil` | Additional labels for PrometheusRule alerts. |
+| auditLogs.prometheus.rules.annotations | object | `{}` | Annotations for PrometheusRules. |
+| auditLogs.prometheus.rules.create | bool | `true` | Enables PrometheusRule resources to be created. |
+| auditLogs.prometheus.rules.disabled | list | `[]` | PrometheusRules to disable. |
+| auditLogs.prometheus.rules.labels | object | `{}` | Labels for PrometheusRules. |
 | auditLogs.prometheus.serviceMonitor | object | `{"enabled":false}` | Activates the pod-monitoring for the Logs Collector. |
 | auditLogs.region | string | `nil` | Region label for Logging |
 | commonLabels | string | `nil` | Common labels to apply to all resources |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.0.1
+version: 0.0.2
 appVersion: "v0.121.0"
 maintainers:
 - name: olandr

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -36,6 +36,31 @@ auditLogs:
     serviceMonitor:
       enabled: false
 
+    # -- Label selectors for the Prometheus resources to be picked up by prometheus-operator.
+    additionalLabels: {}
+    # plugin: kube-monitoring
+    # prometheus: infra
+
+    # -- Default rules for monitoring the opentelemetry components.
+    rules:
+      # -- Enables PrometheusRule resources to be created.
+      create: true
+
+      # -- PrometheusRules to disable.
+      disabled: []
+
+      # -- Labels for PrometheusRules.
+      labels: {}
+
+      # -- Annotations for PrometheusRules.
+      annotations: {}
+
+      ## This is useful for adding additional labels such as "support_group" or "service" for the routing of alerts to each rule
+      # -- Additional labels for PrometheusRule alerts.
+      additionalRuleLabels:
+        # support_group: support
+        # service: my-service
+
   collectorImage:
     # -- overrides the default image repository for the OpenTelemetry Collector image.
     repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.0.1
+    version: 0.0.2
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.0.1
+        version: 0.0.2
     options:
         - name: auditLogs.region
           description: Region label for logging
@@ -62,6 +62,18 @@ spec:
           description: auditLogs.prometheus.serviceMonitor.enabled
           required: false
           type: bool
+        - name: auditLogs.prometheus.rules.create
+          description: auditLogs.prometheus.rules.create
+          required: false
+          type: bool
+        - name: auditLogs.prometheus.additionalLabels
+          description: Label selector for Prometheus resources to be picked-up by the operator
+          required: false
+          type: map
+        - name: auditLogs.prometheus.rules.additionalRuleLabels
+          description: Additional labels for PrometheusRule alerts
+          required: false
+          type: map
         - name: auditLogs.collectorImage.repository
           default: ghcr.io/cloudoperators/opentelemetry-collector-contrib
           description: Collector image repository


### PR DESCRIPTION
This resolves an error where there were missing 'pluginDefinition' fields and 'values.yaml' for e.g. '.Values.auditLogs.prometheus.additionalLabels'.

---------

Signed off by: Simon Olander (simon.olander@sap.com)