### PR TITLE
feat(perses): Add alert for perses-content-sync

### DIFF
--- a/perses/charts/Chart.yaml
+++ b/perses/charts/Chart.yaml
@@ -3,7 +3,7 @@ name: perses
 description: A Helm chart for Perses
 icon: https://avatars.githubusercontent.com/u/77209215?s=200&v=4
 type: application
-version: 0.20.1
+version: 0.20.2
 maintainers:
   - name: richardtief
   - name: ibakshay

--- a/perses/charts/alerts/content-sync.yaml
+++ b/perses/charts/alerts/content-sync.yaml
@@ -1,0 +1,16 @@
+groups:
+  - name: perses-content-sync
+    rules:
+      - alert: PersesContentSyncJobFailed
+        annotations:
+          summary: "Perses content sync job failed"
+          description: "The Perses content sync Job {{`{{ $labels.namespace }}`}}/{{`{{ $labels.job_name }}`}} has failed. The Perses provisioning PVC has not been updated; new dashboards and datasources will not appear until the sync succeeds."
+        expr: |
+          max by (namespace, job_name) (
+            kube_job_failed{job_name=~"{{ include "release.name" . }}-content-sync-.*"}
+          ) > 0
+        for: 5m
+        labels:
+          severity: warning
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/blob/main/perses/playbooks/PersesContentSyncJobFailed.md
+          {{- include "perses.alertLabels" . | nindent 10 }}

--- a/perses/charts/alerts/content-sync.yaml
+++ b/perses/charts/alerts/content-sync.yaml
@@ -7,8 +7,8 @@ groups:
           description: "The Perses content sync Job {{`{{ $labels.namespace }}`}}/{{`{{ $labels.job_name }}`}} has failed. The Perses provisioning PVC has not been updated; new dashboards and datasources will not appear until the sync succeeds."
         expr: |
           max by (namespace, job_name) (
-            kube_job_failed{job_name=~"{{ include "release.name" . }}-content-sync-.*"}
-          ) > 0
+            kube_job_failed{job_name=~"{{ include "release.name" . }}-content-sync-.*", condition="true"}
+          ) == 1
         for: 5m
         labels:
           severity: warning

--- a/perses/charts/alerts/perses.yaml
+++ b/perses/charts/alerts/perses.yaml
@@ -3,15 +3,24 @@ groups:
     rules:
       - alert: PersesServiceDown
         annotations:
-          description: "The pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} is down for more than 10 minutes"
+          description: "The Perses pod {{`{{ $labels.namespace }}`}}/{{`{{ $labels.pod }}`}} has been down for more than 10 minutes."
           summary: "Perses service is down"
         expr: |
           up{job="{{ include "perses.jobName" . }}"} == 0
-          or
+        for: 10m
+        labels:
+          severity: warning
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/blob/main/perses/playbooks/PersesServiceDown.md
+          {{- include "perses.alertLabels" . | nindent 10 }}
+
+      - alert: PersesServiceAbsent
+        annotations:
+          description: "No Perses targets are being scraped for job {{`{{ $labels.job }}`}}. The service may be missing, misconfigured, or its ServiceMonitor is not selecting any targets."
+          summary: "Perses service is absent (no scrape targets)"
+        expr: |
           absent(up{job="{{ include "perses.jobName" . }}"})
         for: 10m
         labels:
           severity: warning
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/perses/playbooks/PersesServiceDown.md
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/blob/main/perses/playbooks/PersesServiceDown.md
           {{- include "perses.alertLabels" . | nindent 10 }}
-

--- a/perses/playbooks/PersesContentSyncJobFailed.md
+++ b/perses/playbooks/PersesContentSyncJobFailed.md
@@ -1,0 +1,114 @@
+# Perses Content Sync Job Failed
+
+## Problem
+
+The Perses **content sync** CronJob runs on a schedule to pull a Perses content
+OCI image (dashboards, datasources, etc.) and copy its contents to the Perses
+provisioning PVC. This PVC is shared with the Perses pod, which reads
+provisioned content directly from it; the CronJob is the writer and Perses
+is the reader. This alert fires when the most recent Job spawned by that
+CronJob has reached its `backoffLimit` and is in the `Failed` condition.
+
+While this alert is firing:
+
+* The cluster's Perses instance keeps running and serving its current content.
+* Newer dashboards published to the OCI image are **not** being
+  rolled out to Perses.
+* Provisioned content on the PVC is effectively stale.
+
+## Impact
+
+* **Stale content:** Existing dashboards continue to work. New or updated
+  content shipped via the content image will not appear in Perses until the
+  sync succeeds again.
+
+## Diagnosis
+
+### 1. Identify the failing Job
+
+Use the alert labels (`namespace`, `job_name`), or list the recent Jobs
+spawned by the CronJob:
+
+```bash
+kubectl get jobs -n <namespace> -l plugindefinition=perses | grep content-sync
+```
+
+### 2. Inspect the Job
+
+```bash
+kubectl describe job <job_name> -n <namespace>
+```
+
+Check `Conditions`, `Events`, and the pod counts (`Failed`, `Succeeded`).
+
+### 3. Read the pod logs
+
+```bash
+kubectl logs job/<job_name> -c content-sync -n <namespace> --tail=500
+```
+
+The CronJob retains up to 3 failed Jobs (`failedJobsHistoryLimit: 3`), so
+logs are typically available while this alert is firing. If the pod has been
+garbage-collected, fall back to the cluster's log aggregator (e.g. OpenSearch) and query by `namespace` and `job_name`.
+
+### 4. Inspect the CronJob
+
+```bash
+kubectl describe cronjob <release>-content-sync -n <namespace>
+```
+
+## Resolution Steps
+
+### Scenario A: Cannot reach or pull the OCI content image
+
+**Diagnosis:** Logs show `crane digest` or `crane export` errors such as
+`UNAUTHORIZED`, `MANIFEST_UNKNOWN`, `connection refused`, DNS errors, or TLS
+failures.
+
+1. Verify `contentSync.ociImageRef` in the Helm values is correct (registry,
+   repository, tag/digest).
+2. Confirm the registry is reachable from the pod's network.
+3. For private registries, verify pull credentials have not expired.
+
+### Scenario B: Image pull error for the content-sync container
+
+**Diagnosis:** Pod events show `ErrImagePull` / `ImagePullBackOff` on the
+`content-sync` container.
+
+1. Verify `contentSync.image.repository` and `contentSync.image.tag`.
+2. Verify the cluster can pull from the registry hosting the content-sync
+   image.
+
+### Scenario C: PVC mount or storage issues
+
+**Diagnosis:** Logs or pod events reference the volume `perses-content-volume`
+or the mount path (`contentSync.provisioningMountPath`). Common signs:
+`MountVolume.SetUp failed`, "read-only file system" when copying.
+
+1. Resolve the exact PVC name being mounted by the failing Job:
+   ```bash
+   PVC=$(kubectl get job <job_name> -n <namespace> \
+     -o jsonpath='{.spec.template.spec.volumes[?(@.name=="perses-content-volume")].persistentVolumeClaim.claimName}')
+   echo "$PVC"
+   ```
+2. Inspect the PVC and its bound state:
+   ```bash
+   kubectl describe pvc "$PVC" -n <namespace>
+   kubectl get pvc "$PVC" -n <namespace> -o wide
+   ```
+3. Ensure the PVC is `Bound` and the underlying storage is healthy.
+4. If a stale pod still holds the volume, ensure no leftover pod is attached:
+   ```bash
+   kubectl get pods -n <namespace> -l app.kubernetes.io/name=perses
+   ```
+
+## Manually re-run the sync
+
+After fixing the underlying issue, trigger an immediate run instead of
+waiting for the next scheduled tick:
+
+```bash
+kubectl create job --from=cronjob/<release>-content-sync \
+  <release>-content-sync-rerun-$(date +%s) -n <namespace>
+```
+

--- a/perses/plugindefinition.yaml
+++ b/perses/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: perses
 spec:
-  version: 0.13.1
+  version: 0.13.2
   displayName: Perses
   description: "Perses is a dashboard tooling to visualize metrics and traces produced by observability tools such as Prometheus/Thanos/Jaeger"
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/perses/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: perses
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.20.1
+    version: 0.20.2
   options:
     - description: "The image version of the Perses app. If not provided, the latest version will be used"
       name: perses.image.version


### PR DESCRIPTION
- Add an alert for Perses-content-sync cronjob when it is down.
- Add a playbook for this alert.
- Refine the existing perses down alert
