### PR TITLE
feat(opensearch): make dashboards Service expose via service-proxy optional

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -259,7 +259,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | operator.serviceAccount.name | string | `"opensearch-operator-controller-manager"` |  |
 | operator.tolerations | list | `[]` |  |
 | operator.useRoleBindings | bool | `false` |  |
-| serviceProxy.dashboards.enabled | bool | `true` | Expose the OpenSearch Dashboards UI through the Greenhouse service-proxy. When enabled, an extra `<release>-dashboards-ui` Service is rendered with the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches. |
+| serviceProxy.dashboards.enabled | bool | `true` | Expose the OpenSearch Dashboards UI through the Greenhouse service-proxy. When enabled, an extra `<cluster.cluster.name>-dashboards-ui` Service is rendered (falling back to `<release>-dashboards-ui` when `cluster.cluster.name` is not set) with the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches. |
 | testFramework.enabled | bool | `true` | Activates the Helm chart testing framework. |
 | testFramework.image.registry | string | `"ghcr.io"` | Defines the image registry for the test framework. |
 | testFramework.image.repository | string | `"cloudoperators/greenhouse-extensions-integration-test"` | Defines the image repository for the test framework. |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -259,6 +259,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | operator.serviceAccount.name | string | `"opensearch-operator-controller-manager"` |  |
 | operator.tolerations | list | `[]` |  |
 | operator.useRoleBindings | bool | `false` |  |
+| serviceProxy.dashboards.enabled | bool | `true` | Expose the OpenSearch Dashboards UI through the Greenhouse service-proxy. When enabled, an extra `<release>-dashboards-ui` Service is rendered with the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches. |
 | testFramework.enabled | bool | `true` | Activates the Helm chart testing framework. |
 | testFramework.image.registry | string | `"ghcr.io"` | Defines the image registry for the test framework. |
 | testFramework.image.repository | string | `"cloudoperators/greenhouse-extensions-integration-test"` | Defines the image repository for the test framework. |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.1.2
+version: 0.1.3
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/dashboard-service.yaml
+++ b/opensearch/chart/templates/dashboard-service.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cluster.cluster.dashboards.enable }}
+{{- if and .Values.cluster.cluster.dashboards.enable .Values.serviceProxy.dashboards.enabled }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -30,8 +30,9 @@ auth:
 serviceProxy:
   dashboards:
     # -- Expose the OpenSearch Dashboards UI through the Greenhouse service-proxy.
-    # When enabled, an extra `<release>-dashboards-ui` Service is rendered with
-    # the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches.
+    # When enabled, an extra `<cluster.cluster.name>-dashboards-ui` Service is rendered
+    # (falling back to `<release>-dashboards-ui` when `cluster.cluster.name` is not set)
+    # with the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches.
     enabled: true
 
 certManager:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -27,6 +27,13 @@ auth:
       # -- Base redirect URL for OIDC callback (your dashboards URL, e.g., https://dashboards.example.com/)
       baseRedirectUrl: ""
 
+serviceProxy:
+  dashboards:
+    # -- Expose the OpenSearch Dashboards UI through the Greenhouse service-proxy.
+    # When enabled, an extra `<release>-dashboards-ui` Service is rendered with
+    # the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches.
+    enabled: true
+
 certManager:
   # -- Enable cert-manager integration for issuing TLS certificates
   enable: true

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.1.2
+  version: 0.1.3
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.2
+    version: 0.1.3


### PR DESCRIPTION
## Pull Request Details

The chart unconditionally rendered a `<release>-dashboards-ui` Service annotated with `greenhouse.sap/expose: "true"` for the Greenhouse service-proxy. Releases that don't expose Dashboards via Service Proxy but Ingress shouldn't get this Service. This PR adds `serviceProxy.dashboards.enabled` (default `true` for backward compatibility). Opt-out by setting `false` in your values/PluginPreset.