### PR TITLE
feat(opensearch): allow configuring HTTP DNS names via plugin

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -60,13 +60,14 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| certManager | object | `{"defaults":{"durations":{"ca":"8760h","leaf":"4800h"},"privateKey":{"algorithm":"RSA","encoding":"PKCS8","size":2048},"usages":["digital signature","key encipherment","server auth","client auth"]},"enable":true,"httpDnsNames":["opensearch-client.tld"],"issuer":{"ca":{"name":"opensearch-ca-issuer"},"digicert":{"group":"certmanager.cloud.sap","kind":"DigicertIssuer","name":"digicert-issuer"},"selfSigned":{"name":"opensearch-issuer"}}}` | Enable cert-manager integration for issuing TLS certificates |
 | certManager.defaults.durations.ca | string | `"8760h"` | Validity period for CA certificates (1 year) |
 | certManager.defaults.durations.leaf | string | `"4800h"` | Validity period for leaf certificates (200 days to comply with CA/B Forum baseline requirements) |
 | certManager.defaults.privateKey.algorithm | string | `"RSA"` | Algorithm used for generating private keys |
 | certManager.defaults.privateKey.encoding | string | `"PKCS8"` | Encoding format for private keys (PKCS8 recommended) |
 | certManager.defaults.privateKey.size | int | `2048` | Key size in bits for RSA keys |
 | certManager.defaults.usages | list | `["digital signature","key encipherment","server auth","client auth"]` | List of extended key usages for certificates |
+| certManager.enable | bool | `true` | Enable cert-manager integration for issuing TLS certificates |
+| certManager.httpDnsNames | list | `["opensearch-client.tld"]` | Override HTTP DNS names for OpenSearch client endpoints |
 | certManager.issuer.ca | object | `{"name":"opensearch-ca-issuer"}` | Name of the CA Issuer to be used for internal certs |
 | certManager.issuer.digicert | object | `{"group":"certmanager.cloud.sap","kind":"DigicertIssuer","name":"digicert-issuer"}` | API group for the DigicertIssuer custom resource |
 | certManager.issuer.selfSigned | object | `{"name":"opensearch-issuer"}` | Name of the self-signed issuer used to sign the internal CA certificate |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -60,6 +60,16 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| certManager | object | `{"defaults":{"durations":{"ca":"8760h","leaf":"4800h"},"privateKey":{"algorithm":"RSA","encoding":"PKCS8","size":2048},"usages":["digital signature","key encipherment","server auth","client auth"]},"enable":true,"httpDnsNames":["opensearch-client.tld"],"issuer":{"ca":{"name":"opensearch-ca-issuer"},"digicert":{"group":"certmanager.cloud.sap","kind":"DigicertIssuer","name":"digicert-issuer"},"selfSigned":{"name":"opensearch-issuer"}}}` | Enable cert-manager integration for issuing TLS certificates |
+| certManager.defaults.durations.ca | string | `"8760h"` | Validity period for CA certificates (1 year) |
+| certManager.defaults.durations.leaf | string | `"4800h"` | Validity period for leaf certificates (200 days to comply with CA/B Forum baseline requirements) |
+| certManager.defaults.privateKey.algorithm | string | `"RSA"` | Algorithm used for generating private keys |
+| certManager.defaults.privateKey.encoding | string | `"PKCS8"` | Encoding format for private keys (PKCS8 recommended) |
+| certManager.defaults.privateKey.size | int | `2048` | Key size in bits for RSA keys |
+| certManager.defaults.usages | list | `["digital signature","key encipherment","server auth","client auth"]` | List of extended key usages for certificates |
+| certManager.issuer.ca | object | `{"name":"opensearch-ca-issuer"}` | Name of the CA Issuer to be used for internal certs |
+| certManager.issuer.digicert | object | `{"group":"certmanager.cloud.sap","kind":"DigicertIssuer","name":"digicert-issuer"}` | API group for the DigicertIssuer custom resource |
+| certManager.issuer.selfSigned | object | `{"name":"opensearch-issuer"}` | Name of the self-signed issuer used to sign the internal CA certificate |
 | cluster.actionGroups | list | `[]` | List of OpensearchActionGroup. Check values.yaml file for examples. |
 | cluster.cluster.annotations | object | `{}` | OpenSearchCluster annotations |
 | cluster.cluster.bootstrap.additionalConfig | object | `{}` | bootstrap additional configuration, key-value pairs that will be added to the opensearch.yml configuration |
