### PR TITLE
fix(opensearch): set namespace explicitly

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.40
+version: 0.0.41
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/alerts.yaml
+++ b/opensearch/chart/templates/alerts.yaml
@@ -6,6 +6,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" $.Release.Name ($path | trimSuffix ".yaml") | replace "/" "-" | trunc 63 }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "opensearch.labels" $ | nindent 4 }}
     {{- if $.Values.cluster.cluster.general.monitoring.labels }}
@@ -22,6 +23,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
   name: {{ printf "%s-%s" $.Release.Name ($path | trimSuffix ".yaml") | replace "/" "-" | trunc 63 }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "opensearch.labels" $ | nindent 4 }}
 spec:

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -5,6 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-ca-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -21,6 +22,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-transport-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -44,6 +46,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-admin-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -61,6 +64,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-http-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -84,6 +88,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-http-cert-external
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:

--- a/opensearch/chart/templates/client-service.yaml
+++ b/opensearch/chart/templates/client-service.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $.Values.cluster.cluster.name | default (printf "%s-logs" $.Release.Name) }}-client-external
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
     opster.io/opensearch-cluster: {{ $.Values.cluster.cluster.name | default (printf "%s-logs" $.Release.Name) }}

--- a/opensearch/chart/templates/dashboard-service.yaml
+++ b/opensearch/chart/templates/dashboard-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.cluster.cluster.name | default .Release.Name }}-dashboards-external
+  namespace: {{ .Release.Namespace }}
   annotations:
     greenhouse.sap/expose: "true"
   labels:

--- a/opensearch/chart/templates/issuer.yaml
+++ b/opensearch/chart/templates/issuer.yaml
@@ -5,6 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Values.certManager.issuer.selfSigned.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -14,6 +15,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ .Values.certManager.issuer.ca.name }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -25,6 +27,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: opensearch-siem-ca-issuer
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:

--- a/opensearch/chart/templates/security-config.yaml
+++ b/opensearch/chart/templates/security-config.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: opensearch-security-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 stringData:

--- a/opensearch/chart/templates/siem-certificates.yaml
+++ b/opensearch/chart/templates/siem-certificates.yaml
@@ -5,6 +5,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-siem-ca-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -21,6 +22,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-siem-transport-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -45,6 +47,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-siem-admin-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -63,6 +66,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-siem-http-cert
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:
@@ -87,6 +91,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: opensearch-siem-http-cert-external
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 spec:

--- a/opensearch/chart/templates/siem-client-service.yaml
+++ b/opensearch/chart/templates/siem-client-service.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ $.Values.siem.cluster.name | default (printf "%s-siem" $.Release.Name) }}-client-external
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
     opster.io/opensearch-cluster: {{ $.Values.siem.cluster.name | default (printf "%s-siem" $.Release.Name) }}

--- a/opensearch/chart/templates/siem-dashboard-service.yaml
+++ b/opensearch/chart/templates/siem-dashboard-service.yaml
@@ -5,6 +5,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ .Values.siem.cluster.name | default (printf "%s-siem" .Release.Name) }}-dashboards-external
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
     opensearch.cluster.dashboards: {{ .Values.siem.cluster.name | default (printf "%s-siem" .Release.Name) }}

--- a/opensearch/chart/templates/siem-security-config.yaml
+++ b/opensearch/chart/templates/siem-security-config.yaml
@@ -6,6 +6,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: opensearch-siem-security-config
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
 stringData:

--- a/opensearch/chart/templates/siem-users-secret.yaml
+++ b/opensearch/chart/templates/siem-users-secret.yaml
@@ -8,6 +8,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $userKey | lower }}-credentials
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "opensearch.labels" $ | nindent 4 }}
 type: Opaque

--- a/opensearch/chart/templates/users-secret.yaml
+++ b/opensearch/chart/templates/users-secret.yaml
@@ -7,6 +7,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ $userKey }}-credentials
+  namespace: {{ $.Release.Namespace }}
   labels:
     {{- include "opensearch.labels" $ | nindent 4 }}
 type: Opaque

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.40
+  version: 0.0.41
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.40
+    version: 0.0.41
   options:
     - name: cluster.cluster.general.monitoring.pluginUrl
       description: "Defines a custom URL for the monitoring plugin. Leave blank to use the default monitoring configuration."


### PR DESCRIPTION
## Pull Request Details

Flux reports a missing namespace, even though it is correctly set during the Helm install. Adding it explicitly.
