### PR TITLE
chore(kube-monitoring): Enforce CRD upgrade job when kubeMonitoring.crds.enabled is true

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 10.3.1
+version: 10.4.0
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/templates/validate-crds-upgradejob.yaml
+++ b/kube-monitoring/charts/templates/validate-crds-upgradejob.yaml
@@ -1,0 +1,3 @@
+{{- if and .Values.kubeMonitoring.crds.enabled (not .Values.kubeMonitoring.crds.upgradeJob.enabled) -}}
+{{- fail "Invalid configuration: kubeMonitoring.crds.upgradeJob.enabled must be true when kubeMonitoring.crds.enabled is true. Reason: Helm does not upgrade CRDs during chart upgrades. This job upgrades CRDs using Helm hooks (pre-install, pre-upgrade)." -}}
+{{- end -}}

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 11.3.1
+  version: 11.4.0
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 10.3.1
+    version: 10.4.0
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
This PR adds a chart-level validation guard to fail rendering when `kubeMonitoring.crds.enabled=true` and `kubeMonitoring.crds.upgradeJob.enabled=false`

The error message will look like the below snippet. 

```yaml
> helm template .
Error: execution error at (kube-monitoring/templates/validate-crds-upgradejob.yaml:2:4): Invalid configuration: kubeMonitoring.crds.upgradeJob.enabled must be true when kubeMonitoring.crds.enabled is true. Reason: Helm does not upgrade CRDs during chart upgrades. This job upgrades CRDs using Helm hooks (pre-install, pre-upgrade).
```


