### PR TITLE
Bump digicert

### DIFF
--- a/digicert-issuer/plugindefinition.yaml
+++ b/digicert-issuer/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: digicert-issuer
 spec:
-  version: 1.3.1
+  version: 1.3.2
   displayName: DigiCert extensions
   description: Extensions to the cert-manager for DigiCert support
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/digicert-issuer/README.md
   helmChart:
     name: digicert-issuer
     repository: oci://ghcr.io/sapcc/helm-charts
-    version: 2.5.2
+    version: 2.6.0
   options:
     - name: provisioner.apiToken
       description: DigiCert cert-central API token


### PR DESCRIPTION
This bumps the digicert plugin to use the latest helm chart published with https://github.com/sapcc/helm-charts/commit/4429322b3fa7754944f69d3aec1500b274cadfe0