### PR TITLE
fix(opensearch): disable drain on rolling restart

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -127,7 +127,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.dashboards.version | string | `"3.5.0"` | dashboards version |
 | cluster.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
 | cluster.cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
-| cluster.cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
+| cluster.cluster.general.drainDataNodes | bool | `false` | Controls whether to drain data notes on rolling restart operations |
 | cluster.cluster.general.httpPort | int | `9200` | Opensearch service http port |
 | cluster.cluster.general.image | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
 | cluster.cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
@@ -312,7 +312,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | siem.cluster.dashboards.version | string | `"3.5.0"` | dashboards version |
 | siem.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
 | siem.cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
-| siem.cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
+| siem.cluster.general.drainDataNodes | bool | `false` | Controls whether to drain data notes on rolling restart operations |
 | siem.cluster.general.httpPort | int | `9200` | Opensearch service http port |
 | siem.cluster.general.image | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
 | siem.cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.55
+version: 0.0.56
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -240,7 +240,7 @@ cluster:
         #   restartPods: false
 
       # -- Controls whether to drain data notes on rolling restart operations
-      drainDataNodes: true
+      drainDataNodes: false
 
       # -- Opensearch service http port
       httpPort: 9200
@@ -962,7 +962,7 @@ siem:
         #   restartPods: false
 
       # -- Controls whether to drain data notes on rolling restart operations
-      drainDataNodes: true
+      drainDataNodes: false
 
       # -- Opensearch service http port
       httpPort: 9200


### PR DESCRIPTION
## Pull Request Details

With replicas enabled, draining is unnecessary. Replicas are promoted to primaries when a node restarts, and replica shards are reassigned when it rejoins. Draining causes the operator to get stuck waiting for green status during rolling restarts. Hence, disable it by default for both logs and SIEM clusters. 