### PR TITLE
fix(alert): duplicate plugin label

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 4.0.0
+version: 4.0.1
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/charts/templates/am-base-config.yaml
+++ b/alerts/charts/templates/am-base-config.yaml
@@ -4,7 +4,6 @@ kind: AlertmanagerConfig
 metadata:
   name: {{ include "kube-prometheus-stack.fullname" . }}-alertmanager-config
   labels:
-    plugin: "{{ $.Release.Name }}"
 {{- include "kube-prometheus-stack.labels" . | indent 4 }}
 spec:
   route:

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 5.0.0
+  version: 5.0.1
   weight: 0
   displayName: Alerts
   description: The Alerts Plugin consists of both Prometheus Alertmanager and Supernova, the holistic alert management UI
@@ -16,7 +16,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/alerts
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 4.0.0
+    version: 4.0.1
   uiApplication:
     name: supernova
     version: "latest"


### PR DESCRIPTION
plugin label is already adde with `kube-prometheus-stack.labels`

https://github.com/cloudoperators/greenhouse-extensions/blob/5c1a8a30408ce19d4fd2265d1fcd82378b92b48e/alerts/charts/templates/_helper.tpl#L19