### PR TITLE
fix(shoot-grafter): use semver versioning in renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -155,11 +155,11 @@
         "^shoot-grafter/charts/Chart\\.yaml$"
       ],
       "matchStrings": [
-        "appVersion:\\s*\"(?<currentValue>sha-[a-f0-9]+)\""
+        "appVersion:\\s*\"(?<currentValue>v?\\d+\\.\\d+\\.\\d+)\""
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
-      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",
@@ -172,7 +172,8 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
-      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",
@@ -185,7 +186,8 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
-      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver"
     },
     {
       "customType": "regex",
@@ -198,7 +200,8 @@
       ],
       "datasourceTemplate": "docker",
       "depNameTemplate": "ghcr.io/cloudoperators/shoot-grafter",
-      "versioningTemplate": "regex:^sha-(?<major>[a-f0-9]+)$"
+      "extractVersionTemplate": "^v?(?<version>.*)$",
+      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [

--- a/shoot-grafter/charts/Chart.yaml
+++ b/shoot-grafter/charts/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 description: Automatic onboarding of Gardener Shoots to Greenhouse
 type: application
 name: shoot-grafter
-version: 0.1.11
-appVersion: "sha-66484e77a7c87fed3219435186e81ac138299970"
+version: 0.2.0
+appVersion: "v0.2.0"
 keywords:
 - operator
 - gardener 

--- a/shoot-grafter/plugindefinition.yaml
+++ b/shoot-grafter/plugindefinition.yaml
@@ -7,9 +7,9 @@ metadata:
   name: shoot-grafter
 spec:
   description: Automatic onboarding of Gardener Shoots to Greenhouse
-  version: 0.1.11
+  version: 0.2.0
   helmChart:
     name: shoot-grafter
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.11
+    version: 0.2.0
   


### PR DESCRIPTION
## Pull Request Details

Fix broken shoot-grafter Renovate config from #1433. Replace SHA-based regex versioning (which can't compare git SHAs) with standard `semver` versioning.

## Breaking Changes

None.

## Issues Fixed

None.

## Other Relevant Information

Requires companion PR on shoot-grafter to add semver container tags.
After merging both, `appVersion` in `shoot-grafter/charts/Chart.yaml` needs a one-time update from SHA to semver.