### PR TITLE
fix(thanos) remove plugin label from smon

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.6.0
+version: 0.6.1
 keywords:
   - thanos
   - storage

--- a/thanos/charts/templates/blackbox-exporter/servicemonitor.yaml
+++ b/thanos/charts/templates/blackbox-exporter/servicemonitor.yaml
@@ -3,7 +3,6 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   labels:
-    {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}
     {{- if .Values.thanos.serviceMonitor.labels }} 
     {{- toYaml .Values.thanos.serviceMonitor.labels | nindent 4 }}

--- a/thanos/charts/templates/servicemonitor.yaml
+++ b/thanos/charts/templates/servicemonitor.yaml
@@ -5,7 +5,6 @@ kind: ServiceMonitor
 metadata:
   name: {{ include "release.name" . }}
   labels:
-    {{- include "plugin.labels" . | nindent 4 }}
     {{- include "thanos.labels" . | nindent 4 }}
     {{- if .Values.thanos.serviceMonitor.labels }} 
     {{- toYaml .Values.thanos.serviceMonitor.labels | nindent 4 }}

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
   name: thanos
 spec:
-  version: 0.6.0
+  version: 0.6.1
   description: thanos
   helmChart:
     name: thanos
     repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-    version: 0.6.0
+    version: 0.6.1
   options:
     - default: null
       description: CLI param for Thanos Query


### PR DESCRIPTION
thanos service monitor need matching label of kube-monitoring plugin. to avoid conflicting labels we won't include thanos plugin label on serviceMonitor resource