### PR TITLE
fix(gh-actions) PR target sync helm lint test

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -2,6 +2,8 @@ name: "Helm lint and tests"
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  pull_request_target:
+    types: [synchronize]
   push:
     branches:
       - main


### PR DESCRIPTION
re-run helm test on PRs when changes are made to main to avoid merging same chart/plugindeifinition versions