### PR TITLE
chore(logs): fix naming for operator, update maintainers

### DIFF
--- a/.github/workflows/ci-pr-build.yaml
+++ b/.github/workflows/ci-pr-build.yaml
@@ -45,7 +45,7 @@ jobs:
           - chartDir: opensearch/chart
             chartName: opensearch
           - chartDir: logs/charts
-            chartName: logs-operator
+            chartName: opentelemetry-operator
           - chartDir: perses/charts
             chartName: perses
           - chartDir: plutono/charts

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -61,7 +61,7 @@ jobs:
           - chartDir: opensearch/chart
             chartName: opensearch
           - chartDir: logs/charts
-            chartName: logs-operator
+            chartName: opentelemetry-operator
           - chartDir: perses/charts
             chartName: perses
           - chartDir: plutono/charts

--- a/audit-logs/test-dependencies.yaml
+++ b/audit-logs/test-dependencies.yaml
@@ -2,7 +2,7 @@ dependencies:
   - logs
 
 values:
-  logs-operator:
+  opentelemetry-operator:
     crds:
       create: false
     admissionWebhooks:

--- a/logs/README.md
+++ b/logs/README.md
@@ -80,18 +80,6 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | commonLabels | object | `{}` | common labels to apply to all resources. |
-| opentelemetry-operator.admissionWebhooks.autoGenerateCert | object | `{"recreate":false}` | Activate to use Helm to create self-signed certificates. |
-| opentelemetry-operator.admissionWebhooks.autoGenerateCert.recreate | bool | `false` | Activate to recreate the cert after a defined period (certPeriodDays default is 365). |
-| opentelemetry-operator.admissionWebhooks.certManager | object | `{"enabled":false}` | Activate to use the CertManager for generating self-signed certificates. |
-| opentelemetry-operator.admissionWebhooks.failurePolicy | string | `"Ignore"` | Defines if the admission webhooks should `Ignore` errors or `Fail` on errors when communicating with the API server. |
-| opentelemetry-operator.crds.create | bool | `false` | The required CRDs used by this dependency are version-controlled in this repository under ./crds. If you want to use the upstream CRDs, set this variable to `true``. |
-| opentelemetry-operator.kubeRBACProxy | object | `{"enabled":false}` | the kubeRBACProxy can be enabled to allow the operator perform RBAC authorization against the Kubernetes API. |
-| opentelemetry-operator.manager.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | overrides the default image repository for the OpenTelemetry Collector image. |
-| opentelemetry-operator.manager.collectorImage.tag | string | `"5a4f148"` | overrides the default image tag for the OpenTelemetry Collector image. |
-| opentelemetry-operator.manager.image.repository | string | `"ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"` | overrides the default image repository for the OpenTelemetry Operator image. |
-| opentelemetry-operator.manager.image.tag | string | `"v0.127.0"` | overrides the default tag repository for the OpenTelemetry Operator image. |
-| opentelemetry-operator.manager.serviceMonitor | object | `{"enabled":true}` | Enable serviceMonitor for Prometheus metrics scrape |
-| opentelemetry-operator.nameOverride | string | `"operator"` | Provide a name in place of the default name `opentelemetry-operator`. |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
 | openTelemetry.customLabels | object | `{}` | custom Labels applied to servicemonitor, secrets and collectors |
 | openTelemetry.logsCollector.cephConfig | object | `{"enabled":false}` | Activates the configuration for Ceph logs (requires logsCollector to be enabled). |
@@ -115,6 +103,18 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.prometheus.rules.labels | object | `{}` | Labels for PrometheusRules. |
 | openTelemetry.prometheus.serviceMonitor | object | `{"enabled":true}` | Activates the service-monitoring for the Logs Collector. |
 | openTelemetry.region | string | `nil` | Region label for Logging |
+| opentelemetry-operator.admissionWebhooks.autoGenerateCert | object | `{"recreate":false}` | Activate to use Helm to create self-signed certificates. |
+| opentelemetry-operator.admissionWebhooks.autoGenerateCert.recreate | bool | `false` | Activate to recreate the cert after a defined period (certPeriodDays default is 365). |
+| opentelemetry-operator.admissionWebhooks.certManager | object | `{"enabled":false}` | Activate to use the CertManager for generating self-signed certificates. |
+| opentelemetry-operator.admissionWebhooks.failurePolicy | string | `"Ignore"` | Defines if the admission webhooks should `Ignore` errors or `Fail` on errors when communicating with the API server. |
+| opentelemetry-operator.crds.create | bool | `false` | The required CRDs used by this dependency are version-controlled in this repository under ./crds. If you want to use the upstream CRDs, set this variable to `true``. |
+| opentelemetry-operator.kubeRBACProxy | object | `{"enabled":false}` | the kubeRBACProxy can be enabled to allow the operator perform RBAC authorization against the Kubernetes API. |
+| opentelemetry-operator.manager.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | overrides the default image repository for the OpenTelemetry Collector image. |
+| opentelemetry-operator.manager.collectorImage.tag | string | `"5a4f148"` | overrides the default image tag for the OpenTelemetry Collector image. |
+| opentelemetry-operator.manager.image.repository | string | `"ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"` | overrides the default image repository for the OpenTelemetry Operator image. |
+| opentelemetry-operator.manager.image.tag | string | `"v0.127.0"` | overrides the default tag repository for the OpenTelemetry Operator image. |
+| opentelemetry-operator.manager.serviceMonitor | object | `{"enabled":true}` | Enable serviceMonitor for Prometheus metrics scrape |
+| opentelemetry-operator.nameOverride | string | `"operator"` | Provide a name in place of the default name `opentelemetry-operator`. |
 | testFramework.enabled | bool | `true` | Activates the Helm chart testing framework. |
 | testFramework.image.registry | string | `"ghcr.io"` | Defines the image registry for the test framework. |
 | testFramework.image.repository | string | `"cloudoperators/greenhouse-extensions-integration-test"` | Defines the image repository for the test framework. |

