### PR TITLE
fix(ci): pin python version of helm chart testing

### DIFF
--- a/.github/workflows/helm-lint-test.yaml
+++ b/.github/workflows/helm-lint-test.yaml
@@ -26,8 +26,7 @@ jobs:
 
       - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.x"
-          check-latest: true
+          python-version: "3.13"
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up chart-linting and chart-testing


### PR DESCRIPTION
CI failing
https://github.com/cloudoperators/greenhouse-extensions/actions/runs/18461599413/job/52601974022?pr=1208

```
Traceback (most recent call last):
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/bin/yamale", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 124, in main
    _router(args.path, args.schema, args.cpu_num, args.parser, not args.no_strict)
    ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 104, in _router
    _validate_single(root, schema_name, parser, strict)
    ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 69, in _validate_single
    _validate(s, yaml_path, parser, strict, True)
    ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/command_line.py", line 28, in _validate
    schema = yamale.make_schema(schema_path, parser)
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/yamale.py", line 15, in make_schema
    s = Schema(raw_schemas[0], path, validators=validators)
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 17, in __init__
    self._schema = self._process_schema(DataPath(),
                   ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^
                                        schema_dict,
                                        ^^^^^^^^^^^^
                                        self.validators)
                                        ^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 36, in _process_schema
    schema_data[key] = self._process_schema(path + DataPath(key),
                       ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
                                            data,
                                            ^^^^^
                                            validators)
                                            ^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 40, in _process_schema
    schema_data = self._parse_schema_item(path,
                                          schema_data,
                                          validators)
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/schema/schema.py", line 47, in _parse_schema_item
    return syntax.parse(expression, validators)
           ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/syntax/parser.py", line 40, in parse
    _validate_expr(tree.body, validators)
    ~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/ct/3.12.0/amd64/venv/lib/python3.14/site-packages/yamale/syntax/parser.py", line 22, in _validate_expr
    ast.Constant, ast.Num, ast.Str, ast.Bytes, ast.NameConstant]
                  ^^^^^^^
AttributeError: module 'ast' has no attribute 'Num'
Error: failed linting and installing charts: failed processing charts

```