### PR TITLE
feat(kafka): add extraManifests support

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -48,6 +48,7 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | entityOperator.enabled | bool | `true` | Enable Entity Operator |
 | entityOperator.topicOperator | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | Topic Operator resource configuration |
 | entityOperator.userOperator | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | User Operator resource configuration |
+| extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart. Each entry can be a raw YAML string or a map object. |
 | kafka.config | object | See values.yaml for production defaults | Kafka broker configuration |
 | kafka.enabled | bool | `true` | Enable or disable Kafka cluster deployment |
 | kafka.jvmOptions | object | xms: 1024m, xmx: 2048m | JVM heap settings for Kafka brokers. xms (initial heap) and xmx (max heap): Heap should be kept modest to preserve memory for OS page cache, which Kafka relies on heavily for performance. See: https://docs.confluent.io/platform/current/kafka/deployment.html |

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.4
+version: 0.1.5
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/extra-manifests.yaml
+++ b/kafka/charts/templates/extra-manifests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- range .Values.extraManifests }}
+{{- if kindIs "map" . }}
+---
+{{ toYaml . }}
+{{- else if kindIs "string" . }}
+---
+{{ tpl . $ }}
+{{- else }}
+{{- fail (printf "extraManifests: unsupported entry type %s (expected string or map)" (kindOf .)) }}
+{{- end }}
+{{- end }}

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -220,3 +220,7 @@ topics:
     cleanupPolicy: "delete"
     # -- Max message size (1 MB)
     maxMessageBytes: 1048576
+
+# -- Extra Kubernetes manifests to deploy alongside the chart.
+# Each entry can be a raw YAML string or a map object.
+extraManifests: []

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.4
+  version: 0.1.5
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.4
+    version: 0.1.5
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

Adds extraManifests to the kafka chart allowing arbitrary Kubernetes manifests to be injected alongside the release
