### PR TITLE
chore(logs): bumps crd Chart.yaml

### DIFF
--- a/logs/charts/Chart.lock
+++ b/logs/charts/Chart.lock
@@ -4,6 +4,6 @@ dependencies:
   version: 0.100.0
 - name: crds
   repository: ""
-  version: 0.0.2
-digest: sha256:cae3bf0f1a1f2ee8a9e42f6d32ce3e2af7a35abc2ad1471841568bef31a25618
-generated: "2025-12-15T09:17:26.522853+01:00"
+  version: 0.0.3
+digest: sha256:467fabfd282546ee784c07cada6acbb0573b1756a054cdf4e7e22710b8c7e562
+generated: "2026-01-19T09:47:59.881246+01:00"

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: logs
-version: 0.0.13
+version: 0.0.14
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
@@ -19,5 +19,5 @@ dependencies:
   version: 0.100.0
   condition: opentelemetry-operator.enabled
 - name: crds
-  version: 0.0.2
+  version: 0.0.3
   condition: customCRDs.enabled

--- a/logs/charts/charts/crds/Chart.yaml
+++ b/logs/charts/charts/crds/Chart.yaml
@@ -1,3 +1,3 @@
 apiVersion: v2
 name: crds
-version: 0.0.2
+version: 0.0.3

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.24
+  version: 0.11.25
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.13
+    version: 0.0.14
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
I forgot to bump the Chart.yaml for the CRDs, which seems to have been a reason for the plugin not updating in the cluster

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>