--- a/logs/README.md
+++ b/logs/README.md
@@ -80,18 +80,18 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | commonLabels | object | `{}` | common labels to apply to all resources. |
-| logs-operator.admissionWebhooks.autoGenerateCert | object | `{"recreate":false}` | Activate to use Helm to create self-signed certificates. |
-| logs-operator.admissionWebhooks.autoGenerateCert.recreate | bool | `false` | Activate to recreate the cert after a defined period (certPeriodDays default is 365). |
-| logs-operator.admissionWebhooks.certManager | object | `{"enabled":false}` | Activate to use the CertManager for generating self-signed certificates. |
-| logs-operator.admissionWebhooks.failurePolicy | string | `"Ignore"` | Defines if the admission webhooks should `Ignore` errors or `Fail` on errors when communicating with the API server. |
-| logs-operator.crds.create | bool | `false` | The required CRDs used by this dependency are version-controlled in this repository under ./crds. If you want to use the upstream CRDs, set this variable to `true``. |
-| logs-operator.kubeRBACProxy | object | `{"enabled":false}` | the kubeRBACProxy can be enabled to allow the operator perform RBAC authorization against the Kubernetes API. |
-| logs-operator.manager.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | overrides the default image repository for the OpenTelemetry Collector image. |
-| logs-operator.manager.collectorImage.tag | string | `"5a4f148"` | overrides the default image tag for the OpenTelemetry Collector image. |
-| logs-operator.manager.image.repository | string | `"ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"` | overrides the default image repository for the OpenTelemetry Operator image. |
-| logs-operator.manager.image.tag | string | `"v0.127.0"` | overrides the default tag repository for the OpenTelemetry Operator image. |
-| logs-operator.manager.serviceMonitor | object | `{"enabled":true}` | Enable serviceMonitor for Prometheus metrics scrape |
-| logs-operator.nameOverride | string | `"operator"` | Provide a name in place of the default name `opentelemetry-operator`. |
+| opentelemetry-operator.admissionWebhooks.autoGenerateCert | object | `{"recreate":false}` | Activate to use Helm to create self-signed certificates. |
+| opentelemetry-operator.admissionWebhooks.autoGenerateCert.recreate | bool | `false` | Activate to recreate the cert after a defined period (certPeriodDays default is 365). |
+| opentelemetry-operator.admissionWebhooks.certManager | object | `{"enabled":false}` | Activate to use the CertManager for generating self-signed certificates. |
+| opentelemetry-operator.admissionWebhooks.failurePolicy | string | `"Ignore"` | Defines if the admission webhooks should `Ignore` errors or `Fail` on errors when communicating with the API server. |
+| opentelemetry-operator.crds.create | bool | `false` | The required CRDs used by this dependency are version-controlled in this repository under ./crds. If you want to use the upstream CRDs, set this variable to `true``. |
+| opentelemetry-operator.kubeRBACProxy | object | `{"enabled":false}` | the kubeRBACProxy can be enabled to allow the operator perform RBAC authorization against the Kubernetes API. |
+| opentelemetry-operator.manager.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | overrides the default image repository for the OpenTelemetry Collector image. |
+| opentelemetry-operator.manager.collectorImage.tag | string | `"5a4f148"` | overrides the default image tag for the OpenTelemetry Collector image. |
+| opentelemetry-operator.manager.image.repository | string | `"ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"` | overrides the default image repository for the OpenTelemetry Operator image. |
+| opentelemetry-operator.manager.image.tag | string | `"v0.127.0"` | overrides the default tag repository for the OpenTelemetry Operator image. |
+| opentelemetry-operator.manager.serviceMonitor | object | `{"enabled":true}` | Enable serviceMonitor for Prometheus metrics scrape |
+| opentelemetry-operator.nameOverride | string | `"operator"` | Provide a name in place of the default name `opentelemetry-operator`. |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
 | openTelemetry.customLabels | object | `{}` | custom Labels applied to servicemonitor, secrets and collectors |
 | openTelemetry.logsCollector.cephConfig | object | `{"enabled":false}` | Activates the configuration for Ceph logs (requires logsCollector to be enabled). |

