### PR TITLE
fix(logs) add plugin label to logs alerts

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: v0.124.1
 name: logs-operator
-version: 0.9.2
+version: 0.9.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_helpers.tpl
+++ b/logs/charts/templates/_helpers.tpl
@@ -8,6 +8,7 @@ Generic plugin name
 {{/* Generate plugin specific labels */}}
 {{- define "plugin.labels" -}}
 plugindefinition: logs
+plugin: {{ $.Release.Name }}
 {{- if .Values.commonLabels }}
 {{ tpl (toYaml .Values.commonLabels) . }}
 {{- end }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: logs
 spec:
-    version: 0.9.2
+    version: 0.9.3
     displayName: Logs
     description: Observability framework for instrumenting, generating, collecting, and exporting logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
     helmChart:
         name: logs-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.9.2
+        version: 0.9.3
     options:
         - default: true
           description: Activates the standard configuration for logs


### PR DESCRIPTION
for proper integration with absent metrics operator we need a common label on PrometheusRule CR for the operator to select from

adding `plugin` label to align with other plugins

<img width="727" alt="Screenshot 2025-06-20 at 11 42 51 AM" src="https://github.com/user-attachments/assets/c25bb7ff-d415-468f-b90c-1884cf899d70" />
