### PR TITLE
chore(logs): fix labeling, rm double scrape

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -113,7 +113,8 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | opentelemetry-operator.manager.collectorImage.tag | string | `"2016982"` | overrides the default image tag for the OpenTelemetry Collector image. |
 | opentelemetry-operator.manager.image.repository | string | `"ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator"` | overrides the default image repository for the OpenTelemetry Operator image. |
 | opentelemetry-operator.manager.image.tag | string | `"v0.131.0"` | overrides the default tag repository for the OpenTelemetry Operator image. |
-| opentelemetry-operator.manager.serviceMonitor | object | `{"enabled":true}` | Enable serviceMonitor for Prometheus metrics scrape |
+| opentelemetry-operator.manager.serviceMonitor.enabled | bool | `true` | Enable serviceMonitor for Prometheus metrics scrape |
+| opentelemetry-operator.manager.serviceMonitor.extraLabels | object | `{}` | Additional labels on the ServiceMonitor |
 | opentelemetry-operator.nameOverride | string | `"operator"` | Provide a name in place of the default name `opentelemetry-operator`. |
 | testFramework.enabled | bool | `true` | Activates the Helm chart testing framework. |
 | testFramework.image.registry | string | `"ghcr.io"` | Defines the image registry for the test framework. |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.3
+version: 0.11.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -70,7 +70,11 @@ spec:
       filelog/containerd:
         include_file_path: true
         include: [ /var/log/pods/*/*/*.log ]
+{{- if .Values.openTelemetry.logsCollector.kvmConfig.enabled }}
+        exclude: [ /var/log/pods/otel_logs-*, /var/log/pods/logs_*, /var/log/pods/kvm-monitoring_*/monitoring/*.log ]
+{{- else }}
         exclude: [ /var/log/pods/otel_logs-*, /var/log/pods/logs_* ]
+{{- end }}
         operators:
           - id: container-parser
             type: container

--- a/logs/charts/templates/smon.yaml
+++ b/logs/charts/templates/smon.yaml
@@ -27,7 +27,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/component: opentelemetry-collector
-      app.kubernetes.io/instance: {{ .Release.Namespace }}.openTelemetry.metrics
+      app.kubernetes.io/instance: {{ .Release.Namespace }}.metrics
       app.kubernetes.io/managed-by: opentelemetry-operator
       app.kubernetes.io/part-of: opentelemetry
 {{- end }}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -36,9 +36,11 @@ opentelemetry-operator:
       repository: ghcr.io/open-telemetry/opentelemetry-operator/opentelemetry-operator
     # -- overrides the default tag repository for the OpenTelemetry Operator image.
       tag: v0.131.0
-    # -- Enable serviceMonitor for Prometheus metrics scrape
     serviceMonitor:
+    # -- Enable serviceMonitor for Prometheus metrics scrape
       enabled: true
+    # -- Additional labels on the ServiceMonitor
+      extraLabels: {}
   # -- the kubeRBACProxy can be enabled to allow the operator perform RBAC authorization against the Kubernetes API.
   kubeRBACProxy:
     enabled: false

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.3
+  version: 0.11.4
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: opentelemetry-operator
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.11.3
+    version: 0.11.4
   options:
     - default: true
       description: Activates the standard configuration for logs


### PR DESCRIPTION
## Pull Request Details

- fix label on serviceMonitor
- add `extraLabels` to serviceMonitor
- exclude `kvm-monitoring_*/monitoring/*.log` in case kvmConfig.enabled is `true` from container logs as this is collected in the dedicated filelog receiver `filelog/kvm_monitoring`
