### PR TITLE
chore(opensearch): bump chart to 0.1.1 to enable OCI publish

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.1.0
+version: 0.1.1
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.1.0
+  version: 0.1.1
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.0
+    version: 0.1.1


### PR DESCRIPTION
## Pull Request Details

The `helm-release` workflow failed on the #1633 merge because `opensearch:0.1.0` already existed in GHCR (from a prior publish which we had to revert), and the workflow refuses to overwrite an existing tag. Bumping to `0.1.1` so the chart from main can actually be published.