### PR TITLE
fix add missing num_consumers to otel config

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opentelemetry-operator
-version: 0.11.7
+version: 0.11.8
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/failover-config.tpl
+++ b/logs/charts/templates/failover-config.tpl
@@ -18,7 +18,8 @@ opensearch/failover_b:
     max_elapsed_time: 0s
   sending_queue:
     enabled: true
-    queue_size: 10000
+    queue_size: 100000
+    num_consumers: 2
     block_on_overflow: true
   timeout: 30s
 {{- end }}

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -298,7 +298,8 @@ spec:
           max_elapsed_time: 0s
         sending_queue:
           enabled: true
-          queue_size: 10000
+          queue_size: 100000
+          num_consumers: 2
           block_on_overflow: true
         timeout: 30s
 {{- if .Values.openTelemetry.logsCollector.failover.enabled }}


### PR DESCRIPTION
# Submit a pull request

## Pull Request Details

Fix: adding missing config setting num_consumers to otel config, as the otel-collector is crashlooping

## Issues Fixed

last release is crashlooping
