### PR TITLE
fix(thanos) plugindef agnostic of sci

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.5.26
+version: 0.5.27
 keywords:
   - thanos
   - storage

--- a/thanos/charts/templates/servicemonitor.yaml
+++ b/thanos/charts/templates/servicemonitor.yaml
@@ -5,6 +5,8 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "release.name" . }}
   labels:
+    {{- include "plugin.labels" . | nindent 4 }}
+    {{- include "thanos.labels" . | nindent 4 }}
     {{- toYaml .Values.thanos.serviceMonitor.labels | nindent 4 }}
 
 spec:

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
     name: thanos
 spec:
-    version: 0.5.29
+    version: 0.5.30
     description: thanos
     helmChart:
         name: thanos
         repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-        version: 0.5.26
+        version: 0.5.27
     options:
         - default: null
           description: CLI param for Thanos Query
@@ -111,7 +111,7 @@ spec:
           name: thanos.compactor.enabled
           required: false
           type: bool
-        - default: true
+        - default: false
           description: Enable Thanos Ruler
           name: thanos.ruler.enabled
           required: false
@@ -153,8 +153,5 @@ spec:
           type: secret
         - name: thanos.serviceMonitor.alertLabels
           description: Labels to add to the PrometheusRules alerts
-          default: |
-            support_group: observability
-            service: metrics
           type: string
           required: false


### PR DESCRIPTION
alertLabels will be passed through pluginpreset

https://github.com/sapcc/helm-charts/pull/8901/files

disabling thanos ruler by default