### PR TITLE
fix(logs): exclude failover components when Kafka is enabled

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: logs
-version: 0.0.25
+version: 0.0.26
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -324,6 +324,7 @@ spec:
     exporters:
       debug:
         verbosity: basic
+{{- if not .Values.openTelemetry.logsCollector.kafka.enabled }}
       opensearch/failover_a:
         http:
           auth:
@@ -336,6 +337,7 @@ spec:
         timeout: 30s
 {{- if .Values.openTelemetry.logsCollector.failover.enabled }}
     {{- include "failover.exporter" . | nindent 6 -}}
+{{- end }}
 {{- end }}
 {{- if .Values.openTelemetry.logsCollector.kafka.enabled }}
       kafka:
@@ -353,6 +355,7 @@ spec:
     extensions:
       file_storage/journald:
         directory: .
+{{- if not .Values.openTelemetry.logsCollector.kafka.enabled }}
       basicauth/failover_a:
         client_auth:
           username: ${failover_username_a}
@@ -360,8 +363,10 @@ spec:
 {{- if .Values.openTelemetry.logsCollector.failover.enabled }}
     {{- include "failover.extension" . | nindent 6 -}}
 {{- end }}
+{{- end }}
     connectors:
       forward: {}
+{{- if not .Values.openTelemetry.logsCollector.kafka.enabled }}
       failover:
         priority_levels:
           - [logs/failover_a]
@@ -374,12 +379,15 @@ spec:
           queue_size: 100000
           num_consumers: 2
           block_on_overflow: true
+{{- end }}
     service:
       extensions:
         - file_storage/journald
+{{- if not .Values.openTelemetry.logsCollector.kafka.enabled }}
         - basicauth/failover_a
 {{- if .Values.openTelemetry.logsCollector.failover.enabled }}
         - basicauth/failover_b
+{{- end }}
 {{- end }}
 {{- if .Values.openTelemetry.prometheus.podMonitor.enabled }}
       telemetry:
@@ -409,13 +417,13 @@ spec:
           exporters: [kafka]
 {{- else }}
           exporters: [failover]
-{{- end }}
         logs/failover_a:
           receivers: [failover]
           processors: [attributes/failover_username_a]
           exporters: [opensearch/failover_a]
 {{- if .Values.openTelemetry.logsCollector.failover.enabled }}
     {{- include "failover.pipeline" . | nindent 8 -}}
+{{- end }}
 {{- end }}
 {{- if not (or .Values.openTelemetry.logsCollector.kvmConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled) }}
         logs/containerd:

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.11.36
+  version: 0.11.37
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.25
+    version: 0.0.26
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Properly exclude OpenSearch failover components when Kafka exporter is enabled, preventing duplicate log ingestion. When `kafka.enabled=true`, the chart was creating both Kafka exporter AND failover components (OpenSearch exporter, failover connector, failover pipeline). This caused logs to be sent to both Kafka and OpenSearch simultaneously, resulting in duplicate ingestion.

