### PR TITLE
fix(thanos): remove not needed tpl

### DIFF
--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.6.5
+version: 0.6.6
 keywords:
   - thanos
   - storage

--- a/thanos/charts/alerts/compactor.yaml
+++ b/thanos/charts/alerts/compactor.yaml
@@ -10,7 +10,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactmultiplerunning
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosCompactHalted
     annotations:
       description: Thanos Compact `{{`{{$labels.job}}`}}` has failed to run and now is halted.
@@ -20,7 +20,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/cloudoperators/greenhouse-extensions/thanos/playbooks/ThanosCompactHalted.md
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosCompactHighCompactionFailures
     annotations:
       description: Thanos Compact `{{`{{$labels.job}}`}}` is failing to execute `{{`{{$value | humanize}}`}}`% of compactions.
@@ -36,7 +36,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthighcompactionfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosCompactBucketHighOperationFailures
     annotations:
       description: Thanos Compact `{{`{{$labels.job}}`}}` Bucket is failing to execute `{{`{{$value | humanize}}`}}`% of operations.
@@ -52,7 +52,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactbuckethighoperationfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosCompactHasNotRun
     annotations:
       description: Thanos Compact `{{`{{$labels.job}}`}}` has not uploaded anything for 24
@@ -63,7 +63,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompacthasnotrun
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosCompactIsDown
     annotations:
       description: ThanosCompact has disappeared. Prometheus target for the component
@@ -75,4 +75,4 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanoscompactisdown
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}

--- a/thanos/charts/alerts/query.yaml
+++ b/thanos/charts/alerts/query.yaml
@@ -16,7 +16,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryhttprequestqueryerrorratehigh
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryHttpRequestQueryRangeErrorRateHigh
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` is failing to handle `{{`{{$value | humanize}}`}}`%
@@ -32,7 +32,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryhttprequestqueryrangeerrorratehigh
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryGrpcServerErrorRate
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` is failing to handle `{{`{{$value | humanize}}`}}`%
@@ -49,7 +49,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosquerygrpcservererrorrate
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryGrpcClientErrorRate
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` is failing to send `{{`{{$value | humanize}}`}}`%
@@ -65,7 +65,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosquerygrpcclienterrorrate
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryHighDNSFailures
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` have `{{`{{$value | humanize}}`}}`% of failing
@@ -81,7 +81,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryhighdnsfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryInstantLatencyHigh
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` has a 99th percentile latency of `{{`{{$value}}`}}`
@@ -97,7 +97,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryinstantlatencyhigh
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryRangeLatencyHigh
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` has a 99th percentile latency of `{{`{{$value}}`}}`
@@ -113,7 +113,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryrangelatencyhigh
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryOverload
     annotations:
       description: Thanos Query `{{`{{$labels.job}}`}}` has been overloaded for more than
@@ -130,7 +130,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryoverload
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosQueryIsDown
     annotations:
       description: ThanosQuery has disappeared. Prometheus target for the component
@@ -142,4 +142,4 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosqueryisdown
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}

--- a/thanos/charts/alerts/ruler.yaml
+++ b/thanos/charts/alerts/ruler.yaml
@@ -11,7 +11,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulequeueisdroppingalerts
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleSenderIsFailingAlerts
     annotations:
       description: Thanos Rule `{{`{{$labels.instance}}`}}` is failing to send alerts to alertmanager.
@@ -22,7 +22,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulesenderisfailingalerts
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleHighRuleEvaluationFailures
     annotations:
       description: Thanos Rule `{{`{{$labels.instance}}`}}` is failing to evaluate rules.
@@ -38,7 +38,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulehighruleevaluationfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleHighRuleEvaluationWarnings
     annotations:
       description: Thanos Rule `{{`{{$labels.instance}}`}}` has high number of evaluation
@@ -50,7 +50,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulehighruleevaluationwarnings
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleRuleEvaluationLatencyHigh
     annotations:
       description: Thanos Rule `{{`{{$labels.instance}}`}}` has higher evaluation latency
@@ -66,7 +66,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleruleevaluationlatencyhigh
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleGrpcErrorRate
     annotations:
       description: Thanos Rule `{{`{{$labels.job}}`}}` is failing to handle `{{`{{$value | humanize}}`}}`%
@@ -83,7 +83,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulegrpcerrorrate
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleConfigReloadFailure
     annotations:
       description: Thanos Rule `{{`{{$labels.job}}`}}` has not been able to reload its configuration.
@@ -94,7 +94,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleconfigreloadfailure
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleQueryHighDNSFailures
     annotations:
       description: Thanos Rule `{{`{{$labels.job}}`}}` has `{{`{{$value | humanize}}`}}`% of failing
@@ -111,7 +111,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulequeryhighdnsfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleAlertmanagerHighDNSFailures
     annotations:
       description: Thanos Rule `{{`{{$labels.instance}}`}}` has `{{`{{$value | humanize}}`}}`% of
@@ -128,7 +128,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulealertmanagerhighdnsfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleNoEvaluationFor10Intervals
     annotations:
       description: Thanos Rule `{{`{{$labels.job}}`}}` has rule groups that did not evaluate
@@ -142,7 +142,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosrulenoevaluationfor10intervals
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosNoRuleEvaluations
     annotations:
       description: Thanos Rule `{{`{{$labels.instance}}`}}` did not perform any rule evaluations
@@ -156,7 +156,7 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosnoruleevaluations
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosRuleIsDown
     annotations:
       description: ThanosRule has disappeared. Prometheus target for the component
@@ -168,4 +168,4 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosruleisdown
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}

--- a/thanos/charts/alerts/store.yaml
+++ b/thanos/charts/alerts/store.yaml
@@ -17,7 +17,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoregrpcerrorrate
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosStoreSeriesGateLatencyHigh
     annotations:
       description: Thanos Store `{{`{{$labels.job}}`}}` has a 99th percentile latency of `{{`{{$value}}`}}`
@@ -48,7 +48,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstorebuckethighoperationfailures
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosStoreObjstoreOperationLatencyHigh
     annotations:
       description: Thanos Store `{{`{{$labels.job}}`}}` Bucket has a 99th percentile latency
@@ -64,7 +64,7 @@ groups:
     labels:
       severity: info
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreobjstoreoperationlatencyhigh
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
   - alert: ThanosStoreIsDown
     annotations:
       description: ThanosStore has disappeared. Prometheus target for the component
@@ -76,4 +76,4 @@ groups:
     labels:
       severity: warning
       playbook: https://github.com/thanos-io/thanos/tree/main/mixin/runbook.md#alert-name-thanosstoreisdown
-      {{ tpl .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}
+      {{ toYaml .Values.thanos.serviceMonitor.alertLabels . | nindent 6 }}

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
   name: thanos
 spec:
-  version: 0.6.5
+  version: 0.6.6
   description: thanos
   helmChart:
     name: thanos
     repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-    version: 0.6.5
+    version: 0.6.6
   options:
     - default: null
       description: CLI param for Thanos Query


### PR DESCRIPTION
When reusing this chart it runs into this error
template: gotpl:13:20: executing "gotpl" at <.Values.thanos.serviceMonitor.alertLabels>: wrong type for value; expected string; got map[string]interface {}

This is caused because tpl expects a string as the first argument. It could be circumvented by passing values with |-, but then it loses yaml format
