### PR TITLE
fix(kube-monitoring) disable unused alert/metrics

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 3.0.5
+version: 3.0.6
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -13,7 +13,6 @@ kubeMonitoring:
       PrometheusRemoteStorageFailures: true
       PrometheusRemoteWriteBehind: true
       PrometheusRemoteWriteDesiredShards: true
-      PrometheusSDRefreshFailure: true
     create: true
     rules:
       alertmanager: false

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -9,6 +9,11 @@ kubeMonitoring:
   # Create open source community rules for monitoring the cluster
   # @ignored
   defaultRules:
+    disabled:
+      PrometheusRemoteStorageFailures: true
+      PrometheusRemoteWriteBehind: true
+      PrometheusRemoteWriteDesiredShards: true
+      PrometheusSDRefreshFailure: true
     create: true
     rules:
       alertmanager: false

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 4.0.5
+  version: 4.0.6
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 3.0.5
+    version: 3.0.6
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
specific alert names can be disabled from value file
see template
https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/prometheus/rules-1.14/prometheus.yaml#L366


absent metrics operator highlighting unused prometheus metrics

<img width="854" alt="Screenshot 2025-06-25 at 3 15 01 PM" src="https://github.com/user-attachments/assets/b5f8bb01-4125-4ce9-9c6f-7d2b73a37f17" />
