### PR TITLE
fix(kube-monitoring) pin integration-test version

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 2.1.0
+version: 2.1.1
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -490,7 +490,7 @@ testFramework:
   image:
     registry: ghcr.io
     repository: cloudoperators/greenhouse-extensions-integration-test
-    tag: main
+    tag: v0.0.1
   imagePullPolicy: IfNotPresent
 
 # @ignored

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 3.4.0
+  version: 3.4.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 2.1.0
+    version: 2.1.1
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
latest patches to `kubectl` CLI in integration-test image are throwing some errors
```
not ok 4 Verify creation of required custom resource definitions (CRDs) for gno-prometheus-operator
        # (from function `verify' in file /usr/lib/bats/bats-detik/detik.bash, line 193,
        #  in test file /tests/run.sh, line 22)
        #   `verify "there is 1 customresourcedefinition named 'prometheuses'"' failed with status 3
        # Valid expression. Verification in progress...
        # /usr/local/bin/kubectl: line 1: syntax error near unexpected token `<'
        # /usr/local/bin/kubectl: line 1: `<?xml version='1.0' encoding='UTF-8'?><Error><Code>NoSuchKey</Code><Message>The specified key does not exist.</Message><Details>No such object: kubernetes-release/release/v1.30.13/bin/linux/amd64/kubectl</Details></Error>'
        # Found 0 cus
```