### PR TITLE
fix(kube-monitoring) remove hardcoded labels

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 5.1.3
+version: 5.1.4
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/templates/absent-metrics-operator/alert.yaml
+++ b/kube-monitoring/charts/templates/absent-metrics-operator/alert.yaml
@@ -16,8 +16,6 @@ spec:
         expr: sum(time() - absent_metrics_operator_successful_reconcile_time) by (prometheusrule_namespace, prometheusrule_name) > 600
         for: 5m
         labels:
-          support_group: observability
-          service: metrics
           {{- if .Values.global.commonLabels }}
           {{ .Values.global.commonLabels | toYaml | nindent 10 }}
           {{- end }}

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 6.1.3
+  version: 6.1.4
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 5.1.3
+    version: 5.1.4
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
          support_group: observability
          service: metrics
those labels are generally passed by users and should not be hardcoded