### PR TITLE
git action helm test trigger on push to main

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -2,6 +2,9 @@ name: "Helm lint and tests"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
to avoid having ready to merge PRs that may have conflicting plugindefinition version with main branch we can re-trigger this git action on all open PRs