### PR TITLE
feat(plugins): allow both labels and annotations to define exposed services

### DIFF
--- a/exposed-services/README.md
+++ b/exposed-services/README.md
@@ -4,9 +4,15 @@ title: Service exposure test
 
 This Plugin is just providing a simple exposed service for manual testing.
 
-By adding the following label to a service it will become accessible from the central greenhouse system via a service proxy:
+By adding the following label or annotation to a service it will become accessible from the central greenhouse system via a service proxy:
 
+**Label (legacy, transitioning to annotation):**
 ```greenhouse.sap/expose: "true"```
+
+**Annotation:**
+```greenhouse.sap/expose: "true"```
+
+During the transition period, both label and annotation are supported.
 
 This plugin create an nginx deployment with an exposed service for testing.
 
@@ -16,4 +22,10 @@ This plugin create an nginx deployment with an exposed service for testing.
 
 By default expose would always use the first port. If you need another port, you've got to specify it by name:
 
+**Label (legacy, transitioning to annotation):**
 ```greenhouse.sap/exposeNamedPort: YOURPORTNAME```
+
+**Annotation:**
+```greenhouse.sap/exposed-named-port: YOURPORTNAME```
+
+During the transition period, both label and annotation are supported.

--- a/exposed-services/charts/v1.0.0/exposed-service/Chart.yaml
+++ b/exposed-services/charts/v1.0.0/exposed-service/Chart.yaml
@@ -4,6 +4,9 @@
 apiVersion: v2
 name: exposed-service
 description: A Helm chart for Kubernetes
+maintainers:
+  - name: ivogoman
+  - name: uwe-mayer
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -18,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.0.0
+version: 1.0.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/exposed-services/charts/v1.0.0/exposed-service/templates/_helpers.tpl
+++ b/exposed-services/charts/v1.0.0/exposed-service/templates/_helpers.tpl
@@ -60,12 +60,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{/*
-Service annotations
-*/}}
-{{- define "exposed-service.serviceAnnotations" -}}
-{{- with .Values.service.annotations }}
-{{- toYaml . }}
-{{- end }}
-{{- end }}

--- a/exposed-services/charts/v1.0.0/exposed-service/templates/_helpers.tpl
+++ b/exposed-services/charts/v1.0.0/exposed-service/templates/_helpers.tpl
@@ -60,3 +60,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Service annotations
+*/}}
+{{- define "exposed-service.serviceAnnotations" -}}
+{{- with .Values.service.annotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}

--- a/exposed-services/charts/v1.0.0/exposed-service/templates/service.yaml
+++ b/exposed-services/charts/v1.0.0/exposed-service/templates/service.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- include "exposed-service.labels" . | nindent 4 }}
   annotations:
     greenhouse.sap/expose: "true"
