### PR TITLE
feat(opensearch): add dashboards external service resource for service proxy

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.27
+version: 0.0.28
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/dashboard-service.yaml
+++ b/opensearch/chart/templates/dashboard-service.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.cluster.cluster.dashboards.enable }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.cluster.cluster.name | default .Release.Name }}-dashboards-external
+  labels:
+    opensearch.cluster.dashboards: {{ .Values.cluster.cluster.name | default .Release.Name }}
+    {{- with .Values.cluster.cluster.dashboards.service.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  type: {{ .Values.cluster.cluster.dashboards.service.type }}
+  ports:
+    - name: http
+      port: 5601
+      targetPort: 5601
+      protocol: TCP
+  selector:
+    opensearch.cluster.dashboards: {{ .Values.cluster.cluster.name | default .Release.Name }}
+{{- end }}

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.27
+  version: 0.0.28
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.27
+    version: 0.0.28
   options:
     - name: cluster.cluster.general.monitoring.pluginUrl
       description: "Defines a custom URL for the monitoring plugin. Leave blank to use the default monitoring configuration."


### PR DESCRIPTION
## Pull Request Details

The OpenSearch Operator creates the dashboards service dynamically, which means it is not part of the Helm-managed resources. As a result, the service proxy does not recognize it properly, since it only supports services defined within a Helm release.

This PR re-adds an external dashboards service definition to the Helm chart to ensure the service is tracked by Helm and compatible with the proxy requirements.

