### PR TITLE
fix(kube-monitoring): incorporate PrometheusRule with thanos-ruler label for absent-metrics-operator

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 11.1.0
+version: 11.1.1
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -499,7 +499,7 @@ absentMetricsOperator:
   # @section -- absent-metrics-operator options
   enabled: false
   # @ignored
-  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else }}{{ index .metadata.labels "prometheus" }}{{ end }}'
+  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else if index .metadata.labels "thanos-ruler" }}{{ index .metadata.labels "thanos-ruler" }}{{ else }}{{ index .metadata.labels "prometheus" }}{{ end }}'
   # @ignored
   image:
     registry: ghcr.io

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 11.1.0
+    version: 11.1.1
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 12.1.0
+  version: 12.1.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md


### PR DESCRIPTION
## Pull Request Details

The absent-metrics-operator logs errors and has issues processing PrometheusRules that include `thanos-ruler` labels, and neither `plugin` nor `prometheus`. This is the case, when PrometheusRules are processed by Thanos Rule.

According [to the docs](https://github.com/cloudoperators/absent-metrics-operator/blob/master/docs/absence-alert-rule-definition.md#aggregation) this is already the default, so let's not deviate here, and respect the `thanos-ruler` labels here too if present.