### PR TITLE
fix(git-actions) sync-plugindef support chart/charts folder structure

### DIFF
--- a/.github/workflows/sync-plugindefinition.yaml
+++ b/.github/workflows/sync-plugindefinition.yaml
@@ -20,7 +20,7 @@ jobs:
         id: chartdiff
         run: |
           git fetch origin ${{ github.base_ref }}
-          files=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep 'charts/Chart.yaml$' || true)
+          files=$(git diff --name-only origin/${{ github.base_ref }} HEAD | grep -E 'charts?/Chart.yaml$' || true)
           echo $files
           echo "files<<EOF"$'\n'"$files"$'\n'"EOF" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
https://github.com/cloudoperators/greenhouse-extensions/pull/963

git-action can not find Chart.yaml since it is located in chart instead of charts