### PR TITLE
fix(actions): ensure current year for new spdx refs

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -2,8 +2,11 @@ header:
   license:
     spdx-id: Apache-2.0
     content: |
-      SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+      SPDX-FileCopyrightText: [year] SAP SE or an SAP affiliate company and Greenhouse contributors
       SPDX-License-Identifier: Apache-2.0
+    pattern: |
+      SPDX-FileCopyrightText: [0-9]+ SAP SE or an SAP affiliate company and Greenhouse contributors
+      SPDX-License-Identifier: Apache-2\.0
 
   paths: # `paths` are the path list that will be checked (and fixed) by license-eye, default is ['**'].
     - '**'


### PR DESCRIPTION
This ensures the license headers added to new files have the current year set. 
