### PR TITLE
feat(.github): speedup docker by removing arm64, adds cache

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -26,9 +26,11 @@ jobs:
           - Context: .
             Dockerfiles: Dockerfile.integration-test
             Imagename: greenhouse-extensions-integration-test
+            Platform: linux/amd64
           - Context: logs/build
             Dockerfiles: logs/build/Dockerfile
             Imagename: opentelemetry-collector-contrib
+            Platform: linux/amd64
 
     permissions:
       contents: read
@@ -104,11 +106,9 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           # remove untagged images produced for multi platform builds
           provenance: false
-        #  cache-from: type=gha
-        #  cache-to: type=gha,mode=max
-          platforms: |
-            linux/amd64
-            linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          platforms: ${{ matrix.Platform }}
 
       # Sign the resulting Docker image digest except on PRs.
       # This will only write to the public Rekor transparency log when the Docker

--- a/logs/build/Dockerfile
+++ b/logs/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang AS BUILD
+FROM golang AS build
 
 ARG OTEL_VERSION=0.142.0
 
@@ -16,7 +16,7 @@ RUN apt-get update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
-COPY --from=BUILD /go/dist/otelcol /usr/local/bin/otelcol
+COPY --from=build /go/dist/otelcol /usr/local/bin/otelcol
 RUN chmod +x /usr/local/bin/otelcol
 
 RUN groupadd --system --gid 10001 otel && \


### PR DESCRIPTION
x6 speed improvement of the docker logs build by removing the arm64 build from the step.

Also removed the arm64 (through templating just the amd64 instead) of the integration test

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>