### PR TITLE
feat(oli): bump the OLI PD to reference v2.0.0 helm chart

### DIFF
--- a/owner-label-injector/plugindefinition.yaml
+++ b/owner-label-injector/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: owner-label-injector
 spec:
-  version: 1.0.0
+  version: 2.0.0
   displayName: Owner Label Injector
   description: Kubernetes mutating admission webhook that ensures every relevant resource carries standardized owner labels (support-group and service) for auditable ownership tracking, incident routing, cost allocation, and cleanup automation.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/owner-label-injector/main/README.md
@@ -14,7 +14,7 @@ spec:
   helmChart:
     name: owner-label-injector
     repository: oci://ghcr.io/cloudoperators/owner-label-injector/charts
-    version: 1.0.0
+    version: 2.0.0
   options:
     - name: replicaCount
       displayName: Replica Count


### PR DESCRIPTION
## Pull Request Details

Bump the `owner-label-injector` plugin definition to reference the `v2.0.0` helm chart.

## Breaking Changes

None

## Issues Fixed

None

## Other Relevant Information

None
