### PR TITLE
fix(ci): ignore licenserc spdx templates

### DIFF
--- a/.github/licenserc.yaml
+++ b/.github/licenserc.yaml
@@ -1,3 +1,4 @@
+# REUSE-IgnoreStart
 header:
   license:
     spdx-id: Apache-2.0
@@ -7,6 +8,7 @@ header:
     pattern: |
       SPDX-FileCopyrightText: [0-9]+ SAP SE or an SAP affiliate company and Greenhouse contributors
       SPDX-License-Identifier: Apache-2\.0
+# REUSE-IgnoreEnd
 
   paths: # `paths` are the path list that will be checked (and fixed) by license-eye, default is ['**'].
     - '**'


### PR DESCRIPTION
REUSE linter is not compatible with the SPDX templates used
