### PR TITLE
feat(thanos): add per-alert disable and label override support

### DIFF
--- a/.github/workflows/e2e-flux-helm.yaml
+++ b/.github/workflows/e2e-flux-helm.yaml
@@ -278,12 +278,29 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # Determine branch (PR vs push)
-          export branch="${{ github.head_ref || github.ref_name }}"
-          export repo=${{ github.repository }}
-          yq eval '.spec.url = "https://github.com/" + strenv(repo) |
-            .spec.ref.branch= strenv(branch)' \
-          ${{ env.E2E_PATH }}/gitrepository.yaml | kubectl apply -f -
+          # For PRs (including from forks), use the base repository with PR ref
+          # This allows Flux to access the PR code even when it comes from a private fork
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            export repo="${{ github.event.pull_request.base.repo.full_name }}"
+            export ref="refs/pull/${{ github.event.pull_request.number }}/head"
+            echo "📋 PR detected: Using base repo with PR ref"
+            echo "   Repository: $repo"
+            echo "   Ref: $ref"
+            yq eval '.spec.url = "https://github.com/" + strenv(repo) |
+              .spec.ref.branch = null |
+              .spec.ref.name = strenv(ref)' \
+            ${{ env.E2E_PATH }}/gitrepository.yaml | kubectl apply -f -
+          else
+            # For push events and workflow_dispatch, use the current branch
+            export branch="${{ github.ref_name }}"
+            export repo="${{ github.repository }}"
+            echo "📋 Push/Manual run detected: Using current branch"
+            echo "   Repository: $repo"
+            echo "   Branch: $branch"
+            yq eval '.spec.url = "https://github.com/" + strenv(repo) |
+              .spec.ref.branch = strenv(branch)' \
+            ${{ env.E2E_PATH }}/gitrepository.yaml | kubectl apply -f -
+          fi
           kubectl -n flux-system get gitrepository workspace -o yaml
 
       - name: Ensure test-values.yaml exists

--- a/.github/workflows/e2e-flux-helm.yaml
+++ b/.github/workflows/e2e-flux-helm.yaml
@@ -278,18 +278,33 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          # For PRs (including from forks), use the base repository with PR ref
-          # This allows Flux to access the PR code even when it comes from a private fork
           if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            export repo="${{ github.event.pull_request.base.repo.full_name }}"
-            export ref="refs/pull/${{ github.event.pull_request.number }}/head"
-            echo "📋 PR detected: Using base repo with PR ref"
-            echo "   Repository: $repo"
-            echo "   Ref: $ref"
-            yq eval '.spec.url = "https://github.com/" + strenv(repo) |
-              .spec.ref.branch = null |
-              .spec.ref.name = strenv(ref)' \
-            ${{ env.E2E_PATH }}/gitrepository.yaml | kubectl apply -f -
+            # Detect fork PRs: head repo differs from base repo
+            if [[ "${{ github.event.pull_request.head.repo.full_name }}" != "${{ github.event.pull_request.base.repo.full_name }}" ]]; then
+              # Fork PR: Flux source-controller cannot resolve commit objects for
+              # refs/pull/<n>/head from the base repo when the commit lives in a fork.
+              # Point Flux directly at the fork's repository URL and branch instead.
+              export repo="${{ github.event.pull_request.head.repo.full_name }}"
+              export branch="${{ github.event.pull_request.head.ref }}"
+              echo "📋 Fork PR detected: Using fork repo with branch ref"
+              echo "   Repository: $repo"
+              echo "   Branch: $branch"
+              yq eval '.spec.url = "https://github.com/" + strenv(repo) |
+                .spec.ref.branch = strenv(branch) |
+                .spec.ref.name = null' \
+              ${{ env.E2E_PATH }}/gitrepository.yaml | kubectl apply -f -
+            else
+              # Same-repo PR: use the base repository with PR ref
+              export repo="${{ github.event.pull_request.base.repo.full_name }}"
+              export ref="refs/pull/${{ github.event.pull_request.number }}/head"
+              echo "📋 Same-repo PR detected: Using base repo with PR ref"
+              echo "   Repository: $repo"
+              echo "   Ref: $ref"
+              yq eval '.spec.url = "https://github.com/" + strenv(repo) |
+                .spec.ref.branch = null |
+                .spec.ref.name = strenv(ref)' \
+              ${{ env.E2E_PATH }}/gitrepository.yaml | kubectl apply -f -
+            fi
           else
             # For push events and workflow_dispatch, use the current branch
             export branch="${{ github.ref_name }}"