-    {{- include "exposed-service.serviceAnnotations" . | nindent 4 }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/exposed-services/charts/v1.0.0/exposed-service/templates/service.yaml
+++ b/exposed-services/charts/v1.0.0/exposed-service/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     greenhouse.sap/expose: "true"
     {{- include "exposed-service.labels" . | nindent 4 }}
+  annotations:
+    greenhouse.sap/expose: "true"
+    {{- include "exposed-service.serviceAnnotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/exposed-services/charts/v1.0.0/exposed-service/values.yaml
+++ b/exposed-services/charts/v1.0.0/exposed-service/values.yaml
@@ -21,6 +21,7 @@ podAnnotations: {}
 
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 80
 

--- a/exposed-services/charts/v2.0.0/exposed-service/Chart.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.2
+version: 2.1.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/exposed-services/charts/v2.0.0/exposed-service/templates/_helpers.tpl
+++ b/exposed-services/charts/v2.0.0/exposed-service/templates/_helpers.tpl
@@ -60,12 +60,3 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
-
-{{/*
-Service annotations
-*/}}
-{{- define "exposed-service.serviceAnnotations" -}}
-{{- with .Values.service.annotations }}
-{{- toYaml . }}
-{{- end }}
-{{- end }}

--- a/exposed-services/charts/v2.0.0/exposed-service/templates/_helpers.tpl
+++ b/exposed-services/charts/v2.0.0/exposed-service/templates/_helpers.tpl
@@ -60,3 +60,12 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Service annotations
+*/}}
+{{- define "exposed-service.serviceAnnotations" -}}
+{{- with .Values.service.annotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end }}

--- a/exposed-services/charts/v2.0.0/exposed-service/templates/service.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/templates/service.yaml
@@ -12,7 +12,9 @@ metadata:
     {{- include "exposed-service.labels" . | nindent 4 }}
   annotations:
     greenhouse.sap/expose: "true"
-    {{- include "exposed-service.serviceAnnotations" . | nindent 4 }}
+    {{- with .Values.service.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/exposed-services/charts/v2.0.0/exposed-service/templates/service.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
   labels:
     greenhouse.sap/expose: "true"
     {{- include "exposed-service.labels" . | nindent 4 }}
+  annotations:
+    greenhouse.sap/expose: "true"
+    {{- include "exposed-service.serviceAnnotations" . | nindent 4 }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/exposed-services/charts/v2.0.0/exposed-service/values.yaml
+++ b/exposed-services/charts/v2.0.0/exposed-service/values.yaml
@@ -21,6 +21,7 @@ podAnnotations: {}
 
 
 service:
+  annotations: {}
   type: ClusterIP
   port: 8080
 

--- a/openbao/charts/openbao/Chart.yaml
+++ b/openbao/charts/openbao/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: openbao
-version: 0.4.2
+version: 0.4.3
 appVersion: v2.0.0-alpha20240329
 kubeVersion: ">= 1.27.0-0"
 description: Official OpenBao Chart

--- a/openbao/charts/openbao/templates/server-service.yaml
+++ b/openbao/charts/openbao/templates/server-service.yaml
@@ -20,6 +20,7 @@ metadata:
     app.kubernetes.io/managed-by: {{ .Release.Service }}
     greenhouse.sap/expose: "true"
   annotations:
+    greenhouse.sap/expose: "true"
 {{ template "openbao.service.annotations" .}}
 spec:
   {{- if .Values.server.service.type}}

--- a/plutono/README.md
+++ b/plutono/README.md
@@ -160,8 +160,8 @@ Data sources are selected from `Secrets` across namespaces. The plugin searches 
 | plutono.securityContext.runAsGroup | int | `472` |  |
 | plutono.securityContext.runAsNonRoot | bool | `true` |  |
 | plutono.securityContext.runAsUser | int | `472` |  |
-| plutono.service | object | `{"annotations":{},"appProtocol":"","enabled":true,"ipFamilies":[],"ipFamilyPolicy":"","labels":{"greenhouse.sap/expose":"true"},"loadBalancerClass":"","loadBalancerIP":"","loadBalancerSourceRanges":[],"port":80,"portName":"service","targetPort":3000,"type":"ClusterIP"}` | Expose the plutono service to be accessed from outside the cluster (LoadBalancer service). # or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it. # ref: http://kubernetes.io/docs/user-guide/services/ # |
-| plutono.service.annotations | object | `{}` | Service annotations. Can be templated. |
+| plutono.service | object | `{"annotations":{"greenhouse.sap/expose":"true"},"appProtocol":"","enabled":true,"ipFamilies":[],"ipFamilyPolicy":"","labels":{"greenhouse.sap/expose":"true"},"loadBalancerClass":"","loadBalancerIP":"","loadBalancerSourceRanges":[],"port":80,"portName":"service","targetPort":3000,"type":"ClusterIP"}` | Expose the plutono service to be accessed from outside the cluster (LoadBalancer service). # or access it from within the cluster (ClusterIP service). Set the service type and the port to serve it. # ref: http://kubernetes.io/docs/user-guide/services/ # |
+| plutono.service.annotations | object | `{"greenhouse.sap/expose":"true"}` | Service annotations. Can be templated. |
 | plutono.service.appProtocol | string | `""` | Adds the appProtocol field to the service. This allows to work with istio protocol selection. Ex: "http" or "tcp" |
 | plutono.service.ipFamilies | list | `[]` | Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6. |
 | plutono.service.ipFamilyPolicy | string | `""` | Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services) |

--- a/plutono/charts/Chart.yaml
+++ b/plutono/charts/Chart.yaml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: v2
 name: plutono
-version: 0.3.4
+version: 0.3.5
 description: Plutono is a fork of Grafana v7.5.17 keeping the Apache License
 type: application
 maintainers:

--- a/plutono/charts/values.yaml
+++ b/plutono/charts/values.yaml
@@ -240,7 +240,8 @@ plutono:
       3000
       # targetPort: 4181 To be used with a proxy extraContainer
     # -- Service annotations. Can be templated.
-    annotations: {}
+    annotations:
+      greenhouse.sap/expose: "true"
     labels:
       greenhouse.sap/expose: "true"
     portName: service

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -349,7 +349,7 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.compactor.retentionResolution1h | string | 157680000s | Set Thanos Compactor retention.resolution-1h |
 | thanos.compactor.retentionResolution5m | string | 7776000s | Set Thanos Compactor retention.resolution-5m |
 | thanos.compactor.retentionResolutionRaw | string | 7776000s | Set Thanos Compactor retention.resolution-raw |
-| thanos.compactor.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Compactor service |
+| thanos.compactor.serviceAnnotations | object | `{}` | Service specific annotations to add to the Thanos Compactor service in addition to its already configured annotations. |
 | thanos.compactor.serviceLabels | object | `{}` | Labels to add to the Thanos Compactor service |
 | thanos.compactor.volume.labels | list | `[]` | Labels to add to the Thanos Compactor PVC resource |
 | thanos.compactor.volume.size | string | 100Gi | Set Thanos Compactor PersistentVolumeClaim size in Gi |
@@ -387,7 +387,7 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.query.replicaLabel | string | `"prometheus_replica"` | Set Thanos Query replica-label for Prometheus replicas |
 | thanos.query.replicas | string | `nil` | Number of Thanos Query replicas to deploy |
 | thanos.query.resources | object | <pre>ressources:<br>  requests:<br>    memory:<br>    cpu:<br>  limits:<br>    memory:<br>    cpu:<br></pre> | Resource requests and limits for the Thanos Query container. |
-| thanos.query.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Query service |
+| thanos.query.serviceAnnotations | object | `{}` | Service specific annotations to add to the Thanos Query service in addition to its already configured annotations. |
 | thanos.query.serviceLabels | object | `{}` | Labels to add to the Thanos Query service |
 | thanos.query.standalone | bool | `false` |  |
 | thanos.query.stores | list | `[]` |  |
@@ -415,7 +415,7 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.ruler.resources | object | <pre>ressources:<br>  requests:<br>    memory:<br>    cpu:<br>  limits:<br>    memory:<br>    cpu:<br></pre> | Resource requests and limits for the Thanos Ruler container. |
 | thanos.ruler.retention | string | `"24h"` | Time duration ThanosRuler shall retain data for. Default is ‘24h’, and must match the regular expression [0-9]+(ms|s|m|h|d|w|y) (milliseconds seconds minutes hours days weeks years). |
 | thanos.ruler.securityContext | object | `{"fsGroup":2000,"runAsGroup":2000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext holds pod-level security attributes and common container settings. |
-| thanos.ruler.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Ruler service |
+| thanos.ruler.serviceAnnotations | object | `{}` | Service specific annotations to add to the Thanos Ruler service in addition to its already configured annotations. |
 | thanos.ruler.serviceLabels | object | `{}` | Labels to add to the Thanos Ruler service |
 | thanos.ruler.storage | object | `{}` |  |
 | thanos.serviceMonitor.alertLabels | string | <pre> alertLabels: \| <br>   support_group: "default" <br>   meta: "" </pre> | Labels to add to the PrometheusRules alerts. |
@@ -431,5 +431,5 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.store.indexCacheSize | string | 1GB | Set Thanos Store index-cache-size |
 | thanos.store.logLevel | string | info | Thanos Store log level |
 | thanos.store.resources | object | <pre>ressources:<br>  requests:<br>    memory:<br>    cpu:<br>  limits:<br>    memory:<br>    cpu:<br></pre> | Resource requests and limits for the Thanos Store container. |
-| thanos.store.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Store service |
+| thanos.store.serviceAnnotations | object | `{}` | Service specific annotations to add to the Thanos Store service in addition to its already configured annotations. |
 | thanos.store.serviceLabels | object | `{}` | Labels to add to the Thanos Store service |

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -349,6 +349,7 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.compactor.retentionResolution1h | string | 157680000s | Set Thanos Compactor retention.resolution-1h |
 | thanos.compactor.retentionResolution5m | string | 7776000s | Set Thanos Compactor retention.resolution-5m |
 | thanos.compactor.retentionResolutionRaw | string | 7776000s | Set Thanos Compactor retention.resolution-raw |
+| thanos.compactor.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Compactor service |
 | thanos.compactor.serviceLabels | object | `{}` | Labels to add to the Thanos Compactor service |
 | thanos.compactor.volume.labels | list | `[]` | Labels to add to the Thanos Compactor PVC resource |
 | thanos.compactor.volume.size | string | 100Gi | Set Thanos Compactor PersistentVolumeClaim size in Gi |
@@ -386,6 +387,7 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.query.replicaLabel | string | `"prometheus_replica"` | Set Thanos Query replica-label for Prometheus replicas |
 | thanos.query.replicas | string | `nil` | Number of Thanos Query replicas to deploy |
 | thanos.query.resources | object | <pre>ressources:<br>  requests:<br>    memory:<br>    cpu:<br>  limits:<br>    memory:<br>    cpu:<br></pre> | Resource requests and limits for the Thanos Query container. |
+| thanos.query.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Query service |
 | thanos.query.serviceLabels | object | `{}` | Labels to add to the Thanos Query service |
 | thanos.query.standalone | bool | `false` |  |
 | thanos.query.stores | list | `[]` |  |
@@ -413,6 +415,7 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.ruler.resources | object | <pre>ressources:<br>  requests:<br>    memory:<br>    cpu:<br>  limits:<br>    memory:<br>    cpu:<br></pre> | Resource requests and limits for the Thanos Ruler container. |
 | thanos.ruler.retention | string | `"24h"` | Time duration ThanosRuler shall retain data for. Default is ‘24h’, and must match the regular expression [0-9]+(ms|s|m|h|d|w|y) (milliseconds seconds minutes hours days weeks years). |
 | thanos.ruler.securityContext | object | `{"fsGroup":2000,"runAsGroup":2000,"runAsNonRoot":true,"runAsUser":1000,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext holds pod-level security attributes and common container settings. |
+| thanos.ruler.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Ruler service |
 | thanos.ruler.serviceLabels | object | `{}` | Labels to add to the Thanos Ruler service |
 | thanos.ruler.storage | object | `{}` |  |
 | thanos.serviceMonitor.alertLabels | string | <pre> alertLabels: \| <br>   support_group: "default" <br>   meta: "" </pre> | Labels to add to the PrometheusRules alerts. |
@@ -428,4 +431,5 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.store.indexCacheSize | string | 1GB | Set Thanos Store index-cache-size |
 | thanos.store.logLevel | string | info | Thanos Store log level |
 | thanos.store.resources | object | <pre>ressources:<br>  requests:<br>    memory:<br>    cpu:<br>  limits:<br>    memory:<br>    cpu:<br></pre> | Resource requests and limits for the Thanos Store container. |
+| thanos.store.serviceAnnotations | object | `{}` | Annotations to add to the Thanos Store service |
 | thanos.store.serviceLabels | object | `{}` | Labels to add to the Thanos Store service |

--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.6.3
+version: 0.6.4
 keywords:
   - thanos
   - storage

--- a/thanos/charts/templates/_helpers.tpl
+++ b/thanos/charts/templates/_helpers.tpl
@@ -37,3 +37,17 @@ kube-monitoring-prometheus
 object-storage-configs.yaml
 {{- end }}
 {{- end }}
+
+{{/*
+Renders a single `annotations:` block by merging two maps.
+`b` overrides `a` on key conflicts. Emits nothing if the merged map is empty.
+*/}}
+{{- define "thanos.annotations" -}}
+{{- $a := .a | default dict -}}
+{{- $b := .b | default dict -}}
+{{- $m := merge (dict) $a $b -}}
+{{- if $m -}}
+annotations:
+{{- toYaml $m | nindent 2 }}
+{{- end -}}
+{{- end }}

--- a/thanos/charts/templates/_helpers.tpl
+++ b/thanos/charts/templates/_helpers.tpl
@@ -40,14 +40,14 @@ object-storage-configs.yaml
 
 {{/*
 Renders a single `annotations:` block by merging two maps.
-`b` overrides `a` on key conflicts. Emits nothing if the merged map is empty.
+`overrideAnnotations` overrides `baseAnnotations` on key conflicts. Emits nothing if the merged map is empty.
 */}}
 {{- define "thanos.annotations" -}}
-{{- $a := .a | default dict -}}
-{{- $b := .b | default dict -}}
-{{- $m := merge (dict) $a $b -}}
-{{- if $m -}}
+{{- $baseAnnotations := .a | default dict -}}
+{{- $overrideAnnotations := .b | default dict -}}
+{{- $mergedAnnotations := merge (dict) $baseAnnotations $overrideAnnotations -}}
+{{- if $mergedAnnotations -}}
 annotations:
-{{- toYaml $m | nindent 2 }}
+{{- toYaml $mergedAnnotations | nindent 2 }}
 {{- end -}}
 {{- end }}

--- a/thanos/charts/templates/_helpers.tpl
+++ b/thanos/charts/templates/_helpers.tpl
@@ -38,16 +38,14 @@ object-storage-configs.yaml
 {{- end }}
 {{- end }}
 
-{{/*
-Renders a single `annotations:` block by merging two maps.
-`overrideAnnotations` overrides `baseAnnotations` on key conflicts. Emits nothing if the merged map is empty.
-*/}}
 {{- define "thanos.annotations" -}}
-{{- $baseAnnotations := .a | default dict -}}
-{{- $overrideAnnotations := .b | default dict -}}
-{{- $mergedAnnotations := merge (dict) $baseAnnotations $overrideAnnotations -}}
-{{- if $mergedAnnotations -}}
+{{- if or .base .service }}
 annotations:
-{{- toYaml $mergedAnnotations | nindent 2 }}
-{{- end -}}
+{{- with .base }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .service }}
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/thanos/charts/templates/compactor/service.yaml
+++ b/thanos/charts/templates/compactor/service.yaml
@@ -2,15 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if or .Values.thanos.compactor.annotations .Values.thanos.compactor.serviceAnnotations }}
-  annotations:
-    {{- if .Values.thanos.store.annotations }}
-    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
-    {{- end }}
-    {{- if .Values.thanos.store.serviceAnnotations }}
-    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
-    {{- end }}
-  {{- end }}
+  {{- include "thanos.annotations" (dict 
+        "a" .Values.thanos.compactor.annotations 
+        "b" .Values.thanos.compactor.serviceAnnotations 
+      ) | nindent 2 }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/compactor/service.yaml
+++ b/thanos/charts/templates/compactor/service.yaml
@@ -2,9 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.thanos.compactor.annotations }}
+  {{- if or .Values.thanos.compactor.annotations .Values.thanos.compactor.serviceAnnotations }}
   annotations:
