### PR TITLE
fix(.github): fixes file target issues as context is not added to the dockerfile path

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -27,7 +27,7 @@ jobs:
             Dockerfiles: Dockerfile.integration-test
             Imagename: greenhouse-extensions-integration-test
           - Context: logs/build
-            Dockerfiles: Dockerfile
+            Dockerfiles: logs/build/Dockerfile
             Imagename: opentelemetry-collector-contrib
 
     permissions:
@@ -139,7 +139,7 @@ jobs:
             Dockerfiles: Dockerfile.integration-test
             Imagename: greenhouse-extensions-integration-test
           - Context: logs/build
-            Dockerfiles: Dockerfile
+            Dockerfiles: logs/build/Dockerfile
             Imagename: opentelemetry-collector-contrib
 
     name: Vulnerability Scan


### PR DESCRIPTION
Apparently the context is not added to the file by default (even though I specified the context), so it has to be added again.

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>