### PR TITLE
fix(alerts): set auth-tls-verify-client = on

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 2.0.0
+version: 2.0.1
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/charts/values.yaml
+++ b/alerts/charts/values.yaml
@@ -215,7 +215,7 @@ alerts:
         disco: "true"
         kubernetes.io/tls-acme: "true"
         nginx.ingress.kubernetes.io/auth-tls-secret: "{{ $.Release.Namespace }}/{{ $.Release.Namespace }}-ca-bundle"
-        nginx.ingress.kubernetes.io/auth-tls-verify-client: "true"
+        nginx.ingress.kubernetes.io/auth-tls-verify-client: "on"
         nginx.ingress.kubernetes.io/auth-tls-verify-depth: "3"
         nginx.ingress.kubernetes.io/cors-allow-headers: Content-Type
         nginx.ingress.kubernetes.io/cors-allow-methods: DELETE

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 3.0.0
+  version: 3.0.1
   weight: 0
   displayName: Alerts
   description: The Alerts Plugin consists of both Prometheus Alertmanager and Supernova, the holistic alert management UI
@@ -16,7 +16,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/alerts
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 2.0.0
+    version: 2.0.1
   uiApplication:
     name: supernova
     version: "latest"


### PR DESCRIPTION
"true" is not accepted by the ingress-nginx controller. according to https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/annotations/#client-certificate-authentication

# Submit a pull request

Thank you for submitting a pull request!  
To speed up the review process, please ensure that everything below
is true:

1. This is not a duplicate of an existing Plugin.
2. No existing features have been broken without good reason.
3. The Documentation has been updated to reflect your changes.
4. Tests have been added or updated to reflect your changes.
5. All tests pass.

---

Replace any ":question:" below with information about your pull request.

## Pull Request Details

Provide details about your pull request and what it adds, fixes, or changes.

:question:

## Breaking Changes

Describe what features are broken by this pull request and why, if any.

:question:

## Issues Fixed

Enter the issue numbers resolved by this pull request below, if any.

1. :question:

## Other Relevant Information

Provide any other important details below.

:question:
