### PR TITLE
[kube-monitoring]: Enable scraping native histogram by default

### DIFF
--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 11.4.0
+  version: 11.5.0
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -143,3 +143,9 @@ spec:
         key: config.yaml
       required: false
       type: map
+    - name: kubeMonitoring.prometheus.prometheusSpec.scrapeNativeHistograms
+      value: true
+    - name: kubeMonitoring.prometheus.prometheusSpec.scrapeClassicHistograms
+      value: true
+    - name: kubeMonitoring.prometheus.prometheusSpec.convertClassicHistogramsToNHCB
+      value: true


### PR DESCRIPTION
# Submit a pull request

With this change, 
- native histogram will be scraped by default. 
- Classic histogram will be converted to native histogram custom buckets (nhcb).
- Classic histgoram will be stored as well. So no breaking change.