### PR TITLE
Fix timestamp field parsing config

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.0.17
+version: 0.0.18
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -15,6 +15,10 @@ metadata:
   {{- end }}
 spec:
   mode: daemonset
+  {{- if .Values.auditLogs.nodeSelector }}
+  nodeSelector:
+    {{- toYaml .Values.auditLogs.nodeSelector | nindent 4 }}
+  {{- end }}
   hostPID: true
   securityContext:
     privileged: true

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -127,12 +127,12 @@ spec:
           - id: kube-audit-json
             type: json_parser
             parse_to: body
+            timestamp:
+              parse_from: body.stageTimestamp
+              layout: "2006-01-02T15:04:05.999999Z"
           - type: add
             field: attributes["log.type"]
             value: kube-audit
-          - type: timestamp
-            parse_from: body.stageTimestamp
-            layout: "2006-01-02T15:04:05.999999Z"
 {{- end }}
 
     processors:

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -6,6 +6,8 @@ commonLabels:
 
 auditLogs:
 
+  nodeSelector: {}
+
   collectorImage:
     # -- overrides the default image repository for the OpenTelemetry Collector image.
     repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -23,6 +23,10 @@ spec:
           description: Cluster label for logging
           required: false
           type: string
+        - name: auditLogs.nodeSelector
+          description: Node selector for the collector pods
+          required: false
+          type: map
         - name: auditLogs.openSearchLogs.endpoint
           description: Endpoint URL for OpenSearch
           required: false

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.0.17
+    version: 0.0.18
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.0.17
+        version: 0.0.18
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
Fixes
```
<rt-qa-de-1/audit-logs> ~ % ukl audit-logs-collector-g85br -n audit-logs
Error: failed to get config: cannot unmarshal the configuration: decoding failed due to the following error(s):

'receivers' error reading configuration for "filelog/kube_audit": decoding failed due to the following error(s):

'operators[2]' unsupported type 'timestamp'
```

schema docs
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/types/timestamp.md
https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/pkg/stanza/docs/operators/json_parser.md


And added ability to configure node selector (e.g. to enable plugin only for control plane nodes)
node selector field schema https://github.com/open-telemetry/opentelemetry-operator/blob/main/docs/api/opentelemetrycollectors.md?plain=1#L267