### PR TITLE
chore(opensearch): upgrade to OpenSearch 3.6.0

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -124,10 +124,10 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.dashboards.tls.generate | bool | `false` | generate certificate, if false secret must be provided |
 | cluster.cluster.dashboards.tls.secret | object | `{"name":"opensearch-http-cert"}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.cluster.dashboards.tolerations | list | `[]` | dashboards pod tolerations |
-| cluster.cluster.dashboards.version | string | `"3.5.0"` | dashboards version |
+| cluster.cluster.dashboards.version | string | `"3.6.0"` | dashboards version |
 | cluster.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
 | cluster.cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
-| cluster.cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
+| cluster.cluster.general.drainDataNodes | bool | `false` | Controls whether to drain data notes on rolling restart operations |
 | cluster.cluster.general.httpPort | int | `9200` | Opensearch service http port |
 | cluster.cluster.general.image | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
 | cluster.cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
@@ -135,7 +135,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.general.monitoring.enable | bool | `true` | Enable cluster monitoring |
 | cluster.cluster.general.monitoring.labels | object | `{}` | ServiceMonitor labels |
 | cluster.cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
-| cluster.cluster.general.monitoring.pluginUrl | string | `"https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.5.0.0/prometheus-exporter-3.5.0.0.zip"` | Custom URL for the monitoring plugin |
+| cluster.cluster.general.monitoring.pluginUrl | string | `"https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip"` | Custom URL for the monitoring plugin |
 | cluster.cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |
 | cluster.cluster.general.monitoring.tlsConfig | object | `{"insecureSkipVerify":true}` | Override the tlsConfig of the generated ServiceMonitor |
 | cluster.cluster.general.pluginsList | list | `[]` | List of Opensearch plugins to install |
@@ -146,7 +146,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.general.setVMMaxMapCount | bool | `true` | Enable setVMMaxMapCount. OpenSearch requires the Linux kernel vm.max_map_count option to be set to at least 262144 |
 | cluster.cluster.general.snapshotRepositories | list | `[]` | Opensearch snapshot repositories configuration |
 | cluster.cluster.general.vendor | string | `"Opensearch"` |  |
-| cluster.cluster.general.version | string | `"3.5.0"` | Opensearch version |
+| cluster.cluster.general.version | string | `"3.6.0"` | Opensearch version |
 | cluster.cluster.ingress.dashboards.annotations | object | `{}` | dashboards ingress annotations |
 | cluster.cluster.ingress.dashboards.className | string | `""` | Ingress class name |
 | cluster.cluster.ingress.dashboards.enabled | bool | `false` | Enable ingress for dashboards service |
@@ -309,10 +309,10 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | siem.cluster.dashboards.tls.generate | bool | `false` | generate certificate, if false secret must be provided |
 | siem.cluster.dashboards.tls.secret | object | `{"name":"opensearch-siem-http-cert"}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | siem.cluster.dashboards.tolerations | list | `[]` | dashboards pod tolerations |
-| siem.cluster.dashboards.version | string | `"3.5.0"` | dashboards version |
+| siem.cluster.dashboards.version | string | `"3.6.0"` | dashboards version |
 | siem.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
 | siem.cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
-| siem.cluster.general.drainDataNodes | bool | `true` | Controls whether to drain data notes on rolling restart operations |
+| siem.cluster.general.drainDataNodes | bool | `false` | Controls whether to drain data notes on rolling restart operations |
 | siem.cluster.general.httpPort | int | `9200` | Opensearch service http port |
 | siem.cluster.general.image | string | `"docker.io/opensearchproject/opensearch"` | Opensearch image |
 | siem.cluster.general.imagePullPolicy | string | `"IfNotPresent"` | Default image pull policy |
@@ -320,7 +320,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | siem.cluster.general.monitoring.enable | bool | `true` | Enable cluster monitoring |
 | siem.cluster.general.monitoring.labels | object | `{}` | ServiceMonitor labels |
 | siem.cluster.general.monitoring.monitoringUserSecret | string | `""` | Secret with 'username' and 'password' keys for monitoring user. You could also use OpenSearchUser CRD instead of setting it. |