-    {{ toYaml .Values.thanos.compactor.annotations | nindent 8 }}
+    {{- if .Values.thanos.store.annotations }}
+    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.thanos.store.serviceAnnotations }}
+    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}

--- a/thanos/charts/templates/compactor/service.yaml
+++ b/thanos/charts/templates/compactor/service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "thanos.annotations" (dict 
-        "a" .Values.thanos.compactor.annotations 
-        "b" .Values.thanos.compactor.serviceAnnotations 
-      ) | nindent 2 }}
+  {{- include "thanos.annotations" (dict
+        "base" .Values.thanos.compactor.annotations
+        "service" .Values.thanos.compactor.serviceAnnotations
+      ) }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/query/service.yaml
+++ b/thanos/charts/templates/query/service.yaml
@@ -2,15 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if or .Values.thanos.query.annotations .Values.thanos.query.serviceAnnotations }}
-  annotations:
-    {{- if .Values.thanos.store.annotations }}
-    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
-    {{- end }}
-    {{- if .Values.thanos.store.serviceAnnotations }}
-    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
-    {{- end }}
-  {{- end }}
+  {{- include "thanos.annotations" (dict 
+        "a" .Values.thanos.query.annotations 
+        "b" .Values.thanos.query.serviceAnnotations 
+      ) | nindent 2 }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/query/service.yaml
+++ b/thanos/charts/templates/query/service.yaml
@@ -2,9 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.thanos.query.annotations }}
+  {{- if or .Values.thanos.query.annotations .Values.thanos.query.serviceAnnotations }}
   annotations:
