### PR TITLE
fix(opensearch): skip user-credentials Secret when password is empty

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.1.1
+version: 0.1.2
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/users-secret.yaml
+++ b/opensearch/chart/templates/users-secret.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- range $userKey, $userData := .Values.cluster.usersCredentials }}
+{{- if $userData.password }}
 ---
 apiVersion: v1
 kind: Secret
@@ -14,4 +15,5 @@ type: Opaque
 data:
   username: {{ default $userKey $userData.username | b64enc }}
   password: {{ $userData.password | b64enc }}
+{{- end }}
 {{- end }}

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.1.1
+  version: 0.1.2
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.1
+    version: 0.1.2


### PR DESCRIPTION
## Pull Request Details

Helm merges maps so chart-default `cluster.usersCredentials` entries (admin/logs/logs2/dashboards/dashboards2) survive even when a consumer overrides only some users. The unset entries materialize as Secrets with empty passwords, which the secrets-injector webhook then mutates, causing infinite drift loops. This PR skips rendering the Secret when the user's `password` is empty.