### PR TITLE
fix(kube-monitoring) fix promrulename spec -  remove extra brackets

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 8.0.4
+version: 8.0.5
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -481,7 +481,7 @@ absentMetricsOperator:
   # @section -- absent-metrics-operator options
   enabled: false
   # @ignored
-  promRuleName: "{{\"{{\"}} index .metadata.labels \"plugin\" {{\"}}\"}}"
+  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else }}{{ index .metadata.labels "prometheus" }}{{ end }}'
   # @ignored
   image:
     registry: ghcr.io

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 9.0.4
+  version: 9.0.5
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 8.0.4
+    version: 8.0.5
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
we use the value directly, it is not templated