### PR TITLE
feat(shoot-grafter): enhance renovate config to react on container image changes

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -150,17 +150,55 @@
     },
     {
       "customType": "regex",
-      "description": "Bump shoot-grafter image version in Chart.yaml",
+      "description": "Update shoot-grafter appVersion in Chart.yaml",
       "managerFilePatterns": [
-        "^shoot-grafter/chart/Chart\\.yaml$"
+        "^shoot-grafter/charts/Chart\\.yaml$"
       ],
       "matchStrings": [
-        "appVersion: \"(?<currentValue>sha-[a-f0-9]+)@sha256:[a-f0-9]+\""
+        "appVersion:\\s*\"(?<currentValue>sha-[a-f0-9]+)\""
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
-      "currentValueTemplate": "{{{currentValue}}}",
-      "extractVersionTemplate": "^(?<version>sha-.*)$"
+      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump shoot-grafter chart version in Chart.yaml",
+      "managerFilePatterns": [
+        "^shoot-grafter/charts/Chart\\.yaml$"
+      ],
+      "matchStrings": [
+        "name:\\s*shoot-grafter\\nversion:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
+      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump shoot-grafter spec.version in plugindefinition.yaml",
+      "managerFilePatterns": [
+        "^shoot-grafter/plugindefinition\\.yaml$"
+      ],
+      "matchStrings": [
+        "description:[^\\n]*\\n\\s+version:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
+      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+    },
+    {
+      "customType": "regex",
+      "description": "Bump shoot-grafter helmChart.version in plugindefinition.yaml",
+      "managerFilePatterns": [
+        "^shoot-grafter/plugindefinition\\.yaml$"
+      ],
+      "matchStrings": [
+        "helmChart:\\n\\s+name:\\s*shoot-grafter\\n\\s+repository:[^\\n]*\\n\\s+version:\\s*(?<currentValue>\\d+\\.\\d+\\.\\d+)"
+      ],
+      "datasourceTemplate": "docker",
+      "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
+      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
     }
   ],
   "packageRules": [
@@ -276,6 +314,25 @@
         "Makefile"
       ],
       "groupName": "Makefile dependencies"
+    },
+    {
+      "matchManagers": [
+        "custom.regex"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/cloudoperators/shoot-grafter"
+      ],
+      "matchFileNames": [
+        "shoot-grafter/charts/Chart.yaml",
+        "shoot-grafter/plugindefinition.yaml"
+      ],
+      "groupName": "shoot-grafter image and versions",
+      "commitMessageTopic": "shoot-grafter",
+      "commitMessageExtra": "to {{newValue}}",
+      "additionalBranchPrefix": "shoot-grafter-",
+      "semanticCommits": "enabled",
+      "semanticCommitType": "chore",
+      "semanticCommitScope": "deps"
     }
   ],
   "separateMinorPatch": true


### PR DESCRIPTION

When a new image is published to [](https://github.com/cloudoperators/shoot-grafter/pkgs/container/shoot-grafter)<https://github.com/cloudoperators/shoot-grafter/pkgs/container/shoot-grafter>, Renovate will:

1. Detect the new `sha-<commit>` tag from the Docker registry
2. Update the `appVersion` in `shoot-grafter/charts/Chart.yaml`
3. Bump the `version` in `shoot-grafter/charts/Chart.yaml`
4. Bump the `spec.version` in `shoot-grafter/plugindefinition.yaml`
5. Bump the `helmChart.version` in `shoot-grafter/plugindefinition.yaml`
6. Create a single grouped PR with all these changes
