### PR TITLE
fix(renovate) group helm update by plugin

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -206,8 +206,12 @@
       "minimumReleaseAge": "7 days",
       "additionalBranchPrefix": "{{parentDir}}-",
       "bumpVersion": "patch",
+      "groupName": "{{{packageFile}}} helm chart updates",
       "postUpdateOptions": [
         "helmUpdateSubChartArchives"
+      ],
+      "ignorePaths": [
+        "**/cert-manager/charts/**"
       ]
     },
     {
@@ -220,8 +224,12 @@
       "minimumReleaseAge": "14 days",
       "additionalBranchPrefix": "{{parentDir}}-",
       "bumpVersion": "minor",
+      "groupName": "{{{packageFile}}} helm chart updates",
       "postUpdateOptions": [
         "helmUpdateSubChartArchives"
+      ],
+      "ignorePaths": [
+        "**/cert-manager/charts/**"
       ]
     },
     {
@@ -234,8 +242,12 @@
       "minimumReleaseAge": "14 days",
       "additionalBranchPrefix": "{{parentDir}}-",
       "bumpVersion": "major",
+      "groupName": "{{{packageFile}}} helm chart updates",
       "postUpdateOptions": [
         "helmUpdateSubChartArchives"
+      ],
+      "ignorePaths": [
+        "**/cert-manager/charts/**"
       ]
     },
     {
@@ -244,14 +256,6 @@
         "npm"
       ],
       "minimumReleaseAge": "14 days"
-    },
-    {
-      "matchManagers": [
-        "helmv3"
-      ],
-      "ignorePaths": [
-        "**/cert-manager/charts/**"
-      ]
     },
     {
       "matchDatasources": [


### PR DESCRIPTION
trying to avoid this, helm-lint-test or plugindefinitionbump git actions don't support renovate PRs updating charts in multiple plugins

<img width="709" alt="Screenshot 2025-06-11 at 4 49 31 PM" src="https://github.com/user-attachments/assets/07f0b484-e38c-4ef1-94b3-785626039e91" />
