### PR TITLE
feat(logs): extract fields from `kvm-monitoring` daemonset

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.2
+version: 0.11.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_kvm-config.tpl
+++ b/logs/charts/templates/_kvm-config.tpl
@@ -95,12 +95,12 @@ transform/kvm_monitoring:
       conditions:
         - resource.attributes["k8s.daemonset.name"] == "kvm-monitoring"
       statements:
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'level=(?P<level>\\w+)', true), "upsert")
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'msg="(?P<msg>[^"]*)"', true), "upsert")
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'domain=(?P<domain>\\S+)', true), "upsert")
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'runID=(?P<runID>\\S+)', true), "upsert")
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'service_env=(?P<service_env>\\S+)', true), "upsert")
-        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'service_name=(?P<service_name>\\S+)', true), "upsert")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'level=(?P<level>[a-zA-Z]+)', true), "upsert")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'msg="(?P<msg>[^"]*?)"', true), "upsert")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'domain=(?P<domain>[^\\s]+)', true), "upsert")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'runID=(?P<runID>[^\\s]+)', true), "upsert")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'service_env=(?P<service_env>[^\\s]+)', true), "upsert")
+        - merge_maps(log.attributes, ExtractGrokPatterns(log.body, 'service_name=(?P<service_name>[^\\s]+)', true), "upsert")
         - set(log.attributes["config.parsed"], "kvm_monitoring") where log.attributes["level"] != nil
 
 {{- end }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.2
+  version: 0.11.3
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: opentelemetry-operator
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.11.2
+    version: 0.11.3
   options:
     - default: true
       description: Activates the standard configuration for logs


### PR DESCRIPTION
## Pull Request Details

Adds field extraction for logs from the `kvm-monitoring` daemonset to parse log entries and extract attributes.

Added `transform/kvm_monitoring` processor to extract structured fields:
  - `level` - Log level (debug, info, warn, error)
  - `msg` - Log message content
  - `domain` - Domain identifier (e.g., instance-00566eb5)
  - `runID` - Run identifier (UUID format)
  - `service_env` - Service environment (e.g., LOCAL)
  - `service_name` - Service name (kvm-monitoring)

Tested via https://ottl.run/ that missing fields are safely ignored and also use `error_mode: ignore` to prevent pipeline failures.