### PR TITLE
feat(trust-manager): add trust-manager plugin for automated trust bundle management

### DIFF
--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -25,6 +25,7 @@ on:
       - service-proxy/charts/1.0.0/service-proxy/**
       - shoot-grafter/charts/**
       - thanos/charts/**
+      - trust-manager/charts/**
       - repo-guard/charts/**
       - oidc-discovery-access/**
 
@@ -78,6 +79,8 @@ jobs:
             chartName: shoot-grafter
           - chartDir: thanos/charts
             chartName: thanos
+          - chartDir: trust-manager/charts
+            chartName: trust-manager
           - chartDir: repo-guard/charts
             chartName: repo-guard
           - chartDir: oidc-discovery-access/charts/1.0.0/oidc-discovery-access

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -17,3 +17,4 @@ resources:
   - service-proxy/plugindefinition.yaml
   - teams2slack/plugindefinition.yaml
   - thanos/plugindefinition.yaml
+  - trust-manager/plugindefinition.yaml

--- a/trust-manager/README.md
+++ b/trust-manager/README.md
@@ -1,0 +1,88 @@
+---
+title: Trust Manager
+---
+
+This Plugin provides [trust-manager](https://github.com/cert-manager/trust-manager) to automate the management and distribution of trust bundles across Kubernetes clusters.
+
+Trust-manager is a Kubernetes operator that distributes trust bundles (CA certificates) to workloads running in your cluster. It works alongside cert-manager and enables you to manage CA trust stores declaratively.
+
+## Prerequisites
+
+- **cert-manager** must be installed on the target cluster before deploying this plugin. Trust-manager depends on cert-manager for its webhook certificates. You can install it using the [cert-manager Greenhouse plugin](https://github.com/cloudoperators/greenhouse-extensions/tree/main/cert-manager).
+
+## Configuration
+
+This section highlights configuration of selected Plugin features.
+All available configuration options are described in the *plugindefinition.yaml*.
+
+### Trust Bundle
+
+The plugin creates a `Bundle` resource that distributes trust bundles to selected namespaces. The bundle includes:
+- Default CAs from the trust package image
+- The cluster's `kube-root-ca.crt` ConfigMap
+
+Bundle creation can be disabled by setting `bundle.enabled` to `false`.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `bundle.enabled` | bool | `true` | Whether to create the Bundle resource |
+| `bundle.name` | string | `trust-bundle` | Name of the Bundle resource to create |
+| `namespaces` | map | `{}` | Namespace selector for the trust bundle target |
+
+> **⚠️ Warning:** An empty `namespaces` selector (`{}`) matches **ALL namespaces**, distributing the trust bundle cluster-wide. To restrict distribution, configure a `matchLabels` or `matchExpressions` selector.
+
+#### Namespace Selector Example
+
+```yaml
+namespaces:
+  matchExpressions:
+    - key: kubernetes.io/metadata.name
+      operator: In
+      values:
+        - my-namespace-1
+        - my-namespace-2
+```
+
+### Additional Bundle Sources
+
+Additional CA sources can be included in the trust bundle by enabling and configuring `additionalSources`.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `additionalSources.enabled` | bool | `false` | Whether to include additional bundle sources |
+| `additionalSources.sources` | list | `[]` | List of additional sources to include |
+
+#### Example
+
+```yaml
+additionalSources:
+  enabled: true
+  sources:
+    - configMap:
+        key: ca.crt
+        name: my-custom-ca
+```
+
+### Cert Exporter
+
+An optional cert-exporter can be deployed to monitor trust bundle certificates and expose Prometheus metrics.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `certExporter.enabled` | bool | `false` | Whether to deploy the cert-exporter |
+| `certExporter.namespaces` | list | `[]` | Namespaces to deploy cert-exporter into |
+| `certExporter.image.registry` | string | `docker.io` | Registry for the cert-exporter image |
+| `certExporter.image.repository` | string | `joeelliott/cert-exporter` | Repository for the cert-exporter image |
+| `certExporter.image.tag` | string | `v2.13.0` | Tag for the cert-exporter image |
+
+### Trust Manager Configuration
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `trust-manager.app.trust.namespace` | string | `trust-manager` | Namespace where trust bundles are managed |
+| `trust-manager.resources.limits.cpu` | string | `200m` | CPU limit for trust-manager |
+| `trust-manager.resources.limits.memory` | string | `256Mi` | Memory limit for trust-manager |
+| `trust-manager.resources.requests.cpu` | string | `100m` | CPU request for trust-manager |
+| `trust-manager.resources.requests.memory` | string | `128Mi` | Memory request for trust-manager |
+| `trust-manager.defaultPackageImage.registry` | string | `quay.io` | Registry for the default trust package image |
+| `trust-manager.defaultPackageImage.repository` | string | `jetstack/trust-pkg-debian-bookworm` | Repository for the default trust package image |

--- a/trust-manager/charts/Chart.yaml
+++ b/trust-manager/charts/Chart.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+description: A Helm chart for installing jetstack/trust-manager for automated trust bundle management.
+name: trust-manager
+keywords:
+  - trust-manager
+  - cert-manager
+  - tls
+  - ca-bundle
+version: v0.22.1
+appVersion: v0.22.1
+maintainers:
+  - name: jagoleni
+  - name: fwiesel
+dependencies:
+  - name: trust-manager
+    repository: https://charts.jetstack.io
+    version: v0.22.1

--- a/trust-manager/charts/templates/bundle.yaml
+++ b/trust-manager/charts/templates/bundle.yaml
@@ -1,0 +1,29 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and (.Capabilities.APIVersions.Has "trust.cert-manager.io/v1alpha1") .Values.bundle.enabled -}}
+apiVersion: trust.cert-manager.io/v1alpha1
+kind: Bundle
+metadata:
+  name: {{ .Values.bundle.name }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation
+spec:
+  sources:
+  - useDefaultCAs: true
+  - configMap:
+      key: ca.crt
+      name: kube-root-ca.crt
+{{- if and .Values.additionalSources.enabled .Values.additionalSources.sources }}
+  {{- .Values.additionalSources.sources | toYaml | nindent 2 }}
+{{- end }}
+  target:
+    configMap:
+      key: "trust-bundle.pem"
+{{- if .Values.namespaces }}
+    namespaceSelector:
+      {{- .Values.namespaces | toYaml | nindent 6 }}
+{{- end }}
+{{- end }}

--- a/trust-manager/charts/templates/exporter.yaml
+++ b/trust-manager/charts/templates/exporter.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.certExporter.enabled }}
+{{- range $i, $namespace := .Values.certExporter.namespaces }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/instance: trust-manager
+    app.kubernetes.io/name: cert-exporter
+    app.kubernetes.io/version: {{ $.Values.certExporter.image.tag }}
+    cert-exporter.io/type: deployment
+  name: trust-manager-cert-exporter
+  namespace: {{ $namespace }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: trust-manager
+      app.kubernetes.io/name: cert-exporter
+      app.kubernetes.io/component: cert-exporter-{{ $namespace }}
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/instance: trust-manager
+        app.kubernetes.io/name: cert-exporter
+        cert-exporter.io/type: deployment
+      annotations:
+        prometheus.io/scrape: "true"
+    spec:
+      containers:
+      - args:
+        - --configmaps-label-selector=trust.cert-manager.io/bundle
+        - --logtostderr
+        command:
+        - ./app
+        image: {{ $.Values.certExporter.image.registry }}/{{ $.Values.certExporter.image.repository }}:{{ $.Values.certExporter.image.tag }}
+        imagePullPolicy: IfNotPresent
+        name: cert-exporter
+        ports:
+        - containerPort: 8080
+          name: metrics
+          protocol: TCP
+        livenessProbe:
+          initialDelaySeconds: 10
+          periodSeconds: 10
+          tcpSocket:
+            port: 8080
+        readinessProbe:
+          failureThreshold: 1
+          httpGet:
+            path: /metrics
+            port: 8080
+          periodSeconds: 10
+{{- end }}
+{{- end }}

--- a/trust-manager/charts/values.yaml
+++ b/trust-manager/charts/values.yaml
@@ -1,0 +1,58 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+trust-manager:
+  app:
+    trust:
+      namespace: kube-system
+  resources:
+    limits:
+      cpu: 200m
+      memory: 256Mi
+    requests:
+      cpu: 100m
+      memory: 128Mi
+  defaultPackageImage:
+    registry: quay.io
+    repository: jetstack/trust-pkg-debian-bookworm
+
+# Bundle configuration
+bundle:
+  # Set to false to disable the Bundle resource creation
+  enabled: true
+  # Name of the Bundle resource to create
+  name: trust-bundle
+
+# Namespace selector for the trust bundle target
+# WARNING: An empty selector ({}) matches ALL namespaces, distributing the trust bundle cluster-wide.
+# To restrict distribution, configure a matchLabels or matchExpressions selector.
+# Example:
+#   matchExpressions:
+#     - key: kubernetes.io/metadata.name
+#       operator: In
+#       values:
+#         - my-namespace
+namespaces: {}
+
+# Additional bundle sources configuration
+additionalSources:
+  # Set to true to include additional bundle sources
+  enabled: false
+  # List of additional sources to include in the bundle
+  # Example:
+  #   sources:
+  #     - configMap:
+  #         key: ca.crt
+  #         name: my-custom-ca
+  sources: []
+
+# Cert-exporter configuration
+certExporter:
+  # Set to true to deploy cert-exporter
+  enabled: false
+  image:
+    registry: docker.io
+    repository: joeelliott/cert-exporter
+    tag: v2.13.0
+  # List of namespaces to deploy cert-exporter into
+  namespaces: []

--- a/trust-manager/plugindefinition.yaml
+++ b/trust-manager/plugindefinition.yaml
@@ -1,0 +1,100 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: trust-manager
+spec:
+  version: v0.22.1
+  displayName: Trust Manager
+  description: Automated trust bundle management for Kubernetes
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/trust-manager/README.md
+  icon: https://raw.githubusercontent.com/cert-manager/trust-manager/main/logo/logo.png
+  helmChart:
+    name: trust-manager
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    version: v0.22.1
+  options:
+    - name: trust-manager.app.trust.namespace
+      description: Namespace where trust bundles are managed
+      default: "trust-manager"
+      required: false
+      type: string
+    - name: trust-manager.resources.limits.cpu
+      description: CPU limit for trust-manager
+      default: "200m"
+      required: false
+      type: string
+    - name: trust-manager.resources.limits.memory
+      description: Memory limit for trust-manager
+      default: "256Mi"
+      required: false
+      type: string
+    - name: trust-manager.resources.requests.cpu
+      description: CPU request for trust-manager
+      default: "100m"
+      required: false
+      type: string
+    - name: trust-manager.resources.requests.memory
+      description: Memory request for trust-manager
+      default: "128Mi"
+      required: false
+      type: string
+    - name: trust-manager.defaultPackageImage.registry
+      description: Registry for the default trust package image
+      default: "quay.io"
+      required: false
+      type: string
+    - name: trust-manager.defaultPackageImage.repository
+      description: Repository for the default trust package image
+      default: "jetstack/trust-pkg-debian-bookworm"
+      required: false
+      type: string
+    - name: bundle.enabled
+      description: Whether to create the Bundle resource
+      default: true
+      required: false
+      type: bool
+    - name: bundle.name
+      description: Name of the trust bundle resource
+      default: "trust-bundle"
+      required: false
+      type: string
+    - name: namespaces
+      description: "Namespace selector for the trust bundle target. WARNING: An empty selector matches ALL namespaces."
+      required: false
+      type: map
+    - name: additionalSources.enabled
+      description: Whether to include additional bundle sources
+      default: false
+      required: false
+      type: bool
+    - name: additionalSources.sources
+      description: List of additional sources to include in the bundle
+      required: false
+      type: list
+    - name: certExporter.enabled
+      description: Whether to deploy the cert-exporter
+      default: false
+      required: false
+      type: bool
+    - name: certExporter.namespaces
+      description: List of namespaces to deploy cert-exporter into
+      required: false
+      type: list
+    - name: certExporter.image.registry
+      description: Registry for the cert-exporter image
+      default: "docker.io"
+      required: false
+      type: string
+    - name: certExporter.image.repository
+      description: Repository for the cert-exporter image
+      default: "joeelliott/cert-exporter"
+      required: false
+      type: string
+    - name: certExporter.image.tag
+      description: Tag for the cert-exporter image
+      default: "v2.13.0"
+      required: false
+      type: string


### PR DESCRIPTION
## Pull Request Details

Adds the trust-manager plugin as a new Greenhouse extension. Trust-manager is a Kubernetes operator (from Jetstack/cert-manager project) that distributes trust bundles (CA certificates) to workloads running in a cluster.

This plugin includes:
- PluginDefinition for trust-manager v0.22.1
- Helm chart wrapper around the upstream jetstack/trust-manager chart
- Bundle template for distributing default CAs and kube-root-ca.crt
- Optional cert-exporter sidecar for monitoring trust bundle certificates
- README with configuration documentation

## Breaking Changes

None. This is a new plugin.

## Issues Fixed

N/A — new feature.

## Other Relevant Information

- Requires cert-manager to be installed on the target cluster (provides CRDs for Certificate/Issuer resources)
- The Bundle resource uses a Helm post-install hook to avoid webhook readiness race conditions during initial deployment
- Default trust package image is from quay.io/jetstack/trust-pkg-debian-bookworm