### PR TITLE
feat(nginx-ingress): add metrics configuration options to plugindefinition

### DIFF
--- a/ingress-nginx/plugindefinition.yaml
+++ b/ingress-nginx/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: ClusterPluginDefinition
 metadata:
   name: ingress-nginx
 spec:
-  version: 1.2.2
+  version: 1.2.3
   displayName: Ingress NGINX
   description: Ingress NGINX controller for Kubernetes
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/ingress-nginx/README.md


### PR DESCRIPTION
- This PR adds metrics enable config and service monitor for nginx-ingress plugin definition.
- It also enables service monitor and allows adding labels --so we can use `plugin: plugin-name` label in the service monitor and the services are discovered by [kube-monitoring plugin](https://github.com/cloudoperators/greenhouse-extensions/blob/main/kube-monitoring/README.md#extension-of-the-plugin)