### PR TITLE
feat(opensearch): add configurable user credentials

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -174,7 +174,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.serviceAccount.name | string | `""` | Service Account name. Set `general.serviceAccount` to use this Service Account for the Opensearch cluster |
 | cluster.tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
 | cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"secretKey":"password","secretName":"logs-credentials"},{"backendRoles":[],"name":"logs2","opendistroSecurityRoles":["logs-role"],"secretKey":"password","secretName":"logs2-credentials"}]` | List of OpenSearch user configurations. Each user references a secret (defined in usersCredentials) for authentication. |
-| cluster.usersCredentials | object | `{"logs":{"password":"","username":""},"logs2":{"password":"","username":""}}` | List of OpenSearch user passwords. These passwords are used to authenticate users with OpenSearch. |
+| cluster.usersCredentials | object | `{"logs":{"password":"","username":""},"logs2":{"password":"","username":""}}` | List of OpenSearch user credentials. These credentials are used for authenticating users with OpenSearch. |
 | cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -173,7 +173,8 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.serviceAccount.create | bool | `false` | Create Service Account |
 | cluster.serviceAccount.name | string | `""` | Service Account name. Set `general.serviceAccount` to use this Service Account for the Opensearch cluster |
 | cluster.tenants | list | `[]` | List of additional tenants. Check values.yaml file for examples. |
-| cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"password":"","secretKey":"password","secretName":"logs-credentials"}]` | List of OpensearchUser. Check values.yaml file for examples. |
+| cluster.users | list | `[{"backendRoles":[],"name":"logs","opendistroSecurityRoles":["logs-role"],"secretKey":"password","secretName":"logs-credentials"},{"backendRoles":[],"name":"logs2","opendistroSecurityRoles":["logs-role"],"secretKey":"password","secretName":"logs2-credentials"}]` | List of OpenSearch user configurations. Each user references a secret (defined in usersCredentials) for authentication. |
+| cluster.usersCredentials | object | `{"logs":{"password":"","username":""},"logs2":{"password":"","username":""}}` | List of OpenSearch user passwords. These passwords are used to authenticate users with OpenSearch. |
 | cluster.usersRoleBinding | list | `[{"name":"logs-access","roles":["logs-role"],"users":["logs"]}]` | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role Check values.yaml file for examples. |
 | operator.fullnameOverride | string | `"opensearch-operator"` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.14
+version: 0.0.15
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/ci/test-values.yaml
+++ b/opensearch/chart/ci/test-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+cluster:
+  usersCredentials:
+    logs:
+      password: "CHANGE_ME_LogsUser2025!@#"
+    logs2:
+      password: "CHANGE_ME_FailoverUser2025$%"

--- a/opensearch/chart/templates/users-secret.yaml
+++ b/opensearch/chart/templates/users-secret.yaml
@@ -2,15 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- $labels := include "opensearch-cluster-local.labels" . }}
-{{- range .Values.cluster.users }}
+{{- range $username, $credentials := .Values.cluster.usersCredentials }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .name }}-credentials
+  name: {{ $username }}-credentials
   labels: {{ $labels | nindent 4 }}
 type: Opaque
 data:
-  username: {{ .name | b64enc }}
-  password: {{ default (printf "%s%s" (randAlphaNum 15) (index (list "!" "@" "#" "$" "%" "^" "&" "*") (randInt 0 8))) .password | b64enc }}
+  username: {{ default $username $credentials.username | b64enc }}
+  password: {{ $credentials.password | b64enc }}
 {{- end }}

--- a/opensearch/chart/templates/users-secret.yaml
+++ b/opensearch/chart/templates/users-secret.yaml
@@ -2,6 +2,11 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- $labels := include "opensearch-cluster-local.labels" . }}
+{{/*
+WARNING: defaultPasswords are dummy passwords for development only!
+MUST be overridden for production environments!
+*/}}
+{{- $defaultPasswords := dict "logs" "DUMMY-LogsUser2025!@#" "logs2" "DUMMY-FailoverUser2025$%^" }}
 {{- range $username, $credentials := .Values.cluster.usersCredentials }}
 ---
 apiVersion: v1
@@ -12,5 +17,5 @@ metadata:
 type: Opaque
 data:
   username: {{ default $username $credentials.username | b64enc }}
-  password: {{ default $username $credentials.password | b64enc }}
+  password: {{ default (index $defaultPasswords $username) $credentials.password | b64enc }}
 {{- end }}

--- a/opensearch/chart/templates/users-secret.yaml
+++ b/opensearch/chart/templates/users-secret.yaml
@@ -12,5 +12,5 @@ metadata:
 type: Opaque
 data:
   username: {{ default $username $credentials.username | b64enc }}
-  password: {{ $credentials.password | b64enc }}
+  password: {{ default $username $credentials.password | b64enc }}
 {{- end }}

--- a/opensearch/chart/templates/users-secret.yaml
+++ b/opensearch/chart/templates/users-secret.yaml
@@ -2,20 +2,15 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- $labels := include "opensearch-cluster-local.labels" . }}
-{{/*
-WARNING: defaultPasswords are dummy passwords for development only!
-MUST be overridden for production environments!
-*/}}
-{{- $defaultPasswords := dict "logs" "DUMMY-LogsUser2025!@#" "logs2" "DUMMY-FailoverUser2025$%^" }}
-{{- range $username, $credentials := .Values.cluster.usersCredentials }}
+{{- range $userKey, $userData := .Values.cluster.usersCredentials }}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ $username }}-credentials
+  name: {{ $userKey }}-credentials
   labels: {{ $labels | nindent 4 }}
 type: Opaque
 data:
