### PR TITLE
fix(logs): fix parsing for kvm logs

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.4
+version: 0.11.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.4
+  version: 0.11.5
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: opentelemetry-operator
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.11.4
+    version: 0.11.5
   options:
     - default: true
       description: Activates the standard configuration for logs


### PR DESCRIPTION
## Pull Request Details

This fixes the current parsing errors with inconsistent timestamps:
- date and time separated by `T` or space
- milliseconds and second separated by comma (`,`) or dot (`.`)
Further parsing should be implemented in a follow-up PR once the inconsistency can be removed.
