### PR TITLE
feat(kubeconfig-generator): Exclude clusters without public version ep

### DIFF
--- a/kubeconfig-generator/chart/Chart.yaml
+++ b/kubeconfig-generator/chart/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
 type: application
 name: kubeconfig-generator
-version: 0.1.14
-appVersion: "97ce7e3908695171b780b33e1e4d09653b72474b"
+version: 0.1.15
+appVersion: "e9a2d6f4cbd4e5358ab01462d3dc82cba355a672"
 keywords:
 - operator
 - kubeconfig

--- a/kubeconfig-generator/plugindefinition.yaml
+++ b/kubeconfig-generator/plugindefinition.yaml
@@ -7,11 +7,11 @@ metadata:
   name: kubeconfig-generator
 spec:
   description: Automated kubeconfig generator for kubectl-sync/kubectl-logon/u8s
-  version: 0.1.14
+  version: 0.1.15
   helmChart:
     name: kubeconfig-generator
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.14
+    version: 0.1.15
   options:
     - name: swift.authUrl
       description: Keystone endpoint to be used for authentication


### PR DESCRIPTION
This fixes a known issue with kubeconfig-generator
---


## Issues Fixed

Clusters that do not have a public `/version` endpoint will not be uploaded to the registry anymore.


