### PR TITLE
feat(service-proxy): Enable OAuth2 proxy groups forwarding

### DIFF
--- a/service-proxy/charts/1.0.0/service-proxy/Chart.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/Chart.yaml
@@ -21,7 +21,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.2.3
+version: 1.2.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/service-proxy/charts/1.0.0/service-proxy/templates/ingress.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/ingress.yaml
@@ -1,4 +1,4 @@
-{{/* 
+{{/*
 SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 SPDX-License-Identifier: Apache-2.0
 */}}
@@ -15,9 +15,10 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
 {{- if $.Values.oauth2proxy.enabled }}
-    nginx.ingress.kubernetes.io/auth-signin: https://auth-proxy.{{ required ".domain missing" $.Values.domain }}/oauth2/start 
-    nginx.ingress.kubernetes.io/auth-url: https://auth-proxy.{{ required ".domain missing" $.Values.domain }}/oauth2/auth 
+    nginx.ingress.kubernetes.io/auth-signin: https://auth-proxy.{{ required ".domain missing" $.Values.domain }}/oauth2/start
+    nginx.ingress.kubernetes.io/auth-url: https://auth-proxy.{{ required ".domain missing" $.Values.domain }}/oauth2/auth
     nginx.ingress.kubernetes.io/service-upstream: "true"
+    nginx.ingress.kubernetes.io/auth-response-headers: "X-Forwarded-User,X-Forwarded-Groups,X-Forwarded-Email"
 {{- end }}
   {{- end }}
 spec:

--- a/service-proxy/charts/1.0.0/service-proxy/templates/oauth2-proxy-config.yaml
+++ b/service-proxy/charts/1.0.0/service-proxy/templates/oauth2-proxy-config.yaml
@@ -14,7 +14,7 @@ data:
         name: {{ printf "%s %s" .Values.global.greenhouse.organizationName "OIDC Provider" }}
         clientID: ${OAUTH2_PROXY_CLIENT_ID}
         clientSecret: ${OAUTH2_PROXY_CLIENT_SECRET}
-        scope: "openid email"
+        scope: "openid email groups"
         loginURLParameters:
           - name: approval_prompt
             default: [""]
@@ -24,6 +24,7 @@ data:
         oidcConfig:
           issuerURL: {{ required "oauth2proxy.issuerURL" .Values.oauth2proxy.issuerURL }}
           emailClaim: email
+          groupsClaim: groups
           audienceClaims:
             - "aud"
     server:


### PR DESCRIPTION
## Pull Request Details

This PR enables end-to-end groups flow from SAP IAS → IDProxy → OAuth2 Proxy → Service-Proxy by:
- Adding `groups` scope to OAuth2 proxy configuration and properly map the groups claim
- Adding Nginx ingress response headers annotation to forward OAuth2 proxy headers
