### PR TITLE
fix(thanos): corrected selector and default datasource

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 2.1.2
+version: 2.1.3
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/templates/configmap-perses-datasource.yaml
+++ b/kube-monitoring/charts/templates/configmap-perses-datasource.yaml
@@ -14,7 +14,7 @@ data:
         "name": "{{ printf "%s-%s" $.Release.Name "prometheus" }}",
       },
       "spec": {
-        "default": true,
+        "default": false,
         "plugin": {
           "kind": "PrometheusDatasource",
           "spec": {

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 3.4.2
+  version: 3.4.3
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 2.1.2
+    version: 2.1.3
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -348,7 +348,7 @@ spec:
 | thanos.query.ingress.tls | list | `[]` | Ingress TLS configuration |
 | thanos.query.logLevel | string | info | Thanos Query log level |
 | thanos.query.persesDatasource.create | bool | `true` | Creates a Perses datasource for Thanos Query |
-| thanos.query.persesDatasource.selector | object | `{}` | Label selectors for the Perses sidecar to detect this datasource. |
+| thanos.query.persesDatasource.selector | object | `{"perses.dev/resource":"\"true\""}` | Label selectors for the Perses sidecar to detect this datasource. |
 | thanos.query.plutonoDatasource.create | bool | `false` | Creates a Perses datasource for standalone Thanos Query |
 | thanos.query.plutonoDatasource.selector | object | `{}` | Label selectors for the Plutono sidecar to detect this datasource. |
 | thanos.query.replicaLabel | string | `nil` |  |

--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.5.23
+version: 0.5.24
 keywords:
   - thanos
   - storage

--- a/thanos/charts/templates/perses-datasource.yaml
+++ b/thanos/charts/templates/perses-datasource.yaml
@@ -17,7 +17,7 @@ data:
         "name": "{{ printf "%s-%s" $.Release.Name "query" }}",
       },
       "spec": {
-        "default": false,
+        "default": true,
         "plugin": {
           "kind": "PrometheusDatasource",
           "spec": {

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -179,7 +179,8 @@ thanos:
       create: true
 
       # -- Label selectors for the Perses sidecar to detect this datasource.
-      selector: {}
+      selector:
+        perses.dev/resource: '"true"'
         # perses-global: '"true"'
 
   store:

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
     name: thanos
 spec:
-    version: 0.5.25
+    version: 0.5.26
     description: thanos
     helmChart:
         name: thanos
         repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-        version: 0.5.23
+        version: 0.5.24
     options:
         - default: null
           description: CLI param for Thanos Query
@@ -95,9 +95,7 @@ spec:
           name: thanos.query.persesDatasource.create
           required: false
           type: bool
-        - default:
-            perses.dev/resource: true
-          description: Label selectors for the Perses sidecar to detect this datasource
+        - description: Label selectors for the Perses sidecar to detect this datasource
           name: thanos.query.persesDatasource.selector
           required: false
           type: map


### PR DESCRIPTION
default datasource is now set to thanos. if thanos is not deployed, it will fall back to prometheus, albeit not being default.
