### PR TITLE
Add cluster name, region, service label and support group label to Heureka k8s asserts scanner plugin definition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,10 +41,10 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /service-proxy/           @cloudoperators/greenhouse-backend
 /thanos/                  @cloudoperators/greenhouse-observability
 ui/                       @cloudoperators/greenhouse-frontend
-/heureka/                 @cloudoperators/greenhouse-src @cloudoperators/greenhouse-frontend @dimtas
-/heureka-scanner-k8s-assets/     @cloudoperators/greenhouse-src @dimtas
-/heureka-scanner-keppel/  @cloudoperators/greenhouse-src @dimtas
-/heureka-scanner-nvd/     @cloudoperators/greenhouse-src @dimtas
+/heureka/                 @cloudoperators/greenhouse-src @cloudoperators/greenhouse-frontend @dimtas @mr2011 @mdrkb
+/heureka-scanner-k8s-assets/     @cloudoperators/greenhouse-src @dimtas @mr2011 @mdrkb
+/heureka-scanner-keppel/  @cloudoperators/greenhouse-src @dimtas @mr2011 @mdrkb
+/heureka-scanner-nvd/     @cloudoperators/greenhouse-src @dimtas @mr2011 @mdrkb
 /repo-guard/              @cloudoperators/greenhouse-backend
 /reloader/                @cloudoperators/greenhouse-backend
 /owner-label-injector/    @cloudoperators/greenhouse-backend

--- a/heureka-scanner-k8s-assets/plugindefinition.yaml
+++ b/heureka-scanner-k8s-assets/plugindefinition.yaml
@@ -22,6 +22,14 @@ spec:
       description: The URL of the Heureka API
       required: true
       type: string
+    - name: scanner.k8s_cluster_name
+      description: Cluster name
+      required: true
+      type: string
+    - name: scanner.k8s_cluster_region
+      description: Cluster region
+      required: true
+      type: string
     - name: scanner.schedule
       description: The schedule for the Heureka Scanner. Use a cron expression (e.g. "0 * * * *")
       required: false
@@ -32,3 +40,11 @@ spec:
       required: false
       type: string
       default: "2h"
+    - name: scanner.service_label
+      description: Pod label indicating the service name
+      type: string
+      default: "ccloud/service"
+    - name: scanner.support_group_label
+      description: Pod label indicating the support group
+      type: string
+      default: "ccloud/support-group"

--- a/heureka-scanner-k8s-assets/plugindefinition.yaml
+++ b/heureka-scanner-k8s-assets/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: heureka-scanner-k8s-assets
 spec:
-  version: 0.1.2
+  version: 0.1.3
   displayName: Heureka Scanner for K8s Assets
   description: The scanner discovers and reports Kubernetes assets (pods, containers, images) to Heureka
   helmChart:
@@ -22,14 +22,6 @@ spec:
       description: The URL of the Heureka API
       required: true
       type: string
-    - name: scanner.k8s_cluster_name
-      description: Cluster name
-      required: true
-      type: string
-    - name: scanner.k8s_cluster_region
-      description: Cluster region
-      required: true
-      type: string
     - name: scanner.schedule
       description: The schedule for the Heureka Scanner. Use a cron expression (e.g. "0 * * * *")
       required: false
@@ -40,11 +32,21 @@ spec:
       required: false
       type: string
       default: "2h"
+    - name: scanner.k8s_cluster_name
+      required: false
+      description: Cluster name
+      type: string
+    - name: scanner.k8s_cluster_region
+      required: false
+      description: Cluster region
+      type: string
     - name: scanner.service_label
       description: Pod label indicating the service name
+      required: false
       type: string
       default: "ccloud/service"
     - name: scanner.support_group_label
       description: Pod label indicating the support group
+      required: false
       type: string
       default: "ccloud/support-group"


### PR DESCRIPTION
In production, Heureka `ComponentInstances` are created with empty region, cluster, service label and support group label. The cronjob template referenced these values but they were never defined, causing them to render as empty strings. Additionally in Greenhouse dashboard, the compliance vulnerabilities cannot be filtered by service name or support group.

**ToDo:**
- Add missing `k8s_cluster_name`, `k8s_cluster_region`, `service_label` and `support_group_label` keys to the `k8s-assets-scanner` Helm `values.yaml `.
- Update code owners for Heureka related repos.