### PR TITLE
feat(opensearch): add extraManifests support

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -190,6 +190,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.users | list | <pre>users:<br>  - name: "logs"<br>    secretName: "logs-credentials"<br>    secretKey: "password"<br>    backendRoles: []</pre> | List of OpenSearch user configurations. |
 | cluster.usersCredentials | object | <pre>usersCredentials:<br>  admin:<br>    username: "admin"<br>    password: "admin"<br>    hash: ""</pre> | List of OpenSearch user credentials. These credentials are used for authenticating users with OpenSearch. See values.yaml file for a full example. |
 | cluster.usersRoleBinding | list | <pre>usersRoleBinding:<br>  - name: "logs-write"<br>    users:<br>      - "logs"<br>      - "logs2"<br>    roles:<br>      - "logs-write-role"</pre> | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role |
+| extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart. Each entry is a raw YAML string (use | or quote). Useful for owner-info ConfigMaps etc. |
 | operator.enabled | bool | `true` | Install the OpenSearch operator subchart with its ServiceMonitor and PrometheusRule alerts. Set false on additional releases that reuse the operator from another release. Note: CRDs in chart/crds/ are managed by Helm independently of this flag. |
 | operator.fullnameOverride | string | `""` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -190,7 +190,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.users | list | <pre>users:<br>  - name: "logs"<br>    secretName: "logs-credentials"<br>    secretKey: "password"<br>    backendRoles: []</pre> | List of OpenSearch user configurations. |
 | cluster.usersCredentials | object | <pre>usersCredentials:<br>  admin:<br>    username: "admin"<br>    password: "admin"<br>    hash: ""</pre> | List of OpenSearch user credentials. These credentials are used for authenticating users with OpenSearch. See values.yaml file for a full example. |
 | cluster.usersRoleBinding | list | <pre>usersRoleBinding:<br>  - name: "logs-write"<br>    users:<br>      - "logs"<br>      - "logs2"<br>    roles:<br>      - "logs-write-role"</pre> | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role |
-| extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart. Each entry is a raw YAML string (use | or quote). Useful for owner-info ConfigMaps etc. |
+| extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart. Each entry can be a raw YAML string or a map object. |
 | operator.enabled | bool | `true` | Install the OpenSearch operator subchart with its ServiceMonitor and PrometheusRule alerts. Set false on additional releases that reuse the operator from another release. Note: CRDs in chart/crds/ are managed by Helm independently of this flag. |
 | operator.fullnameOverride | string | `""` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.1.4
+version: 0.1.5
 description: A Helm chart for the OpenSearch operator
 type: application
 maintainers:

--- a/opensearch/chart/templates/extra-manifests.yaml
+++ b/opensearch/chart/templates/extra-manifests.yaml
@@ -2,13 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- range .Values.extraManifests }}
-  {{- if kindIs "map" . }}
+{{- if kindIs "map" . }}
 ---
 {{ toYaml . }}
-  {{- else if kindIs "string" . }}
+{{- else if kindIs "string" . }}
 ---
 {{ tpl . $ }}
-  {{- else }}
-    {{- fail (printf "extraManifests: unsupported entry type %s (expected string or map)" (kindOf .)) }}
-  {{- end }}
+{{- else }}
+{{- fail (printf "extraManifests: unsupported entry type %s (expected string or map)" (kindOf .)) }}
+{{- end }}
 {{- end }}

--- a/opensearch/chart/templates/extra-manifests.yaml
+++ b/opensearch/chart/templates/extra-manifests.yaml
@@ -1,0 +1,7 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- range .Values.extraManifests }}
+---
+{{ toYaml . }}
+{{- end }}

--- a/opensearch/chart/templates/extra-manifests.yaml
+++ b/opensearch/chart/templates/extra-manifests.yaml
@@ -3,5 +3,9 @@
 
 {{- range .Values.extraManifests }}
 ---
-{{ toYaml . }}
+  {{- if kindIs "map" . }}
+    {{- toYaml . | nindent 0 }}
+  {{- else if kindIs "string" . }}
+    {{- tpl . $ | nindent 0 }}
+  {{- end }}
 {{- end }}

--- a/opensearch/chart/templates/extra-manifests.yaml
+++ b/opensearch/chart/templates/extra-manifests.yaml
@@ -2,10 +2,13 @@
 # SPDX-License-Identifier: Apache-2.0
 
 {{- range .Values.extraManifests }}
----
   {{- if kindIs "map" . }}
-    {{- toYaml . | nindent 0 }}
+---
+{{ toYaml . }}
   {{- else if kindIs "string" . }}
-    {{- tpl . $ | nindent 0 }}
+---
+{{ tpl . $ }}
+  {{- else }}
+    {{- fail (printf "extraManifests: unsupported entry type %s (expected string or map)" (kindOf .)) }}
   {{- end }}
 {{- end }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -872,6 +872,11 @@ cluster:
           - "logs*"
         priority: 100
 
+
+# -- Extra Kubernetes manifests to deploy alongside the chart.
+# Each entry is a raw YAML string (use | or quote). Useful for owner-info ConfigMaps etc.
+extraManifests: []
+
 testFramework:
   # -- Activates the Helm chart testing framework.
   enabled: true

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -874,7 +874,7 @@ cluster:
 
 
 # -- Extra Kubernetes manifests to deploy alongside the chart.
-# Each entry is a raw YAML string (use | or quote). Useful for owner-info ConfigMaps etc.
+# Each entry can be a raw YAML string or a map object.
 extraManifests: []
 
 testFramework:

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.1.4
+  version: 0.1.5
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.4
+    version: 0.1.5


### PR DESCRIPTION
## Pull Request Details

Adds an extraManifests value to the opensearch chart that renders arbitrary Kubernetes manifests alongside the chart
