### PR TITLE
(kube-monitoring): Remove invalid PluginDefinition properties

### DIFF
--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 11.5.0
+  version: 11.5.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -143,9 +143,3 @@ spec:
         key: config.yaml
       required: false
       type: map
-    - name: kubeMonitoring.prometheus.prometheusSpec.scrapeNativeHistograms
-      value: true
-    - name: kubeMonitoring.prometheus.prometheusSpec.scrapeClassicHistograms
-      value: true
-    - name: kubeMonitoring.prometheus.prometheusSpec.convertClassicHistogramsToNHCB
-      value: true


### PR DESCRIPTION
# Description

The bug is that these properties are missing the mandatory properties such as`default`, `required` and `type`. 

The valid property in PluginDefinition should look like below. 

```
- name: kubeMonitoring.prometheus.prometheusSpec.convertClassicHistogramsToNHCB
      description: Enable conversion of classic histograms to NHCB format when scrapeNativeHistograms is enabled.
      default: true
      required: false
      type: bool
```

These properties are redundant as they are already added in values.yaml file. So, I am removing it.