### PR TITLE
fix(alerts): remove plugin label from kube-prometheus-stack.labels

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -8,7 +8,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 4.0.2
+version: 4.0.3
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/charts/ci/test-values.yaml
+++ b/alerts/charts/ci/test-values.yaml
@@ -5,7 +5,13 @@ global:
     baseDomain: example.com
 
 alerts:
+  defaultRules:
+    labels:
+      plugin: test
   alertmanager:
+    serviceMonitor:
+      additionalLabels:
+        plugin: test2
     ingress:
       enabled: false
       hosts:

--- a/alerts/charts/templates/_helper.tpl
+++ b/alerts/charts/templates/_helper.tpl
@@ -16,7 +16,6 @@ The longest name that gets created adds and extra 37 characters, so truncation s
 {{/* Generate basic labels */}}
 {{ define "kube-prometheus-stack.labels" }}
 plugindefinition: alerts
-plugin: {{ $.Release.Name }}
 {{- if .Values.global.commonLabels }}
 {{ tpl (toYaml .Values.global.commonLabels) . }}
 {{- end }}
@@ -24,22 +23,10 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 release: {{ $.Release.Name | quote }}
 {{- end }}
 
-{{/* Generate basic labels */}}
-{{ define "alerts.labels" }}
-{{- $path := index . 0 -}}
-{{- $root := index . 1 -}}
-plugindefinition: alerts
-plugin: {{ $root.Release.Name }}
-{{- if $root.Values.global.commonLabels }}
-{{ tpl (toYaml $root.Values.global.commonLabels) . }}
-{{- end }}
-app.kubernetes.io/managed-by: {{ $root.Release.Service }}
-release: {{ $root.Release.Name | quote }}
-{{- end }}
-
 {{- define "alerts.dashboardSelectorLabels" }}
 {{- $path := index . 0 -}}
 {{- $root := index . 1 -}}
+plugin: {{ $root.Release.Name }}
 {{- if $root.Values.alerts.dashboards.plutonoSelectors }}
 {{- range $i, $target := $root.Values.alerts.dashboards.plutonoSelectors }}
 {{ $target.name | required (printf "$.Values.alerts.dashboards.plutonoSelectors.[%v].name missing" $i) }}: {{ tpl ($target.value | required (printf "$.Values.alerts.dashboards.plutonoSelectors.[%v].value missing" $i)) $ }}

--- a/alerts/charts/templates/dashboard-configmap.yaml
+++ b/alerts/charts/templates/dashboard-configmap.yaml
@@ -8,7 +8,7 @@ metadata:
   name: {{ printf "%s-%s" $root.Release.Name $path | replace "/" "-" | trunc 63 }}
   labels:
 {{ include "alerts.dashboardSelectorLabels" (list $path $root) | indent 4 }}
-{{ include "alerts.labels" (list $path $root) | indent 4 }}
+{{ include "kube-prometheus-stack.labels" $root | indent 4 }}
 data:
 {{ printf "%s: |-" $path | replace "/" "-" | indent 2 }}
 {{ printf "%s" $bytes | indent 4 }}

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 5.0.2
+  version: 5.0.3
   weight: 0
   displayName: Alerts
   description: The Alerts Plugin consists of both Prometheus Alertmanager and Supernova, the holistic alert management UI
@@ -16,7 +16,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/alerts
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 4.0.2
+    version: 4.0.3
   uiApplication:
     name: supernova
     version: "latest"


### PR DESCRIPTION
this makes us loose plugin label on most of the resources but is necessary to avoid duplicate plugin label with ServiceMonitor and PrometheusRule resources

https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/templates/alertmanager/servicemonitor.yaml#L9

