### PR TITLE
chore(gitops): generate github token from shared workflow

### DIFF
--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -4,7 +4,26 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
+  generate-token:
+    name: Generate GitHub App Token
+    runs-on: [ ubuntu-latest ]
+    outputs:
+      token: ${{ steps.github-app-token.outputs.token }}
+    steps:
+      - name: Generate GitHub App Token
+        id: github-app-token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.CLOUDOPERATOR_APP_ID }}
+          private-key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}
+          permission-contents: write
+
   build-license-eye:
+    name: Check & Fix License Headers
+    needs: generate-token
     permissions:
-      contents: write # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main
+      # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
+      contents: write 
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@c12810ffe8dfb7f4f907959e9e85632d5ed5469e # main
+    secrets:
+      pas: ${{ needs.generate-token.outputs.token }}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -7,8 +7,8 @@ jobs:
   license:
     name: Apply Licence Header
     permissions:
-      contents: write
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main
+      contents: write  # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@17d3d6b80851574fcd8c7b6e5c4fe6aee2922359
     secrets:
       app_id: ${{ secrets.CLOUDOPERATOR_APP_ID }}
       private_key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -4,26 +4,7 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  generate-token:
-    name: Generate GitHub App Token
-    runs-on: [ ubuntu-latest ]
-    outputs:
-      token: ${{ steps.github-app-token.outputs.token }}
-    steps:
-      - name: Generate GitHub App Token
-        id: github-app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ secrets.CLOUDOPERATOR_APP_ID }}
-          private-key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}
-          permission-contents: write
-
   build-license-eye:
-    name: Check & Fix License Headers
-    needs: generate-token
     permissions:
-      # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
-      contents: write 
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@c12810ffe8dfb7f4f907959e9e85632d5ed5469e # main
-    secrets:
-      pas: ${{ needs.generate-token.outputs.token }}
+      contents: write # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main

--- a/.github/workflows/license.yaml
+++ b/.github/workflows/license.yaml
@@ -4,26 +4,11 @@ on:
     types: [opened, synchronize, reopened]
 
 jobs:
-  generate-token:
-    name: Generate GitHub App Token
-    runs-on: [ ubuntu-latest ]
-    outputs:
-      token: ${{ steps.github-app-token.outputs.token }}
-    steps:
-      - name: Generate GitHub App Token
-        id: github-app-token
-        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
-        with:
-          app-id: ${{ secrets.CLOUDOPERATOR_APP_ID }}
-          private-key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}
-          permission-contents: write
-
-  build-license-eye:
-    name: Check & Fix License Headers
-    needs: generate-token
+  license:
+    name: Apply Licence Header
     permissions:
-      # Only used when `apply_header: true` else the permission is `read` see: https://github.com/cloudoperators/common/blob/8f15c13b6f4c1631c7e6f6dff5c3300452e9b5b6/.github/workflows/shared-license.yaml#L21-L22
-      contents: write 
-    uses: cloudoperators/common/.github/workflows/shared-license.yaml@c12810ffe8dfb7f4f907959e9e85632d5ed5469e # main
+      contents: write
+    uses: cloudoperators/common/.github/workflows/shared-license.yaml@main
     secrets:
-      pas: ${{ needs.generate-token.outputs.token }}
+      app_id: ${{ secrets.CLOUDOPERATOR_APP_ID }}
+      private_key: ${{ secrets.CLOUDOPERATOR_APP_PRIVATE_KEY }}

--- a/test.yaml
+++ b/test.yaml
@@ -1,3 +1,0 @@
-# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
-

--- a/test.yaml
+++ b/test.yaml
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+


### PR DESCRIPTION
is this step needed?

i don't see it used in https://github.com/cloudoperators/kubernetes-operations/blob/main/.github/workflows/license.yaml

we still having problems when people try to contribute while not part of cloudoperators org

https://github.com/cloudoperators/greenhouse-extensions/pull/1547
https://github.com/cloudoperators/greenhouse-extensions/pull/1317