### PR TITLE
chore(opensearch): bump chart and plugindefinition to 0.1.6

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,8 +3,8 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.1.5
-description: A Helm chart for the OpenSearch operator
+version: 0.1.6
+description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:
   - name: timojohlo

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.1.5
+  version: 0.1.6
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.5
+    version: 0.1.6


### PR DESCRIPTION
## Pull Request Details

Bumps chart and PluginDefinition to 0.1.6. The 0.1.5 publish workflow failed due to a transient `azure/setup-helm` action download error and the chart was never pushed to ghcr.io. This re-triggers the publish pipeline.