-    {{ toYaml .Values.thanos.query.annotations | nindent 8 }}
+    {{- if .Values.thanos.store.annotations }}
+    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.thanos.store.serviceAnnotations }}
+    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}

--- a/thanos/charts/templates/query/service.yaml
+++ b/thanos/charts/templates/query/service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "thanos.annotations" (dict 
-        "a" .Values.thanos.query.annotations 
-        "b" .Values.thanos.query.serviceAnnotations 
-      ) | nindent 2 }}
+  {{- include "thanos.annotations" (dict
+        "base" .Values.thanos.query.annotations
+        "service" .Values.thanos.query.serviceAnnotations
+      ) }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/ruler/service.yaml
+++ b/thanos/charts/templates/ruler/service.yaml
@@ -2,15 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if or .Values.thanos.ruler.annotations .Values.thanos.ruler.serviceAnnotations }}
-  annotations:
-    {{- if .Values.thanos.store.annotations }}
-    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
-    {{- end }}
-    {{- if .Values.thanos.store.serviceAnnotations }}
-    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
-    {{- end }}
-  {{- end }}
+  {{- include "thanos.annotations" (dict 
+        "a" .Values.thanos.ruler.annotations 
+        "b" .Values.thanos.ruler.serviceAnnotations 
+      ) | nindent 2 }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/ruler/service.yaml
+++ b/thanos/charts/templates/ruler/service.yaml
@@ -2,9 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.thanos.ruler.annotations }}
+  {{- if or .Values.thanos.ruler.annotations .Values.thanos.ruler.serviceAnnotations }}
   annotations:
-    {{ toYaml .Values.thanos.ruler.annotations | nindent 8 }}
+    {{- if .Values.thanos.store.annotations }}
+    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.thanos.store.serviceAnnotations }}
+    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}

--- a/thanos/charts/templates/ruler/service.yaml
+++ b/thanos/charts/templates/ruler/service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "thanos.annotations" (dict 
-        "a" .Values.thanos.ruler.annotations 
-        "b" .Values.thanos.ruler.serviceAnnotations 
-      ) | nindent 2 }}
+  {{- include "thanos.annotations" (dict
+        "base" .Values.thanos.ruler.annotations
+        "service" .Values.thanos.ruler.serviceAnnotations
+      ) }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/store/service.yaml
+++ b/thanos/charts/templates/store/service.yaml
@@ -2,10 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- include "thanos.annotations" (dict 
-        "a" .Values.thanos.store.annotations 
-        "b" .Values.thanos.store.serviceAnnotations 
-      ) | nindent 2 }}
+  {{- include "thanos.annotations" (dict
+        "base" .Values.thanos.store.annotations
+        "service" .Values.thanos.store.serviceAnnotations
+      ) }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/store/service.yaml
+++ b/thanos/charts/templates/store/service.yaml
@@ -2,15 +2,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if or .Values.thanos.store.annotations .Values.thanos.store.serviceAnnotations }}
-  annotations:
-    {{- if .Values.thanos.store.annotations }}
-    {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
-    {{- end }}
-    {{- if .Values.thanos.store.serviceAnnotations }}
-    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
-    {{- end }}
-  {{- end }}
+  {{- include "thanos.annotations" (dict 
+        "a" .Values.thanos.store.annotations 
+        "b" .Values.thanos.store.serviceAnnotations 
+      ) | nindent 2 }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}

--- a/thanos/charts/templates/store/service.yaml
+++ b/thanos/charts/templates/store/service.yaml
@@ -2,9 +2,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  {{- if .Values.thanos.store.annotations }}
+  {{- if or .Values.thanos.store.annotations .Values.thanos.store.serviceAnnotations }}
   annotations:
+    {{- if .Values.thanos.store.annotations }}
     {{ toYaml .Values.thanos.store.annotations | nindent 8 }}
+    {{- end }}
+    {{- if .Values.thanos.store.serviceAnnotations }}
+    {{ toYaml .Values.thanos.store.serviceAnnotations | nindent 8 }}
+    {{- end }}
   {{- end }}
   labels:
     {{- include "plugin.labels" . | nindent 4 }}

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -112,6 +112,9 @@ thanos:
     # -- Labels to add to the Thanos Query service
     serviceLabels: {}
 
+    # -- Annotations to add to the Thanos Query service
+    serviceAnnotations: {}
+
     # -- Annotations to add to the Thanos Query resources
     annotations: {}
 
@@ -238,6 +241,9 @@ thanos:
     # -- Labels to add to the Thanos Store service
     serviceLabels: {}
 
+    # -- Annotations to add to the Thanos Store service
+    serviceAnnotations: {}
+
     # -- Annotations to add to the Thanos Store resources
     annotations: {}
 
@@ -281,6 +287,9 @@ thanos:
 
     # -- Labels to add to the Thanos Compactor service
     serviceLabels: {}
+
+    # -- Annotations to add to the Thanos Compactor service
+    serviceAnnotations: {}
 
     # -- Annotations to add to the Thanos Compactor resources
     annotations: {}
@@ -345,6 +354,9 @@ thanos:
 
     # -- Labels to add to the Thanos Ruler service
     serviceLabels: {}
+
+    # -- Annotations to add to the Thanos Ruler service
+    serviceAnnotations: {}
 
     # -- Set Thanos Rule replica-label. Only change this when you also guarantee to add the same as an external label with a value of `"$(POD_NAME)"`
     replicaLabel: thanos_ruler_replica

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -112,7 +112,7 @@ thanos:
     # -- Labels to add to the Thanos Query service
     serviceLabels: {}
 
-    # -- Annotations to add to the Thanos Query service
+    # -- Service specific annotations to add to the Thanos Query service in addition to its already configured annotations.
     serviceAnnotations: {}
 
     # -- Annotations to add to the Thanos Query resources
@@ -241,7 +241,7 @@ thanos:
     # -- Labels to add to the Thanos Store service
     serviceLabels: {}
 
-    # -- Annotations to add to the Thanos Store service
+    # -- Service specific annotations to add to the Thanos Store service in addition to its already configured annotations.
     serviceAnnotations: {}
 
     # -- Annotations to add to the Thanos Store resources
@@ -288,7 +288,7 @@ thanos:
     # -- Labels to add to the Thanos Compactor service
     serviceLabels: {}
 
-    # -- Annotations to add to the Thanos Compactor service
+    # -- Service specific annotations to add to the Thanos Compactor service in addition to its already configured annotations.
     serviceAnnotations: {}
 
     # -- Annotations to add to the Thanos Compactor resources
@@ -355,7 +355,7 @@ thanos:
     # -- Labels to add to the Thanos Ruler service
     serviceLabels: {}
 
-    # -- Annotations to add to the Thanos Ruler service
+    # -- Service specific annotations to add to the Thanos Ruler service in addition to its already configured annotations.
     serviceAnnotations: {}
 
     # -- Set Thanos Rule replica-label. Only change this when you also guarantee to add the same as an external label with a value of `"$(POD_NAME)"`

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
   name: thanos
 spec:
-  version: 0.6.3
+  version: 0.6.4
   description: thanos
   helmChart:
     name: thanos
     repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-    version: 0.6.3
+    version: 0.6.4
   options:
     - default: null
       description: CLI param for Thanos Query

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -74,6 +74,13 @@ spec:
       name: thanos.query.serviceLabels
       required: false
       type: map
+    - default:
+        greenhouse.sap/expose: "true"
+        greenhouse.sap/exposed-named-port: "http"
+      description: Needed for exposing Thanos Query to the service proxy. UI is accessible via http, exposing this particular port.
+      name: thanos.query.serviceAnnotations
+      required: false
+      type: map
     - default: false
       description: Removes standard Thanos endpoints for overarching Queries
       name: thanos.query.standalone
@@ -152,6 +159,13 @@ spec:
         greenhouse.sap/exposeNamedPort: http
       description: Needed for exposing Thanos Ruler to the service proxy. UI is accessible via http, exposing this particular port.
       name: thanos.ruler.serviceLabels
+      required: false
+      type: map
+    - default:
+        greenhouse.sap/expose: "true"
+        greenhouse.sap/exposed-named-port: http
+      description: Needed for exposing Thanos Ruler to the service proxy. UI is accessible via http, exposing this particular port.
+      name: thanos.ruler.serviceAnnotations
       required: false
       type: map
     - default: false


### PR DESCRIPTION
## Pull Request Details

Allow for both labels and annotations to set exposed services. This is only for a transition process. `kube-monitoring` and `perses` changes will be done in seperate PR.

## Breaking Changes

None

## Issues Fixed

https://github.com/cloudoperators/greenhouse/issues/1017

## Other Relevant Information

Related PRs:
- https://github.com/cloudoperators/greenhouse-extensions/pull/1135
- https://github.com/cloudoperators/greenhouse-extensions/pull/1136