-  username: {{ default $username $credentials.username | b64enc }}
-  password: {{ default (index $defaultPasswords $username) $credentials.password | b64enc }}
+  username: {{ default $userKey $userData.username | b64enc }}
+  password: {{ $userData.password | b64enc }}
 {{- end }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -634,10 +634,10 @@ cluster:
   usersCredentials:
     logs:
       username: "" # Username (empty = defaults to key name "logs")
-      password: "" # Password (required - must be set in values or external override)
+      password: "" # Password (empty = uses DUMMY-LogsUser2025!@# - override for production)
     logs2:
       username: "" # Username (empty = defaults to key name "logs2")
-      password: "" # Password (required - must be set in values or external override)
+      password: "" # Password (empty = uses DUMMY-FailoverUser2025$%^ - override for production)
 
   #  - name: "admin"
   #    password: "admin" # If not set, a random password will be generated

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -630,14 +630,14 @@ cluster:
       opendistroSecurityRoles:
         - "logs-role"
 
-  # -- List of OpenSearch user passwords. These passwords are used to authenticate users with OpenSearch.
+  # -- List of OpenSearch user credentials. These credentials are used for authenticating users with OpenSearch.
   usersCredentials:
     logs:
-      username: ""  # Username (empty = defaults to key name "logs")
-      password: ""  # Password (empty = uses DUMMY-LogsUser2025!@# - override for production)
+      username: ""  # Specify the username for the "logs" user. If left empty, defaults to "logs".
+      password: ""  # Replace password with a secure value before deploying to production. A dummy password is set in ci/test-values.yaml for testing purposes.
     logs2:
-      username: ""  # Username (empty = defaults to key name "logs2")
-      password: ""  # Password (empty = uses DUMMY-FailoverUser2025$%^ - override for production)
+      username: ""  # Specify the username for the failover user for "logs". If left empty, defaults to "logs2".
+      password: ""  # Replace password with a secure value before deploying to production. A dummy password is set in ci/test-values.yaml for testing purposes.
 
   #  - name: "admin"
   #    password: "admin" # If not set, a random password will be generated

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -633,11 +633,11 @@ cluster:
   # -- List of OpenSearch user passwords. These passwords are used to authenticate users with OpenSearch.
   usersCredentials:
     logs:
-      username: "" # Username (empty = defaults to key name "logs")
-      password: "" # Password (empty = uses DUMMY-LogsUser2025!@# - override for production)
+      username: ""  # Username (empty = defaults to key name "logs")
+      password: ""  # Password (empty = uses DUMMY-LogsUser2025!@# - override for production)
     logs2:
-      username: "" # Username (empty = defaults to key name "logs2")
-      password: "" # Password (empty = uses DUMMY-FailoverUser2025$%^ - override for production)
+      username: ""  # Username (empty = defaults to key name "logs2")
+      password: ""  # Password (empty = uses DUMMY-FailoverUser2025$%^ - override for production)
 
   #  - name: "admin"
   #    password: "admin" # If not set, a random password will be generated

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -614,15 +614,31 @@ cluster:
   #        allowedActions:
   #          - "*"
 
-  # -- List of OpensearchUser. Check values.yaml file for examples.
+  # -- List of OpenSearch user configurations.
+  # Each user references a secret (defined in usersCredentials) for authentication.
   users:
     - name: "logs"
-      password: ""  # If not set, a random password will be generated
       secretName: "logs-credentials"
       secretKey: "password"
       backendRoles: []
       opendistroSecurityRoles:
         - "logs-role"
+    - name: "logs2"
+      secretName: "logs2-credentials"
+      secretKey: "password"
+      backendRoles: []
+      opendistroSecurityRoles:
+        - "logs-role"
+
+  # -- List of OpenSearch user passwords. These passwords are used to authenticate users with OpenSearch.
+  usersCredentials:
+    logs:
+      username: "" # Username (empty = defaults to key name "logs")
+      password: "" # Password (required - must be set in values or external override)
+    logs2:
+      username: "" # Username (empty = defaults to key name "logs2")
+      password: "" # Password (required - must be set in values or external override)
+
   #  - name: "admin"
   #    password: "admin" # If not set, a random password will be generated
   #    secretName: "admin-credentials"

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.14
+  version: 0.0.15
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.14
+    version: 0.0.15
   options:
     - name: operator.fullnameOverride
       description: "Specifies a custom name for the OpenSearch operator. Use this to override the default naming convention for operator-managed resources."
@@ -52,3 +52,19 @@ spec:
       description: "DNS names for the HTTP certificate and service annotations on client nodes receiving logs via LoadBalancer."
       required: true
       type: list
+    - name: cluster.usersCredentials.logs.username
+      description: "Primary OpenSearch user username"
+      required: true
+      type: secret
+    - name: cluster.usersCredentials.logs.password
+      description: "Primary OpenSearch user password"
+      required: true
+      type: secret
+    - name: cluster.usersCredentials.logs2.username
+      description: "Secondary OpenSearch user username for failover authentication"
+      required: true
+      type: secret
+    - name: cluster.usersCredentials.logs2.password
+      description: "Secondary OpenSearch user password for failover authentication"
+      required: true
+      type: secret


### PR DESCRIPTION
## Pull Request Details

This PR improves the OpenSearch cluster configuration by adding support for configurable user credentials with failover capabilities.

- Configurable user credentials: New `usersCredentials` section in values.yaml allowing override of usernames and passwords for OpenSearch users from Plugin
- Restructured user configuration to separate credentials from user role definitions
- Failover user support: Secondary user (`logs2`) configuration for redundancy