--- a/thanos/README.md
+++ b/thanos/README.md
@@ -425,7 +425,9 @@ If Blackbox-exporter is enabled and store endpoints are provided, this Thanos de
 | thanos.ruler.serviceLabels | object | `{}` | Labels to add to the Thanos Ruler service |
 | thanos.ruler.storage | object | `{}` |  |
 | thanos.serviceMonitor.alertLabels | string | <pre> alertLabels: \| <br>   support_group: "default" <br>   meta: "" </pre> | Labels to add to the PrometheusRules alerts. |
+| thanos.serviceMonitor.alertOverrides | object | `{}` | Per-alert label overrides, keyed by alert name. Merged on top of the alert's existing labels, so specified keys take precedence. |
 | thanos.serviceMonitor.dashboards | bool | `true` | Create configmaps containing Perses dashboards |
+| thanos.serviceMonitor.disabledAlerts | list | `[]` | List of alert names to disable entirely. |
 | thanos.serviceMonitor.labels | object | `{}` | Labels to add to the ServiceMonitor/PrometheusRules. Make sure label is matching your Prometheus serviceMonitorSelector/ruleSelector configs by default Greenhouse kube-monitoring follows this label pattern `plugin: "{{ $.Release.Name }}"` |
 | thanos.serviceMonitor.selfMonitor | bool | `false` | Create a ServiceMonitor and PrometheusRules for Thanos components. Disabled by default since label is required for Prometheus serviceMonitorSelector/ruleSelector. |
 | thanos.store.additionalArgs | list | `[]` | Adding additional arguments to Thanos Store |

--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,10 +11,14 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.9.1
+version: 0.10.0
 dependencies:
   - name: thanos
     repository: https://thanos-community.github.io/helm-charts/
     version: 0.11.0
     alias: thanosCommunity
     condition: thanosCommunity.enabled
+keywords:
+  - thanos
+  - storage
+  - metrics

--- a/thanos/charts/ci/test-alert-overrides-values.yaml
+++ b/thanos/charts/ci/test-alert-overrides-values.yaml
@@ -1,0 +1,16 @@
+ci:
+  enabled: true
+
+thanos:
+  serviceMonitor:
+    selfMonitor: true
+    labels:
+      plugin: default
+    dashboards: false
+    # Disable one alert
+    disabledAlerts:
+      - ThanosCompactMultipleRunning
+    # Override severity on one alert
+    alertOverrides:
+      ThanosCompactHalted:
+        severity: critical

--- a/thanos/charts/templates/alerts.yaml
+++ b/thanos/charts/templates/alerts.yaml
@@ -10,12 +10,28 @@ metadata:
   name: {{ include "release.name" $root }}-{{ $fileName }}-alerts
   labels:
     {{- include "thanos.labels" $root | nindent 4 }}
-    {{- if $root.Values.thanos.serviceMonitor.labels }} 
+    {{- if $root.Values.thanos.serviceMonitor.labels }}
     {{- toYaml $root.Values.thanos.serviceMonitor.labels | nindent 4 }}
     {{- end }}
     thanos-ruler: {{ $root.Values.thanos.ruler.matchLabel | default $root.Release.Name }}
 spec:
-{{ tpl (printf "%s" $bytes) $root | indent 2 }}
+  {{- $alertSpec := tpl (printf "%s" $bytes) $root | fromYaml }}
+  groups:
+  {{- range $alertSpec.groups }}
+  - name: {{ .name }}
+    rules:
+    {{- range .rules }}
+    {{- if not (has .alert $root.Values.thanos.serviceMonitor.disabledAlerts) }}
+    {{- $rule := . }}
+    {{- if hasKey $root.Values.thanos.serviceMonitor.alertOverrides .alert }}
+    {{- $overrides := index $root.Values.thanos.serviceMonitor.alertOverrides .alert }}
+    {{- $_ := merge $overrides $rule.labels }}
+    {{- $rule = merge (dict "labels" $overrides) $rule }}
+    {{- end }}
+    - {{ toYaml $rule | nindent 6 | trim }}
+    {{- end }}
+    {{- end }}
+  {{- end }}
 {{- end }}
 {{- end }}
 ---

