### PR TITLE
Update heureka k8s assets scanner plugin definition

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -27,7 +27,6 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /doop/                    @andypf @artiereus @edda @hodanoori @tilmanhaupt @uwe-mayer
 /exposed-services/        @cloudoperators/greenhouse-backend
 /external-dns/            @cloudoperators/greenhouse-backend
-/heureka/                 @andypf @artiereus @edda @hodanoori @tilmanhaupt @uwe-mayer
 /ingress-nginx/           @cloudoperators/greenhouse-backend
 /kafka/                   @cloudoperators/greenhouse-observability
 /kube-monitoring/         @cloudoperators/greenhouse-observability
@@ -41,10 +40,10 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /service-proxy/           @cloudoperators/greenhouse-backend
 /thanos/                  @cloudoperators/greenhouse-observability
 ui/                       @cloudoperators/greenhouse-frontend
-/heureka/                 @cloudoperators/greenhouse-src @cloudoperators/greenhouse-frontend @dimtas
-/heureka-scanner-k8s-assets/     @cloudoperators/greenhouse-src @dimtas
-/heureka-scanner-keppel/  @cloudoperators/greenhouse-src @dimtas
-/heureka-scanner-nvd/     @cloudoperators/greenhouse-src @dimtas
+/heureka/                 @cloudoperators/greenhouse-src @cloudoperators/greenhouse-frontend
+/heureka-scanner-k8s-assets/     @cloudoperators/greenhouse-src
+/heureka-scanner-keppel/  @cloudoperators/greenhouse-src
+/heureka-scanner-nvd/     @cloudoperators/greenhouse-src
 /repo-guard/              @cloudoperators/greenhouse-backend
 /reloader/                @cloudoperators/greenhouse-backend
 /owner-label-injector/    @cloudoperators/greenhouse-backend

--- a/heureka-scanner-k8s-assets/plugindefinition.yaml
+++ b/heureka-scanner-k8s-assets/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: heureka-scanner-k8s-assets
 spec:
-  version: 0.1.2
+  version: 0.1.3
   displayName: Heureka Scanner for K8s Assets
   description: The scanner discovers and reports Kubernetes assets (pods, containers, images) to Heureka
   helmChart:
@@ -32,3 +32,21 @@ spec:
       required: false
       type: string
       default: "2h"
+    - name: scanner.k8s_cluster_name
+      required: false
+      description: Cluster name
+      type: string
+    - name: scanner.k8s_cluster_region
+      required: false
+      description: Cluster region
+      type: string
+    - name: scanner.service_label
+      description: Pod label indicating the service name
+      required: false
+      type: string
+      default: "ccloud/service"
+    - name: scanner.support_group_label
+      description: Pod label indicating the support group
+      required: false
+      type: string
+      default: "ccloud/support-group"


### PR DESCRIPTION
In production, heureka `ComponentInstances` are created with empty region, cluster, service label and support group label. The cronjob template referenced these values but they were never defined, causing them to render as empty strings. Additionally in Greenhouse dashboard, the compliance vulnerabilities cannot be filtered by service name or support group.

**ToDo:**

- Add missing `k8s_cluster_name`, `k8s_cluster_region`, `service_label` and `support_group_label` keys to the `k8s-assets-scanner` plugin definition.
- Update code owners for heureka related repos.