### PR TITLE
feat(kube-monitoring): allow both labels and annotations to define exposed services

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 5.2.0
+version: 5.2.1
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -309,6 +309,9 @@ kubeMonitoring:
       # Add the label to expose the service via Greenhouse.
       labels:
         greenhouse.sap/expose: "true"
+      # Add the annotation to expose the service via Greenhouse.
+      annotations:
+        greenhouse.sap/expose: "true"
 
     ingress:
       # -- Deploy Prometheus Ingress

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 6.2.0
+  version: 6.2.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 5.2.0
+    version: 5.2.1
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
## Pull Request Details

Allow for both labels and annotations to set exposed services. This is only for a transition process. 
This PR concerns only `kube-monitoring`

## Breaking Changes

None

## Issues Fixed

https://github.com/cloudoperators/greenhouse/issues/1017

## Other Relevant Information

Related PRs:
- https://github.com/cloudoperators/greenhouse-extensions/pull/1134
- https://github.com/cloudoperators/greenhouse-extensions/pull/1136
