### PR TITLE
[logs] fix kvm parsing after consolidation

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: logs
-version: 0.0.21
+version: 0.0.22
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_kvm-config.tpl
+++ b/logs/charts/templates/_kvm-config.tpl
@@ -98,13 +98,15 @@ transform/kvm_monitoring:
         - attributes["log.type"] == "files-kvm-monitoring"
       statements:
         - merge_maps(log.attributes, ExtractPatterns(log.body, "level=(?P<loglevel>\\w+) msg=\"(?P<msg>[^\"]+)"), "upsert")
-        - merge_maps(log.attributes, ExtractPatterns(log.body, "domain=(?P<domain>\\S+)"), "upsert")
+        - merge_maps(log.attributes, ExtractPatterns(log.body, "domain=(?P<domainid>\\S+)"), "upsert")
         - merge_maps(log.attributes, ExtractPatterns(log.body, "runID=(?P<runID>\\S+)"), "upsert")
         - merge_maps(log.attributes, ExtractPatterns(log.body, "service_env=(?P<service_env>\\S+)"), "upsert")
         - merge_maps(log.attributes, ExtractPatterns(log.body, "service_name=(?P<service_name>\\S+)"), "upsert")
         - merge_maps(log.attributes, ExtractPatterns(log.body, "collector=\"(?P<collector>[^\"]+)"), "upsert")
         - set(attributes["log.level"], attributes["loglevel"])
         - delete_key(attributes, "loglevel")
+        - set(attributes["domain.id"], attributes["domainid"])
+        - delete_key(attributes, "domainid")
         - set(log.attributes["config.parsed"], "kvm_monitoring") where log.attributes["log.level"] != nil
         - set(log.observed_time, Now())
         - set(log.time, log.observed_time)

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.31
+  version: 0.11.32
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.21
+    version: 0.0.22
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
field clash fix, after sending compute logs to logs datastream to get openstack and compute logs in one stream.