### PR TITLE
fix(kube-monitoring) disable PrometheusSDRefreshFailure

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 3.0.8
+version: 3.0.9
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/perses-dashboards/prometheus.json
+++ b/kube-monitoring/charts/perses-dashboards/prometheus.json
@@ -911,7 +911,7 @@
                   "kind": "PrometheusTimeSeriesQuery",
                   "spec": {
                     "minStep": "",
-                    "query": "max(prometheus_sd_refresh_failures_total{job=~\"$prometheus\"})",
+                    "query": "max(prometheus_sd_refresh_failures_total{job=~\"$prometheus\"}) or vector(0)",
                     "seriesNameFormat": ""
                   }
                 }

--- a/kube-monitoring/charts/perses-dashboards/prometheus.json
+++ b/kube-monitoring/charts/perses-dashboards/prometheus.json
@@ -873,6 +873,52 @@
             }
           ]
         }
+      },
+      "3-1": {
+        "kind": "Panel",
+        "spec": {
+          "display": {
+            "name": "SD Refresh failures total",
+            "description": "Shows how many SD refresh failures occured"
+          },
+          "plugin": {
+            "kind": "StatChart",
+            "spec": {
+              "calculation": "max",
+              "thresholds": {
+                "steps": [
+                  {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 0
+                  },
+                  {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 0.1
+                  },
+                  {
+                    "color": "rgba(245, 54, 54, 0.9)",
+                    "value": 1
+                  }
+                ]
+              }
+            }
+          },
+          "queries": [
+            {
+              "kind": "TimeSeriesQuery",
+              "spec": {
+                "plugin": {
+                  "kind": "PrometheusTimeSeriesQuery",
+                  "spec": {
+                    "minStep": "",
+                    "query": "max(prometheus_sd_refresh_failures_total{job=~\"$prometheus\"})",
+                    "seriesNameFormat": ""
+                  }
+                }
+              }
+            }
+          ]
+        }
       }
     },
     "layouts": [
@@ -883,14 +929,14 @@
             {
               "x": 0,
               "y": 0,
-              "width": 6,
+              "width": 5,
               "height": 5,
               "content": {
                 "$ref": "#/spec/panels/0"
               }
             },
             {
-              "x": 6,
+              "x": 5,
               "y": 0,
               "width": 6,
               "height": 5,
@@ -899,21 +945,30 @@
               }
             },
             {
-              "x": 12,
+              "x": 11,
               "y": 0,
-              "width": 6,
+              "width": 5,
               "height": 5,
               "content": {
                 "$ref": "#/spec/panels/2"
               }
             },
             {
-              "x": 18,
+              "x": 16,
               "y": 0,
-              "width": 6,
+              "width": 4,
               "height": 5,
               "content": {
                 "$ref": "#/spec/panels/3"
+              }
+            },
+            {
+              "x": 20,
+              "y": 0,
+              "width": 4,
+              "height": 5,
+              "content": {
+                "$ref": "#/spec/panels/3-1"
               }
             },
             {

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -13,6 +13,7 @@ kubeMonitoring:
       PrometheusRemoteStorageFailures: true
       PrometheusRemoteWriteBehind: true
       PrometheusRemoteWriteDesiredShards: true
+      PrometheusSDRefreshFailure: true
     create: true
     rules:
       alertmanager: false

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 4.0.8
+  version: 4.0.9
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 3.0.8
+    version: 3.0.9
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
alert a throwing absent metric on `prometheus_sd_refresh_failures_total`

this metric may only be present when actual sd config refresh are failing but greenhouse setup only uses selectors