### PR TITLE
Audit-logs: another fix for timestamp parsing + remove unnecessary attr

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.0.19
+version: 0.0.20
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -133,8 +133,10 @@ spec:
             parse_to: attributes
             timestamp:
               layout_type: gotime
-              parse_from: body.stageTimestamp
+              parse_from: attributes.stageTimestamp
               layout: "2006-01-02T15:04:05.999999Z"
+          - type: remove
+            field: body
           - type: add
             field: attributes["log.type"]
             value: kube-audit

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.0.19
+    version: 0.0.20
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.0.19
+        version: 0.0.20
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
- fix timestamp attr parsing
- remove unnecessary `body` filed, as it is already parsed into attributes