### PR TITLE
chore(logs): add no_alert_on_absence label for missing metrics

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: logs
-version: 0.1.6
+version: 0.1.7
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/alerts.yaml
+++ b/logs/charts/templates/alerts.yaml
@@ -23,6 +23,7 @@ spec:
         for: 5m
         labels:
           severity: warning
+          no_alert_on_absence: "true" # OTel will not expose the metric if null 
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/logs/playbooks/FilelogRefusedLogs.md
           {{- include "plugin.additionalRuleLabels" . | nindent 10 }}
         annotations:
@@ -36,6 +37,7 @@ spec:
         for: 5m
         labels:
           severity: warning
+          no_alert_on_absence: "true" # OTel will not expose the metric if null
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/logs/playbooks/ReceiverRefusedMetric.md
           {{- include "plugin.additionalRuleLabels" . | nindent 10 }}
         annotations:
@@ -75,6 +77,7 @@ spec:
         for: 1h
         labels:
           severity: info
+          no_alert_on_absence: "true" # OTel will not expose the metric if null 
           playbook: 'docs/support/playbook/logs/otel-logs-exporting-failed'
           {{- include "plugin.additionalRuleLabels" . | nindent 10 }}
         annotations:
@@ -91,7 +94,7 @@ spec:
           {{- include "plugin.additionalRuleLabels" . | nindent 10 }}
         annotations:
           summary: OpenTelemetryCollector Reconciliation
-          description: Reconciliation errors for opentelemetrycollector are increasing
+          description: Reconciliation errors for OTel are increasing
   {{- end }}
 
   {{- if and (has "WorkqueueDepth" .Values.openTelemetry.prometheus.rules.enabled) (".Values.opentelemetry-operator.enabled") }}
@@ -104,6 +107,6 @@ spec:
           {{- include "plugin.additionalRuleLabels" . | nindent 10 }}
         annotations:
           summary: WorkqueueDepth is increasing
-          description: Check manager logs for reasons why this might happen
+          description: Check OTel manager logs for reasons why this might happen
   {{- end }}
 {{- end }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.12.6
+  version: 0.12.7
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.6
+    version: 0.1.7
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Using the [absent-metrics-operator](https://github.com/cloudoperators/absent-metrics-operator/blob/master/docs/playbook.md) absent metrics alerts were triggered due to OTel not exposing the metrics if they are null. This will fix it. 