--- a/logs/charts/Chart.lock
+++ b/logs/charts/Chart.lock
@@ -2,5 +2,5 @@ dependencies:
 - name: opentelemetry-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.90.3
-digest: sha256:8df788956a2ffb494929fc7ed4796788a5619e78ca1719ab434d0b5c77503485
-generated: "2025-06-20T12:20:57.471247+02:00"
+digest: sha256:bccbf6884611212dec74d23609573f1a0e52169402037ce6d5877ab5b8ff3872
+generated: "2025-06-23T12:52:08.398159+02:00"

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -2,20 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 
 apiVersion: v2
-appVersion: v0.124.1
-name: logs-operator
-version: 0.10.0
+appVersion: v0.126.0
+name: opentelemetry-operator
+version: 0.10.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
 maintainers:
 - name: timojohlo
 - name: kuckkuck
-- name: viennaa
+- name: olandr
 sources:
 - https://github.com/cloudoperators/greenhouse-extensions
 dependencies:
 - name: opentelemetry-operator
-  alias: logs-operator
   repository: https://open-telemetry.github.io/opentelemetry-helm-charts
   version: 0.90.3

--- a/logs/charts/ci/test-values.yaml
+++ b/logs/charts/ci/test-values.yaml
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-logs-operator:
+opentelemetry-operator:
   crds:
     create: false
   admissionWebhooks:

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -45,7 +45,7 @@ spec:
     - name: prometheus
       port: 9999
 {{- end }}
-  image: {{ index .Values "logs-operator" "manager" "collectorImage" "repository" }}:{{ index .Values "logs-operator" "manager" "collectorImage" "tag" }}
+  image: {{ index .Values "opentelemetry-operator" "manager" "collectorImage" "repository" }}:{{ index .Values "opentelemetry-operator" "manager" "collectorImage" "tag" }}
   volumeMounts:
   - mountPath: /var/log
     name: varlog

--- a/logs/charts/templates/metrics-collector.yaml
+++ b/logs/charts/templates/metrics-collector.yaml
@@ -15,7 +15,7 @@ metadata:
   {{- end }}
 spec:
   mode: deployment
-  image: {{ index .Values "logs-operator" "manager" "collectorImage" "repository" }}:{{ index .Values "logs-operator" "manager" "collectorImage" "tag" }}
+  image: {{ index .Values "opentelemetry-operator" "manager" "collectorImage" "repository" }}:{{ index .Values "opentelemetry-operator" "manager" "collectorImage" "tag" }}
   config:
     receivers:
       otlp:

--- a/logs/charts/templates/smon.yaml
+++ b/logs/charts/templates/smon.yaml
@@ -28,6 +28,6 @@ spec:
     matchLabels:
       app.kubernetes.io/component: opentelemetry-collector
       app.kubernetes.io/instance: {{ .Release.Namespace }}.openTelemetry.metrics
-      app.kubernetes.io/managed-by: logs-operator
+      app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
 {{- end }}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -5,7 +5,7 @@
 commonLabels: {}
 
 # opentelemetry-operator is an upstream dependency, it is required that it is a separate block. This is customised configuration of the dependency.
-logs-operator:
+opentelemetry-operator:
   # -- Provide a name in place of the default name `opentelemetry-operator`.
   nameOverride: "operator"
 

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -11,7 +11,7 @@ spec:
     description: Observability framework for instrumenting, generating, collecting, and exporting logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
     helmChart:
-        name: logs-operator
+        name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
         version: 0.10.0
     options:
@@ -92,7 +92,7 @@ spec:
           type: map
         - default: true
           description: Activate to use the CertManager for generating self-signed certificates
-          name: logs-operator.admissionWebhooks.certManager.enabled
+          name: opentelemetry-operator.admissionWebhooks.certManager.enabled
           type: bool
         - description: Additional labels for PrometheusRule alerts
           name: openTelemetry.prometheus.rules.additionalRuleLabels
@@ -100,7 +100,7 @@ spec:
           type: map
         - default: false
           description: Activate to use Helm to create self-signed certificates
-          name: logs-operator.admissionWebhooks.autoGenerateCert.enabled
+          name: opentelemetry-operator.admissionWebhooks.autoGenerateCert.enabled
           required: false
           type: bool
         - default: ghcr.io/cloudoperators/opentelemetry-collector-contrib

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: logs
 spec:
-    version: 0.10.0
+    version: 0.10.1
     displayName: Logs
     description: Observability framework for instrumenting, generating, collecting, and exporting logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
     helmChart:
         name: opentelemetry-operator
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.10.0
+        version: 0.10.1
     options:
         - default: true
           description: Activates the standard configuration for logs


### PR DESCRIPTION
## Pull Request Details

- change chart name to make reference to upstream-chart more clear
- update appVersion accordingly to https://github.com/open-telemetry/opentelemetry-helm-charts/blob/main/charts/opentelemetry-operator/Chart.yaml
- update maintainers