@@ -158,11 +168,6 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
 | cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"password":"","secretKey":"password","secretName":"logs-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
 | cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
-| global.certManager.enable | bool | `true` |  |
-| global.certManager.issuerRef.group | string | `"certmanager.cloud.sap"` |  |
-| global.certManager.issuerRef.kind | string | `"DigicertIssuer"` |  |
-| global.certManager.issuerRef.name | string | `"digicert-issuer"` |  |
-| global.greenhouse.baseDomain | string | `nil` |  |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |
 | operator.kubeRbacProxy.enable | bool | `true` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.11
+version: 0.0.12
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -1,22 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.global.certManager.enable }}
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: opensearch-issuer
-spec:
-  selfSigned: {}
----
-apiVersion: cert-manager.io/v1
-kind: Issuer
-metadata:
-  name: opensearch-ca-issuer
-spec:
-  ca:
-    secretName: opensearch-ca-cert
----
+{{- if .Values.certManager.enable }}
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -24,15 +9,12 @@ metadata:
 spec:
   isCA: true
   commonName: opensearch-ca
-  secretName: opensearch-ca-cert
-  duration: 8760h
-  privateKey:
-    algorithm: RSA
-    size: 2048
+  duration: {{ .Values.certManager.defaults.durations.ca }}
   issuerRef:
-    name: opensearch-issuer
-    kind: Issuer
-    group: cert-manager.io
+{{ toYaml .Values.certManager.issuer.selfSigned | indent 4 }}
+  privateKey:
+{{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
+  secretName: opensearch-ca-cert
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -40,25 +22,20 @@ metadata:
   name: opensearch-transport-cert
 spec:
   commonName: opensearch-transport
-  duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
-  dnsNames:
-  - opensearch
-  - opensearch-discovery
-  - opensearch.{{ .Release.Namespace }}
-  - opensearch.{{ .Release.Namespace }}.svc
-  - opensearch.{{ .Release.Namespace }}.svc.cluster.local
+  duration: {{ .Values.certManager.defaults.durations.leaf }}
   issuerRef:
-    name: opensearch-ca-issuer
+{{ toYaml .Values.certManager.issuer.ca | indent 4 }}
   privateKey:
-    algorithm: RSA
-    encoding: PKCS8
-    size: 2048
+{{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-transport-cert
+  dnsNames:
+    - opensearch
+    - opensearch-discovery
+    - {{ printf "opensearch.%s" .Release.Namespace }}
+    - {{ printf "opensearch.%s.svc" .Release.Namespace }}
+    - {{ printf "opensearch.%s.svc.cluster.local" .Release.Namespace }}
   usages:
-    - digital signature
-    - key encipherment
-    - server auth
-    - client auth
+{{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -66,39 +43,28 @@ metadata:
   name: opensearch-admin-cert
 spec:
   commonName: admin
-  duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
+  duration: {{ .Values.certManager.defaults.durations.leaf }}
   issuerRef:
-    name: opensearch-ca-issuer
+{{ toYaml .Values.certManager.issuer.ca | indent 4 }}
   privateKey:
-    algorithm: RSA
-    encoding: PKCS8
-    size: 2048
+{{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-admin-cert
   usages:
-    - digital signature
-    - key encipherment
-    - client auth
-    - server auth
+{{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-http-cert
 spec:
-  commonName: opensearch-http
-  duration: 4800h # 200 days to comply with the upcoming CA/B Forum requirements
-  dnsNames:
-    - {{ printf "*.%s" .Values.global.greenhouse.baseDomain | quote }}
+  duration: {{ .Values.certManager.defaults.durations.leaf }}
   issuerRef:
-  {{- toYaml .Values.global.certManager.issuerRef | nindent 4 }}
+{{ toYaml .Values.certManager.issuer.digicert | indent 4 }}
   privateKey:
-    algorithm: RSA
-    encoding: PKCS8
-    size: 2048
+{{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-http-cert
+  dnsNames:
+{{ toYaml .Values.certManager.httpDnsNames | indent 4 }}
   usages:
-    - digital signature
-    - key encipherment
-    - server auth
-    - client auth
+{{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 {{- end }}

--- a/opensearch/chart/templates/issuer.yaml
+++ b/opensearch/chart/templates/issuer.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.certManager.enable }}
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.certManager.issuer.selfSigned.name }}
+spec:
+  selfSigned: {}
+---
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: {{ .Values.certManager.issuer.ca.name }}
+spec:
+  ca:
+    secretName: opensearch-ca-cert
+{{- end }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -1,18 +1,50 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-global:
-  ## common greenhouse values to use
-  ##
-  greenhouse:
-    # base domain of the greenhouse organisation
-    baseDomain:
-  certManager:
-    enable: true
-    issuerRef:
+# -- Enable cert-manager integration for issuing TLS certificates
+certManager:
+  enable: true
+
+  issuer:
+    # -- API group for the DigicertIssuer custom resource
+    digicert:
       group: certmanager.cloud.sap
       kind: DigicertIssuer
       name: digicert-issuer
+
+    # -- Name of the CA Issuer to be used for internal certs
+    ca:
+      name: opensearch-ca-issuer
+
+    # -- Name of the self-signed issuer used to sign the internal CA certificate
+    selfSigned:
+      name: opensearch-issuer
+
+  defaults:
+    privateKey:
+      # -- Algorithm used for generating private keys
+      algorithm: RSA
+      # -- Encoding format for private keys (PKCS8 recommended)
+      encoding: PKCS8
+      # -- Key size in bits for RSA keys
+      size: 2048
+
+    durations:
+      # -- Validity period for CA certificates (1 year)
+      ca: 8760h
+      # -- Validity period for leaf certificates (200 days to comply with CA/B Forum baseline requirements)
+      leaf: 4800h
+
+    # -- List of extended key usages for certificates
+    usages:
+      - digital signature
+      - key encipherment
+      - server auth
+      - client auth
+
+# -- Override HTTP DNS names for OpenSearch client endpoints
+  httpDnsNames:
+    - opensearch-client.tld
 
 operator:
   namespace: ""

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -1,8 +1,8 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-# -- Enable cert-manager integration for issuing TLS certificates
 certManager:
+  # -- Enable cert-manager integration for issuing TLS certificates
   enable: true
 
   issuer:
@@ -42,7 +42,7 @@ certManager:
       - server auth
       - client auth
 
-# -- Override HTTP DNS names for OpenSearch client endpoints
+  # -- Override HTTP DNS names for OpenSearch client endpoints
   httpDnsNames:
     - opensearch-client.tld
 

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.11
+  version: 0.0.12
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.11
+    version: 0.0.12
   options:
     - name: operator.fullnameOverride
       description: "Specifies a custom name for the OpenSearch operator. Use this to override the default naming convention for operator-managed resources."

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -35,4 +35,4 @@ spec:
     - name: certManager.httpDnsNames
       description: "DNS names for the HTTP certificate and service annotations on client nodes receiving logs via LoadBalancer."
       required: true
-      type: map
+      type: list

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -32,3 +32,7 @@ spec:
       description: "Specifies custom labels for the ServiceMonitor to expose OpenSearch metrics to Prometheus."
       required: false
       type: map
+    - name: certManager.httpDnsNames
+      description: "DNS names for the HTTP certificate and service annotations on client nodes receiving logs via LoadBalancer."
+      required: true
+      type: map


### PR DESCRIPTION
## Pull Request Details

This PR includes the following changes:

- Refactored certificate Helm charts: moved more configuration into `values.yaml`
- Split issuer and certificate definitions into separate files
- Made the HTTP DNS name configurable via the plugin interface