### PR TITLE
[logs] journald from beginning and tracking

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: logs
-version: 0.0.7
+version: 0.0.8
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -59,6 +59,8 @@ spec:
     receivers:
       journald:
         directory: /var/log/journal
+        start_at: beginning
+        storage: file_storage/journald
         operators:
           - id: journal-label
             type: add
@@ -308,6 +310,8 @@ spec:
 {{- end }}
 
     extensions:
+      file_storage/journald:
+        directory: .
       basicauth/failover_a:
         client_auth:
           username: ${failover_username_a}
@@ -328,6 +332,7 @@ spec:
         max_retries: 0
     service:
       extensions:
+        - file_storage/journald
         - basicauth/failover_a
 {{- if .Values.openTelemetry.logsCollector.failover.enabled }}
         - basicauth/failover_b

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.19
+  version: 0.11.20
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.7
+    version: 0.0.8
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
Adding settings for journald input:

- get all journald logs from beginning
- tracking in node filesystem, where the cursor is, that we don't get duplicate log lines