-| siem.cluster.general.monitoring.pluginUrl | string | `"https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.5.0.0/prometheus-exporter-3.5.0.0.zip"` | Custom URL for the monitoring plugin |
+| siem.cluster.general.monitoring.pluginUrl | string | `"https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip"` | Custom URL for the monitoring plugin |
 | siem.cluster.general.monitoring.scrapeInterval | string | `"30s"` | How often to scrape metrics |
 | siem.cluster.general.monitoring.tlsConfig | object | `{"insecureSkipVerify":true}` | Override the tlsConfig of the generated ServiceMonitor |
 | siem.cluster.general.pluginsList | list | `[]` | List of Opensearch plugins to install |
@@ -331,7 +331,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | siem.cluster.general.setVMMaxMapCount | bool | `true` | Enable setVMMaxMapCount. OpenSearch requires the Linux kernel vm.max_map_count option to be set to at least 262144 |
 | siem.cluster.general.snapshotRepositories | list | `[]` | Opensearch snapshot repositories configuration |
 | siem.cluster.general.vendor | string | `"Opensearch"` |  |
-| siem.cluster.general.version | string | `"3.5.0"` | Opensearch version |
+| siem.cluster.general.version | string | `"3.6.0"` | Opensearch version |
 | siem.cluster.ingress.dashboards.annotations | object | `{}` | dashboards ingress annotations |
 | siem.cluster.ingress.dashboards.className | string | `""` | Ingress class name |
 | siem.cluster.ingress.dashboards.enabled | bool | `false` | Enable ingress for dashboards service |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.0.57
+version: 0.0.58
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:
@@ -13,7 +13,7 @@ maintainers:
 home: https://github.com/sapcc/helm-charts/tree/master/system/opensearch-operator
 sources:
   - https://github.com/opensearch-project/opensearch-k8s-operator
-appVersion: v3.5.0
+appVersion: v3.6.0
 dependencies:
   - name: opensearch-operator
     alias: operator

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -240,7 +240,7 @@ cluster:
         #   restartPods: false
 
       # -- Controls whether to drain data notes on rolling restart operations
-      drainDataNodes: true
+      drainDataNodes: false
 
       # -- Opensearch service http port
       httpPort: 9200
@@ -273,7 +273,7 @@ cluster:
         monitoringUserSecret: ""
 
         # -- Custom URL for the monitoring plugin
-        pluginUrl: "https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.5.0.0/prometheus-exporter-3.5.0.0.zip"
+        pluginUrl: "https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip"
 
         # -- How often to scrape metrics
         scrapeInterval: 30s
@@ -315,7 +315,7 @@ cluster:
       vendor: Opensearch
 
       # -- Opensearch version
-      version: 3.5.0
+      version: 3.6.0
 
     # OpenSearchCluster boostrap pod configuration
     bootstrap:
@@ -453,7 +453,7 @@ cluster:
       tolerations: []
 
       # -- dashboards version
-      version: 3.5.0
+      version: 3.6.0
 
     # initHelper configuration
     initHelper:
@@ -962,7 +962,7 @@ siem:
         #   restartPods: false
 
       # -- Controls whether to drain data notes on rolling restart operations
-      drainDataNodes: true
+      drainDataNodes: false
 
       # -- Opensearch service http port
       httpPort: 9200
@@ -995,7 +995,7 @@ siem:
         monitoringUserSecret: ""
 
         # -- Custom URL for the monitoring plugin
-        pluginUrl: "https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.5.0.0/prometheus-exporter-3.5.0.0.zip"
+        pluginUrl: "https://github.com/opensearch-project/opensearch-prometheus-exporter/releases/download/3.6.0.0/prometheus-exporter-3.6.0.0.zip"
 
         # -- How often to scrape metrics
         scrapeInterval: 30s
@@ -1037,7 +1037,7 @@ siem:
       vendor: Opensearch
 
       # -- Opensearch version
-      version: 3.5.0
+      version: 3.6.0
 
     # OpenSearchCluster boostrap pod configuration
     bootstrap:
@@ -1175,7 +1175,7 @@ siem:
       tolerations: []
 
       # -- dashboards version
-      version: 3.5.0
+      version: 3.6.0
 
     # initHelper configuration
     initHelper:

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.0.57
+  version: 0.0.58
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.0.57
+    version: 0.0.58
   options:
     - name: cluster.cluster.general.monitoring.pluginUrl
       description: "Defines a custom URL for the monitoring plugin. Leave blank to use the default monitoring configuration."


### PR DESCRIPTION
## Pull Request Details

- Upgrade OpenSearch and Dashboards version to 3.6.0 (latest)
- Bump prometheus exporter plugin URL to 3.6.0.0
- Disable drainDataNodes by default for both main and SIEM clusters (not needed)
