### PR TITLE
fix(logs): add http timeout to opensearch exporters

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -115,6 +115,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.openSearchLogs.failover_username_a | string | `nil` | Username for OpenSearch endpoint |
 | openTelemetry.openSearchLogs.failover_username_b | string | `nil` | Second Username (as a failover) for OpenSearch endpoint |
 | openTelemetry.openSearchLogs.index | string | `nil` | Name for OpenSearch index |
+| openTelemetry.openSearchLogs.timeout | string | `"30s"` | Timeout for OpenSearch bulk requests |
 | openTelemetry.prometheus.additionalLabels | object | `{}` | Label selectors for the Prometheus resources to be picked up by prometheus-operator. |
 | openTelemetry.prometheus.podMonitor | object | `{"enabled":true}` | Activates the pod-monitoring for the Logs Collector. |
 | openTelemetry.prometheus.rules | object | `{"additionalRuleLabels":null,"annotations":{},"create":true,"enabled":["FilelogRefusedLogs","LogsOTelLogsMissing","LogsOTelLogsDecreasing","LogsExportingFailed","ReconcileErrors","ReceiverRefusedMetric","WorkqueueDepth"],"labels":{}}` | Default rules for monitoring the opentelemetry components. |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: logs
-version: 0.1.4
+version: 0.1.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -326,69 +326,75 @@ spec:
           auth:
             authenticator: basicauth/failover_a
           endpoint: {{ .Values.openTelemetry.openSearchLogs.endpoint }}
+          timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
         logs_index: ${index}-datastream
         retry_on_failure:
           enabled: true
           max_elapsed_time: 0s
-        timeout: 30s
+        timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
       opensearch/failover_b:
         http:
           auth:
             authenticator: basicauth/failover_b
           endpoint: {{ .Values.openTelemetry.openSearchLogs.endpoint }}
+          timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
         logs_index: ${index}-datastream
         retry_on_failure:
           enabled: true
           max_elapsed_time: 0s
-        timeout: 30s
+        timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
       opensearch/cronus_failover_a:
         http:
           auth:
             authenticator: basicauth/failover_a
           endpoint: {{ .Values.openTelemetry.openSearchLogs.endpoint }}
+          timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
         logs_index: cronus-datastream
         retry_on_failure:
           enabled: true
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
       opensearch/cronus_failover_b:
         http:
           auth:
             authenticator: basicauth/failover_b
           endpoint: {{ .Values.openTelemetry.openSearchLogs.endpoint }}
+          timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
         logs_index: cronus-datastream
         retry_on_failure:
           enabled: true
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
       opensearch/swift_failover_a:
         http:
           auth:
             authenticator: basicauth/failover_a
           endpoint: {{ .Values.openTelemetry.openSearchLogs.endpoint }}
+          timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
         logs_index: ${index}-swift-datastream
         retry_on_failure:
           enabled: true
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
       opensearch/swift_failover_b:
         http:
           auth:
             authenticator: basicauth/failover_b
           endpoint: {{ .Values.openTelemetry.openSearchLogs.endpoint }}
+          timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
         logs_index: ${index}-swift-datastream
         retry_on_failure:
           enabled: true
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: {{ .Values.openTelemetry.openSearchLogs.timeout }}
 {{- end }}
 {{- if .Values.openTelemetry.logsCollector.kafka.enabled }}
       kafka:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -68,6 +68,8 @@ openTelemetry:
     failover_password_b:
     # -- Name for OpenSearch index
     index:
+    # -- Timeout for OpenSearch bulk requests
+    timeout: 30s
   # -- Cluster label for Logging
   cluster:
   # -- Region label for Logging

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -13,7 +13,7 @@ spec:
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.4
+    version: 0.1.5
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.12.4
+  version: 0.12.5
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png


### PR DESCRIPTION
## Pull Request Details

Log collectors were dropping data with context deadline exceeded after exactly 5 seconds on _bulk requests to OpenSearch, despite timeout: 30s being set on the exporter level. The confighttp HTTP client timeout defaults to 0 (unlimited), so it should not be the cause. Setting http.timeout explicitly on all OpenSearch exporter configurations to rule out any ambiguity.

(See: [exporterhelper](https://github.com/open-telemetry/opentelemetry-collector/blob/main/exporter/exporterhelper/README.md#timeout), [confighttp](https://github.com/open-telemetry/opentelemetry-collector/blob/main/config/confighttp/README.md))