### PR TITLE
fix(opensearch): reduce alerts to actionable set and use correct labels

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.56
+version: 0.0.57
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -4,79 +4,53 @@ groups:
     interval: 30s
     rules:
       - alert: OpenSearchClusterRed
-        expr: opensearch_cluster_status == 2
+        expr: |
+          (sum by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          /
+          (count by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          == 2
         for: 5m
         labels:
           severity: info # critical
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterRed.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          summary: "OpenSearch cluster status is RED"
-          description: "OpenSearch cluster {{`{{ $labels.cluster }}`}} is in RED status for more than 5 minutes"
+          summary: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is RED"
+          description: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is in RED status for more than 5 minutes"
 
       - alert: OpenSearchClusterYellow
-        expr: opensearch_cluster_status == 1
-        for: 20m
+        expr: |
+          (sum by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          /
+          (count by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          == 1
+        for: 120m
         labels:
           severity: info # warning
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterYellow.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          summary: "OpenSearch cluster status is YELLOW"
-          description: "OpenSearch cluster {{`{{ $labels.cluster }}`}} is in YELLOW status for more than 20 minutes"
+          summary: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is YELLOW"
+          description: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
 
-      - alert: OpenSearchNodeDown
-        expr: up{job=~".*opensearch.*"} == 0
-        for: 10m
+      - alert: OpenSearchDiskSpaceRunningLow
+        expr: predict_linear(opensearch_fs_total_free_bytes[24h], 24*3600) < 0
+        for: 1h
         labels:
           severity: info # critical
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchNodeDown.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "OpenSearch node is down"
-          description: "OpenSearch node {{`{{ $labels.instance }}`}} has been down for more than 10 minutes"
-
-      - alert: OpenSearchHighMemoryUsage
-        expr: (opensearch_jvm_mem_heap_used_bytes / opensearch_jvm_mem_heap_max_bytes) * 100 > 95
-        for: 15m
-        labels:
-          severity: info # warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighMemoryUsage.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "High JVM heap memory usage"
-          description: "OpenSearch node {{`{{ $labels.instance }}`}} heap memory usage is above 95% ({{`{{ $value }}`}}%)"
-
-      - alert: OpenSearchHighCPUUsage
-        # Improved: Use opensearch_process_cpu_percent for direct CPU usage percentage
-        expr: opensearch_process_cpu_percent > 95
-        for: 20m
-        labels:
-          severity: info # warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighCPUUsage.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "High CPU usage"
-          description: "OpenSearch node {{`{{ $labels.instance }}`}} CPU usage is above 95% ({{`{{ $value }}`}}%)"
-
-      - alert: OpenSearchHighDiskUsage
-        expr: 100 * (1 - (opensearch_fs_total_free_bytes / opensearch_fs_total_total_bytes)) > 90
-        for: 10m
-        labels:
-          severity: info # warning
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighDiskUsage.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          summary: "High disk usage"
-          description: "OpenSearch node {{`{{ $labels.instance }}`}} disk usage is above 90% ({{`{{ $value }}`}}%)"
+          summary: "OpenSearch disk space predicted to run out"
+          description: "OpenSearch node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is predicted to run out of disk space within 24 hours"
 
       - alert: OpenSearchIndexSizeTooLarge
-        expr: (max by (cluster, region, elastic_cluster, index) (opensearch_index_store_size_bytes{context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(cluster, region, elastic_cluster, index) (rate(opensearch_index_doc_number{context="primaries", index=~".ds.*"}[15m]) > 1)
+        expr: (max by (opster_io_opensearch_cluster, index) (opensearch_index_store_size_bytes{context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opster_io_opensearch_cluster, index) (rate(opensearch_index_doc_number{context="primaries", index=~".ds.*"}[15m]) > 1)
         for: 30m
         labels:
           severity: info # warning
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchIndexTooLarge.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          description: "The index {{`{{ $labels.index }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."
           summary: "Index size of {{`{{ $labels.index }}`}} has exceeded the threshold."
+          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."

--- a/opensearch/chart/alerts/opensearch-operator.yaml
+++ b/opensearch/chart/alerts/opensearch-operator.yaml
@@ -1,79 +1,17 @@
-# All alert severities are set to 'info' for setup only. Original severity is preserved as a comment on each line.
+# Operator alerts are disabled until the operator ServiceMonitor bug is fixed.
+# Uncomment the rules below once the ServiceMonitor is working again.
 groups:
   - name: opensearch-operator
     interval: 30s
-    rules:
-      - alert: OpenSearchOperatorDown
-        expr: up{job=~".*opensearch-operator.*"} == 0
-        for: 10m
-        labels:
-          severity: info # critical
-          component: opensearch-operator
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorDown.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "OpenSearch operator is down"
-          description: "OpenSearch operator in namespace {{`{{ $labels.namespace }}`}} has been down for more than 10 minutes"
-
-      - alert: OpenSearchOperatorReconcileErrors
-        expr: increase(opensearch_operator_controller_runtime_reconcile_errors_total[10m]) > 10
-        for: 10m
-        labels:
-          severity: info # warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorReconcileErrors.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "OpenSearch operator reconcile errors"
-          description: "OpenSearch operator controller {{`{{ $labels.controller }}`}} has {{`{{ $value }}`}} reconcile errors in the last 10 minutes"
-
-      - alert: OpenSearchOperatorHighReconcileTime
-        expr: |
-          avg by (controller) (
-            rate(opensearch_operator_controller_runtime_reconcile_time_seconds_sum[10m])
-            /
-            rate(opensearch_operator_controller_runtime_reconcile_time_seconds_count[10m])
-          ) > 60
-        for: 10m
-        labels:
-          severity: info # warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorHighReconcileTime.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "High operator reconcile time"
-          description: "OpenSearch operator average reconcile time is above 60s ({{`{{ $value }}`}}s)"
-
-      - alert: OpenSearchOperatorHighMemoryUsage
-        expr: |
-          (
-            container_memory_working_set_bytes{container="operator-controller-manager", namespace="{{ .Release.Namespace }}"}
-            /
-            on(namespace, pod, container)
-            group_left(resource)
-            kube_pod_container_resource_limits{container="operator-controller-manager", namespace="{{ .Release.Namespace }}", resource="memory"}
-          ) * 100 > 95
-        for: 15m
-        labels:
-          severity: info # warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorHighMemoryUsage.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "High operator memory usage"
-          description: "OpenSearch operator memory usage is above 95% of its memory limit ({{`{{ $value }}`}}%)"
-
-      - alert: OpenSearchOperatorHighCPUUsage
-        expr: |
-          (
-            rate(container_cpu_usage_seconds_total{container="operator-controller-manager", namespace="{{ .Release.Namespace }}"}[5m])
-            /
-            on(namespace, pod, container)
-            group_left(resource)
-            kube_pod_container_resource_limits{container="operator-controller-manager", namespace="{{ .Release.Namespace }}", resource="cpu"}
-          ) * 100 > 95
-        for: 20m
-        labels:
-          severity: info # warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorHighCPUUsage.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "High operator CPU usage"
-          description: "OpenSearch operator CPU usage is above 95% of its CPU limit ({{`{{ $value }}`}}%)"
+    rules: []
+#     - alert: OpenSearchOperatorDown
+#       expr: up{job=~".*opensearch-operator.*"} == 0
+#       for: 10m
+#       labels:
+#         severity: info # critical
+#         component: opensearch-operator
+#         playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorDown.md
+#         {{- include "opensearch-alert-labels" . | nindent 10 }}
+#       annotations:
+#         summary: "OpenSearch operator is down"
+#         description: "OpenSearch operator in namespace {{`{{ $labels.namespace }}`}} has been down for more than 10 minutes"

--- a/opensearch/chart/templates/service-monitor-operator.yaml
+++ b/opensearch/chart/templates/service-monitor-operator.yaml
@@ -1,52 +1,55 @@
-{{- if .Values.cluster.cluster.general.monitoring.enable }}
-# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
-# SPDX-License-Identifier: Apache-2.0
-apiVersion: monitoring.coreos.com/v1
-kind: ServiceMonitor
-metadata:
-  name: {{ .Values.cluster.cluster.name | default .Release.Name }}-operator-metrics
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "opensearch.labels" . | nindent 4 }}
-    {{- if .Values.cluster.cluster.general.monitoring.labels }}
-    {{- toYaml .Values.cluster.cluster.general.monitoring.labels | nindent 4 }}
-    {{- end }}
-spec:
-  selector:
-    matchLabels:
-      control-plane: controller-manager
-  endpoints:
-  {{- if .Values.operator.kubeRbacProxy.enable }}
-  - port: https
-    path: /metrics
-    scheme: https
-    interval: {{ .Values.cluster.cluster.general.monitoring.scrapeInterval | default "30s" }}
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    tlsConfig:
-      {{- if .Values.cluster.cluster.general.monitoring.tlsConfig }}
-      {{- toYaml .Values.cluster.cluster.general.monitoring.tlsConfig | nindent 6 }}
-      {{- else }}
-      insecureSkipVerify: true
-      {{- end }}
-    metricRelabelings:
-      - sourceLabels: [__name__]
-        regex: "(.*)"
-        targetLabel: __name__
-        replacement: "opensearch_operator_$1"
-        action: replace
-  {{- else }}
-  - port: http
-    path: /metrics
-    scheme: http
-    interval: {{ .Values.cluster.cluster.general.monitoring.scrapeInterval | default "30s" }}
-    metricRelabelings:
-      - sourceLabels: [__name__]
-        regex: "(.*)"
-        targetLabel: __name__
-        replacement: "opensearch_operator_$1"
-        action: replace
-  {{- end }}
-  namespaceSelector:
-    matchNames:
-    - {{ .Release.Namespace }}
-{{- end }}
+# Operator ServiceMonitor is disabled until the operator metrics bug is fixed.
+# Uncomment the template below once the operator exposes metrics correctly.
+#
+# {{- if .Values.cluster.cluster.general.monitoring.enable }}
+# # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# # SPDX-License-Identifier: Apache-2.0
+# apiVersion: monitoring.coreos.com/v1
+# kind: ServiceMonitor
+# metadata:
+#   name: {{ .Values.cluster.cluster.name | default .Release.Name }}-operator-metrics
+#   namespace: {{ .Release.Namespace }}
+#   labels:
+#     {{- include "opensearch.labels" . | nindent 4 }}
+#     {{- if .Values.cluster.cluster.general.monitoring.labels }}
+#     {{- toYaml .Values.cluster.cluster.general.monitoring.labels | nindent 4 }}
+#     {{- end }}
+# spec:
+#   selector:
+#     matchLabels:
+#       control-plane: controller-manager
+#   endpoints:
+#   {{- if .Values.operator.kubeRbacProxy.enable }}
+#   - port: https
+#     path: /metrics
+#     scheme: https
+#     interval: {{ .Values.cluster.cluster.general.monitoring.scrapeInterval | default "30s" }}
+#     bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+#     tlsConfig:
+#       {{- if .Values.cluster.cluster.general.monitoring.tlsConfig }}
+#       {{- toYaml .Values.cluster.cluster.general.monitoring.tlsConfig | nindent 6 }}
+#       {{- else }}
+#       insecureSkipVerify: true
+#       {{- end }}
+#     metricRelabelings:
+#       - sourceLabels: [__name__]
+#         regex: "(.*)"
+#         targetLabel: __name__
+#         replacement: "opensearch_operator_$1"
+#         action: replace
+#   {{- else }}
+#   - port: http
+#     path: /metrics
+#     scheme: http
+#     interval: {{ .Values.cluster.cluster.general.monitoring.scrapeInterval | default "30s" }}
+#     metricRelabelings:
+#       - sourceLabels: [__name__]
+#         regex: "(.*)"
+#         targetLabel: __name__
+#         replacement: "opensearch_operator_$1"
+#         action: replace
+#   {{- end }}
+#   namespaceSelector:
+#     matchNames:
+#     - {{ .Release.Namespace }}
+# {{- end }}

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.56
+  version: 0.0.57
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.56
+    version: 0.0.57
   options:
     - name: cluster.cluster.general.monitoring.pluginUrl
       description: "Defines a custom URL for the monitoring plugin. Leave blank to use the default monitoring configuration."


### PR DESCRIPTION
## Pull Request Details

- Reduced cluster alerts from 7 noisy alerts to 4 actionable ones: ClusterRed, ClusterYellow, DiskSpaceRunningLow, IndexSizeTooLarge
- Used `opster_io_opensearch_cluster` label to correctly distinguish opensearch-logs and opensearch-siem clusters (the native OpenSearch `cluster` label gets overwritten by the Prometheus external label)
- Used `sum/count` averaging for cluster status to deduplicate per-node reporting
- Replaced static disk threshold with `predict_linear` 24h prediction
- Disabled operator ServiceMonitor and alerts until we use new operator version where metrics bug is fixed (https://github.com/opensearch-project/opensearch-k8s-operator/pull/1391)
