### PR TITLE
Update audit logs config

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -85,6 +85,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.openSearchLogs.failover_username_a | string | `nil` | Username for OpenSearch endpoint |
 | auditLogs.openSearchLogs.failover_username_b | string | `nil` | Second Username (as a failover) for OpenSearch endpoint |
 | auditLogs.openSearchLogs.index | string | `nil` | Name for OpenSearch index |
+| auditLogs.openSearchLogs.timeout | string | `"30s"` | Timeout for OpenSearch requests |
 | auditLogs.prometheus.additionalLabels | object | `{}` | Label selectors for the Prometheus resources to be picked up by prometheus-operator. |
 | auditLogs.prometheus.podMonitor | object | `{"enabled":false}` | Activates the service-monitoring for the Logs Collector. |
 | auditLogs.prometheus.rules | object | `{"additionalRuleLabels":null,"create":true,"labels":{}}` | Default rules for monitoring the opentelemetry components. |

--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -16,10 +16,10 @@ Components included in this Plugin:
 
 - [Collector](https://github.com/open-telemetry/opentelemetry-collector)
 - [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md)
-    - [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
-    - [k8sevents Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver)
-    - [journald Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)
-    - [prometheus/internal](https://opentelemetry.io/docs/collector/internal-telemetry/)
+  - [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
+  - [k8sevents Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver)
+  - [journald Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)
+  - [prometheus/internal](https://opentelemetry.io/docs/collector/internal-telemetry/)
 - [Connector](https://opentelemetry.io/docs/collector/building/connector/)
 - [OpenSearch Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter)
 
@@ -76,7 +76,9 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.elastic.labels | list | `[]` | Labels to be added to Elastic logs |
 | auditLogs.elastic.tls | object | `{"crt":null,"key":null}` | TLS certificate for Elastic |
 | auditLogs.logsCollector.auditd.enabled | bool | `true` | Activates the ingestion of auditd logs. |
+| auditLogs.logsCollector.containerd.enabled | bool | `false` | Activates ingestion of container stdout/stderr logs from /var/log/pods |
 | auditLogs.logsCollector.enabled | bool | `true` | Activates the standard configuration for Logs. |
+| auditLogs.logsCollector.journald.enabled | bool | `false` | Activates ingestion of systemd journal logs |
 | auditLogs.logsCollector.kubeApiAudit.enabled | bool | `false` | Activates export for kube-apiserver audit logs |
 | auditLogs.openSearchLogs.endpoint | string | `nil` | Endpoint URL for OpenSearch |
 | auditLogs.openSearchLogs.failover | object | `{"enabled":true}` | Activates the failover mechanism for shipping logs using the failover_username_band failover_password_b credentials in case the credentials failover_username_a and failover_password_a have expired. |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.0.16
+version: 0.0.17
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/_failover-config.tpl
+++ b/audit-logs/charts/templates/_failover-config.tpl
@@ -13,6 +13,10 @@ opensearch/failover_b:
       authenticator: basicauth/failover_b
     endpoint: {{ .Values.auditLogs.openSearchLogs.endpoint }}
   logs_index: ${index}-datastream
+  retry_on_failure:
+    enabled: true
+    max_elapsed_time: 0s
+  timeout: {{ .Values.auditLogs.openSearchLogs.timeout }}
 {{- end }}
 
 {{- define "failover.extension" }}

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -122,6 +122,13 @@ spec:
         operators:
           - id: kube-audit-json
             type: json_parser
+            parse_to: body
+          - type: add
+            field: attributes["log.type"]
+            value: kube-audit
+          - type: timestamp
+            parse_from: body.stageTimestamp
+            layout: "2010-01-02T15:04:05.999999Z"
 {{- end }}
 
     processors:

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -329,6 +329,10 @@ spec:
             authenticator: basicauth/failover_a
           endpoint: {{ .Values.auditLogs.openSearchLogs.endpoint }}
         logs_index: ${index}-datastream
+        retry_on_failure:
+          enabled: true
+          max_elapsed_time: 0s
+        timeout: {{ .Values.auditLogs.openSearchLogs.timeout }}
 {{- if .Values.auditLogs.openSearchLogs.failover.enabled }}
   {{- include "failover.exporter" . | nindent 6 -}}
 {{- end }}
@@ -347,7 +351,11 @@ spec:
       forward: {}
       failover:
         retry_interval: 2m
-        retry_gap: 30s
+        sending_queue:
+          enabled: true
+          queue_size: 100000
+          num_consumers: 2
+          block_on_overflow: true
         max_retries: 0
         priority_levels:
           - [logs/failover_a]

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -84,6 +84,7 @@ spec:
 {{ end }}
   config:
     receivers:
+{{- if .Values.auditLogs.logsCollector.journald.enabled }}
       journald:
         directory: /var/log/journal
         operators:
@@ -91,10 +92,12 @@ spec:
             type: add
             field: attributes["log.type"]
             value: "journald"
+{{- end }}
 
       k8s_events:
         auth_type: serviceAccount
 
+{{- if .Values.auditLogs.logsCollector.containerd.enabled }}
       filelog/containerd:
         include_file_path: true
         include: [ /var/log/pods/*.log ]
@@ -110,6 +113,7 @@ spec:
             type: add
             field: attributes["log.type"]
             value: "containerd"
+{{- end }}
 
 {{- if .Values.auditLogs.logsCollector.auditd.enabled }}
   {{- include "auditd.receiver" . | nindent 6 -}}
@@ -128,7 +132,7 @@ spec:
             value: kube-audit
           - type: timestamp
             parse_from: body.stageTimestamp
-            layout: "2010-01-02T15:04:05.999999Z"
+            layout: "2006-01-02T15:04:05.999999Z"
 {{- end }}
 
     processors:
@@ -193,6 +197,8 @@ spec:
 {{- if .Values.auditLogs.openSearchLogs.failover.enabled }}
   {{- include "failover.attributes" . | nindent 6 -}}
 {{- end }}
+
+{{- if .Values.auditLogs.logsCollector.journald.enabled }}
       transform/journal:
         error_mode: ignore
         log_statements:
@@ -229,7 +235,9 @@ spec:
               - set(log.attributes["cursor"], log.cache["__CURSOR"])
               - set(log.attributes["monotonic_timestamp"], log.cache["__MONOTONIC_TIMESTAMP"])
               - delete_key(attributes, "log.cache")
+{{- end }}
 
+{{- if .Values.auditLogs.logsCollector.containerd.enabled }}
       transform/ingress:
         error_mode: ignore
         log_statements:
@@ -240,6 +248,7 @@ spec:
               - merge_maps(log.attributes, ExtractGrokPatterns(log.body, "%{IP:client.address} %{NOTSPACE:client.ident} %{NOTSPACE:client.auth} \\[%{HTTPDATE:timestamp}\\] \"%{WORD:request_method} %{NOTSPACE:request_path} %{WORD:network.protocol.name}/%{NOTSPACE:network.protocol.version}\" %{NUMBER:response} %{NUMBER:content_length:int} %{QUOTEDSTRING} \"%{GREEDYDATA:user_agent}\" %{NUMBER:request_length:int} %{BASE10NUM:request_time:float}( \\[%{NOTSPACE:service}\\])? ?(\\[\\])? %{IP:server.address}\\:%{NUMBER:server.port} %{NUMBER:upstream_response_length:int} %{BASE10NUM:upstream_response_time:float} %{NOTSPACE:upstream_status} %{NOTSPACE:request_id}", true),"upsert")
               - set(log.attributes["network.protocol.name"], ConvertCase(attributes["network.protocol.name"], "lower")) where log.attributes["network.protocol.name"] != nil
               - set(log.attributes["config.parsed"], "ingress-nginx") where log.attributes["client.address"] != nil
+{{- end }}
 
       k8sattributes:
         auth_type: "serviceAccount"
@@ -414,12 +423,17 @@ spec:
           exporters: [forward]
 {{- end }}
 
+{{- if .Values.auditLogs.logsCollector.containerd.enabled }}
         logs/containerd:
           receivers: [filelog/containerd]
           processors: [k8sattributes,attributes/cluster,transform/ingress,batch]
           exporters: [forward]
+{{- end }}
+
+{{- if .Values.auditLogs.logsCollector.journald.enabled }}
         logs/journald:
           receivers: [journald]
           processors: [attributes/cluster,transform/journal,batch]
           exporters: [forward]
+{{- end }}
 {{- end }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -27,6 +27,12 @@ auditLogs:
     kubeApiAudit:
       # -- Activates export for kube-apiserver audit logs
       enabled: false
+    containerd:
+      # -- Activates ingestion of container stdout/stderr logs from /var/log/pods
+      enabled: false
+    journald:
+        # -- Activates ingestion of systemd journal logs
+      enabled: false
   openSearchLogs:
     # -- Endpoint URL for OpenSearch
     endpoint:

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -32,6 +32,8 @@ auditLogs:
     endpoint:
     # -- Name for OpenSearch index
     index:
+    # -- Timeout for OpenSearch requests
+    timeout: 30s
     # -- Username for OpenSearch endpoint
     failover_username_a:
     # -- Password for OpenSearch endpoint

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.0.16
+    version: 0.0.17
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.0.16
+        version: 0.0.17
     options:
         - name: auditLogs.region
           description: Region label for logging

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -93,3 +93,13 @@ spec:
           description: Enable k8s kube-apiserver audit logs ingestion
           required: false
           type: bool
+        - name: auditLogs.logsCollector.containerd.enabled
+          default: false
+          description: Enable container logs (stdout/stderr) ingestion
+          required: false
+          type: bool
+        - name: auditLogs.logsCollector.journald.enabled
+          default: false
+          description: Enable systemd journal logs ingestion
+          required: false
+          type: bool


### PR DESCRIPTION
- add unique identifier for kube audit logs - `attributes.log.type=kube-audit`
- fix logs timestamp parsing
- remove raw `body` field from log
- make `journald` and `containerd` logs collection optional
- add retry mechanism to prevent logs loss (by Timo)