--- a/thanos/charts/templates/alerts.yaml
+++ b/thanos/charts/templates/alerts.yaml
@@ -18,19 +18,22 @@ spec:
   {{- $alertSpec := tpl (printf "%s" $bytes) $root | fromYaml }}
   groups:
   {{- range $alertSpec.groups }}
-  - name: {{ .name }}
-    rules:
-    {{- range .rules }}
-    {{- if not (has .alert $root.Values.thanos.serviceMonitor.disabledAlerts) }}
-    {{- $rule := . }}
-    {{- if hasKey $root.Values.thanos.serviceMonitor.alertOverrides .alert }}
-    {{- $overrides := index $root.Values.thanos.serviceMonitor.alertOverrides .alert }}
-    {{- $_ := merge $overrides $rule.labels }}
-    {{- $rule = merge (dict "labels" $overrides) $rule }}
-    {{- end }}
-    - {{ toYaml $rule | nindent 6 | trim }}
-    {{- end }}
-    {{- end }}
+  {{- $group := . }}
+  {{- $filteredRules := list }}
+  {{- range $group.rules }}
+  {{- if not (has .alert $root.Values.thanos.serviceMonitor.disabledAlerts) }}
+  {{- $rule := . }}
+  {{- if hasKey $root.Values.thanos.serviceMonitor.alertOverrides .alert }}
+  {{- $overrides := index $root.Values.thanos.serviceMonitor.alertOverrides .alert }}
+  {{- $mergedLabels := merge (deepCopy $overrides) $rule.labels }}
+  {{- $rule = merge (dict "labels" $mergedLabels) $rule }}
+  {{- end }}
+  {{- $filteredRules = append $filteredRules $rule }}
+  {{- end }}
+  {{- end }}
+  {{- if $filteredRules }}
+  - {{ merge (dict "rules" $filteredRules) (omit $group "rules") | toYaml | nindent 4 | trim }}
+  {{- end }}
   {{- end }}
 {{- end }}
 {{- end }}

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -54,6 +54,19 @@ thanos:
     alertLabels: ""
       # support_group: "default"
 
+    # -- List of alert names to disable entirely.
+    disabledAlerts: []
+    # - ThanosCompactMultipleRunning
+    # - ThanosCompactHasNotRun
+
+    # -- Per-alert label overrides, keyed by alert name. Merged on top of the alert's existing labels, so specified keys take precedence.
+    alertOverrides: {}
+    # ThanosCompactHalted:
+    #   severity: critical
+    # ThanosQueryIsDown:
+    #   severity: critical
+    #   team: infra
+
     # -- Create configmaps containing Perses dashboards
     dashboards: true
 

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
   name: thanos
 spec:
-  version: 0.9.1
+  version: 0.10.0
   description: thanos
   helmChart:
     name: thanos
     repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-    version: 0.9.1
+    version: 0.10.0
   options:
     - default: null
       description: CLI param for Thanos Query
@@ -209,3 +209,13 @@ spec:
       description: Labels to add to the PrometheusRules alerts
       type: string
       required: false
+    - name: thanos.serviceMonitor.disabledAlerts
+      description: List of alert names to disable entirely (e.g. ThanosCompactMultipleRunning)
+      default: []
+      required: false
+      type: list
+    - name: thanos.serviceMonitor.alertOverrides
+      description: Per-alert label overrides keyed by alert name (e.g. ThanosQueryIsDown.severity=critical)
+      default: {}
+      required: false
+      type: map


### PR DESCRIPTION
Provide the capability/option for downstream(KVM cluster) to disable the alerts/overwrite lables 

### summary of changes 
  - Add `thanos.serviceMonitor.disabledAlerts` — list of alert names to suppress entirely from rendered PrometheusRule objects
  - Add `thanos.serviceMonitor.alertOverrides` — map of alert name → label overrides (e.g. override severity, add custom labels)
- Refactor alerts.yaml to parse alert YAML via fromYaml for rule-level filtering
- Expose both options in plugindefinition.yaml as list/map options
- Bump chart and plugin version 0.9.0 → 0.10.0
