### PR TITLE
feat(doop-api): add PluginDefinition for the DOOP central API

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -26,6 +26,7 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /digicert-issuer/         @cloudoperators/greenhouse-backend
 /disco/                   @cloudoperators/greenhouse-backend
 /doop/                    @andypf @artiereus @edda @hodanoori @tilmanhaupt @uwe-mayer
+/doop-api/                @cloudoperators/greenhouse-backend
 /exposed-services/        @cloudoperators/greenhouse-backend
 /external-dns/            @cloudoperators/greenhouse-backend
 /gatekeeper/              @cloudoperators/greenhouse-backend

--- a/.github/workflows/ci-pr-build.yaml
+++ b/.github/workflows/ci-pr-build.yaml
@@ -34,6 +34,8 @@ jobs:
             chartName: blackbox-exporter
           - chartDir: cert-manager/charts
             chartName: cert-manager
+          - chartDir: doop-api/charts
+            chartName: doop-api
           - chartDir: exposed-services/charts/v2.0.0/exposed-service
             chartName: exposed-services
           - chartDir: gatekeeper/charts

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -12,6 +12,7 @@ on:
       - audit-logs/charts/**
       - blackbox-exporter/charts/**
       - cert-manager/charts/**
+      - doop-api/charts/**
       - exposed-services/charts/v1.0.0/exposed-service/**
       - exposed-services/charts/v2.0.0/exposed-service/**
       - gatekeeper/charts/**
@@ -59,6 +60,8 @@ jobs:
             chartName: blackbox-exporter
           - chartDir: cert-manager/charts
             chartName: cert-manager
+          - chartDir: doop-api/charts
+            chartName: doop-api
           - chartDir: exposed-services/charts/v1.0.0/exposed-service
             chartName: exposed-services
           - chartDir: exposed-services/charts/v2.0.0/exposed-service

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -11,6 +11,7 @@ This following table provides an overview of the currently available Plugins in 
 | digicert-issuer|Extensions to the cert-manager for DigiCert support|1.2.0|
 | disco|Automated DNS management using the Designate Ingress CNAME operator (DISCO)|1.0.0|
 | doop|Holistic overview on Gatekeeper policies and violations|1.0.0|
+| doop-api|Central API aggregating Gatekeeper audit reports for the DOOP UI|0.1.0|
 | exposed-service|A test plugin for validating service exposure via Greenhouse|1.0.0|
 | external-dns|The kubernetes-sigs/external-dns plugin.|1.0.0|
 | gatekeeper|Policy controller for Kubernetes admission based on the OPA constraint framework|1.0.0|

--- a/doop-api/README.md
+++ b/doop-api/README.md
@@ -1,0 +1,5 @@
+---
+title: DOOP API
+---
+
+Backend API for the [DOOP](https://github.com/sapcc/gatekeeper-addons) (Decentralized Observer of Policies) system. Reads Gatekeeper audit reports aggregated by per-cluster `doop-analyzer` pods from OpenStack Swift and serves them to the [`doop` UI plugin](../doop).

--- a/doop-api/charts/Chart.yaml
+++ b/doop-api/charts/Chart.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: doop-api
+description: Central API for the DOOP (Decentralized Observer of Policies) system. Reads Gatekeeper audit reports aggregated by per-cluster doop-analyzer pods from OpenStack Swift and serves them to the DOOP UI plugin.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: https://raw.githubusercontent.com/open-policy-agent/opa/main/logo/logo.png
+keywords:
+  - gatekeeper
+  - opa
+  - policy
+  - doop
+maintainers:
+  - name: ivogoman
+  - name: uwe-mayer

--- a/doop-api/charts/templates/_helpers.tpl
+++ b/doop-api/charts/templates/_helpers.tpl
@@ -1,0 +1,23 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- define "doop-api.labels" -}}
+app.kubernetes.io/name: doop-api
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: api
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "doop-api.selectorLabels" -}}
+app.kubernetes.io/name: doop-api
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/component: api
+{{- end -}}
+
+{{- define "doop-api.image" -}}
+{{- $repo := .Values.image.repository | required ".Values.image.repository is required" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}

--- a/doop-api/charts/templates/deployment.yaml
+++ b/doop-api/charts/templates/deployment.yaml
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    {{- include "doop-api.labels" . | nindent 4 }}
+spec:
+  revisionHistoryLimit: 5
+  replicas: {{ .Values.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 1
+  selector:
+    matchLabels:
+      {{- include "doop-api.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "doop-api.selectorLabels" . | nindent 8 }}
+      annotations:
+        kubectl.kubernetes.io/default-container: api
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: api
+          image: {{ include "doop-api.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["doop-api"]
+          env:
+            - name: DOOP_API_DEBUG
+              value: "false"
+            - name: DOOP_API_LISTEN_ADDRESS
+              value: ":8080"
+            - name: DOOP_API_OBJECT_IDENTITY_LABELS
+              value: {{ .Values.objectIdentityLabels | join " " | quote }}
+            - name: DOOP_API_SWIFT_CONTAINER
+              value: {{ .Values.swift.container | quote }}
+            - name: OS_AUTH_URL
+              value: {{ .Values.swift.authURL | required ".Values.swift.authURL is required" | quote }}
+            - name: OS_AUTH_VERSION
+              value: "3"
+            - name: OS_IDENTITY_API_VERSION
+              value: "3"
+            - name: OS_USER_DOMAIN_NAME
+              value: {{ .Values.swift.userDomain | quote }}
+            - name: OS_USERNAME
+              value: {{ .Values.swift.username | required ".Values.swift.username is required" | quote }}
+            - name: OS_PROJECT_DOMAIN_NAME
+              value: {{ .Values.swift.projectDomain | quote }}
+            - name: OS_PROJECT_NAME
+              value: {{ .Values.swift.projectName | required ".Values.swift.projectName is required" | quote }}
+            - name: OS_REGION_NAME
+              value: {{ .Values.swift.region | required ".Values.swift.region is required" | quote }}
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}
+                  key: swift_password
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/doop-api/charts/templates/ingress.yaml
+++ b/doop-api/charts/templates/ingress.yaml
@@ -1,0 +1,36 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+{{- if .Values.ingress.enabled }}
+{{- $host := .Values.ingress.host | required ".Values.ingress.host is required when ingress is enabled" }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    {{- include "doop-api.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- if .Values.ingress.tls.enabled }}
+  tls:
+    - hosts:
+        - {{ $host | quote }}
+      secretName: {{ .Values.ingress.tls.secretName | required ".Values.ingress.tls.secretName is required when tls is enabled" | quote }}
+  {{- end }}
+  rules:
+    - host: {{ $host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Release.Name }}-api
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/doop-api/charts/templates/secret.yaml
+++ b/doop-api/charts/templates/secret.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}
+  labels:
+    {{- include "doop-api.labels" . | nindent 4 }}
+type: Opaque
+data:
+  swift_password: {{ .Values.swift.password | required ".Values.swift.password is required" | b64enc | quote }}

--- a/doop-api/charts/templates/service.yaml
+++ b/doop-api/charts/templates/service.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-api
+  labels:
+    {{- include "doop-api.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "doop-api.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http

--- a/doop-api/charts/values.yaml
+++ b/doop-api/charts/values.yaml
@@ -1,0 +1,46 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+image:
+  repository: ghcr.io/cloudoperators/gatekeeper-addons
+  tag: ""
+  pullPolicy: IfNotPresent
+
+replicas: 1
+
+# object_identity labels propagated into violation metrics.
+objectIdentityLabels:
+  - support_group
+  - service
+  - status
+
+# Swift backend where doop-analyzer uploads audit reports.
+swift:
+  authURL: ""
+  username: ""
+  password: ""
+  userDomain: Default
+  projectName: ""
+  projectDomain: Default
+  region: ""
+  container: doop-analyzer
+
+service:
+  port: 80
+
+ingress:
+  enabled: false
+  className: ""
+  host: ""
+  annotations: {}
+  tls:
+    enabled: false
+    secretName: ""
+
+resources:
+  limits:
+    cpu: "2"
+    memory: 1Gi
+  requests:
+    cpu: 100m
+    memory: 1Gi

--- a/doop-api/plugindefinition.yaml
+++ b/doop-api/plugindefinition.yaml
@@ -1,0 +1,118 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: doop-api
+spec:
+  version: 0.1.0
+  displayName: DOOP API
+  description: Central API for the DOOP (Decentralized Observer of Policies) system that aggregates Gatekeeper audit reports from OpenStack Swift and serves them to the DOOP UI plugin.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/doop-api/README.md
+  icon: https://raw.githubusercontent.com/open-policy-agent/opa/main/logo/logo.png
+  helmChart:
+    name: doop-api
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    version: 0.1.0
+  options:
+    - name: image.repository
+      description: Container image repository for the gatekeeper-addons bundle. Override if you host the image elsewhere (SAP users use keppel.global.cloud.sap/ccloud/gatekeeper-addons).
+      default: ghcr.io/cloudoperators/gatekeeper-addons
+      required: false
+      type: string
+    - name: image.tag
+      description: Container image tag. If empty, the chart's appVersion is used.
+      required: false
+      type: string
+    - name: image.pullPolicy
+      description: Image pull policy.
+      default: IfNotPresent
+      required: false
+      type: string
+    - name: replicas
+      description: Number of doop-api replicas.
+      default: 1
+      required: false
+      type: int
+    - name: swift.authURL
+      description: OpenStack Keystone v3 auth URL.
+      required: true
+      type: string
+    - name: swift.username
+      description: OpenStack username with read access to the Swift container.
+      required: true
+      type: string
+    - name: swift.password
+      description: OpenStack password for the username above. Stored as a Kubernetes Secret.
+      required: true
+      type: secret
+    - name: swift.userDomain
+      description: OpenStack user domain name.
+      default: Default
+      required: false
+      type: string
+    - name: swift.projectName
+      description: OpenStack project that owns the Swift container.
+      required: true
+      type: string
+    - name: swift.projectDomain
+      description: OpenStack project domain name.
+      default: Default
+      required: false
+      type: string
+    - name: swift.region
+      description: OpenStack region for the Swift endpoint.
+      required: true
+      type: string
+    - name: swift.container
+      description: Swift container name where doop-analyzer uploads reports.
+      default: doop-analyzer
+      required: false
+      type: string
+    - name: objectIdentityLabels
+      description: Labels carried over from each violation's object_identity into the metric label set. Match this with the policies you run in your fleet.
+      default:
+        - support_group
+        - service
+        - status
+      required: false
+      type: list
+    - name: resources
+      description: Resource requests and limits for the doop-api container.
+      default:
+        limits:
+          cpu: "2"
+          memory: 1Gi
+        requests:
+          cpu: 100m
+          memory: 1Gi
+      required: false
+      type: map
+    - name: ingress.enabled
+      description: Expose the API via an Ingress resource.
+      default: false
+      required: false
+      type: bool
+    - name: ingress.host
+      description: Hostname for the Ingress. Required when ingress.enabled is true.
+      required: false
+      type: string
+    - name: ingress.className
+      description: Ingress class name.
+      required: false
+      type: string
+    - name: ingress.annotations
+      description: Annotations applied to the Ingress resource. Use this to configure ingress-controller-specific behaviour such as CORS, auth, or rate limits.
+      default: {}
+      required: false
+      type: map
+    - name: ingress.tls.enabled
+      description: Enable TLS on the Ingress.
+      default: false
+      required: false
+      type: bool
+    - name: ingress.tls.secretName
+      description: Existing Kubernetes Secret with TLS cert and key. Required when ingress.tls.enabled is true.
+      required: false
+      type: string

--- a/doop-api/plugindefinition.yaml
+++ b/doop-api/plugindefinition.yaml
@@ -17,7 +17,7 @@ spec:
     version: 0.1.0
   options:
     - name: image.repository
-      description: Container image repository for the gatekeeper-addons bundle. Override if you host the image elsewhere (SAP users use keppel.global.cloud.sap/ccloud/gatekeeper-addons).
+      description: Container image repository for the gatekeeper-addons bundle. Override if you host the image elsewhere.
       default: ghcr.io/cloudoperators/gatekeeper-addons
       required: false
       type: string

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -6,6 +6,7 @@ resources:
   - audit-logs/plugindefinition.yaml
   - blackbox-exporter/plugindefinition.yaml
   - cert-manager/plugindefinition.yaml
+  - doop-api/plugindefinition.yaml
   - exposed-services/plugindefinition.yaml
   - external-dns/plugindefinition.yaml
   - gatekeeper/plugindefinition.yaml


### PR DESCRIPTION
## Pull Request Details

Add a `doop-api` PluginDefinition wrapping the central API of DOOP. Reads Gatekeeper audit reports aggregated by `doop-analyzer` pods from Swift, serves them to the existing `doop` UI plugin.

## Breaking Changes

None.

## Issues Fixed

- Follow-up https://github.com/cloudoperators/greenhouse-extensions/issues/1420

## Other Relevant Information

None