### PR TITLE
ci(chart-testing): register missing plugin charts

### DIFF
--- a/.github/configs/helm-chart-testing.yaml
+++ b/.github/configs/helm-chart-testing.yaml
@@ -10,28 +10,31 @@ skip-clean-up: true
 namespace: default
 release-label: "app.kubernetes.io/instance"
 chart-dirs:
+  - absent-metrics-operator
   - alerts
   - audit-logs
   - blackbox-exporter
   - cert-manager
-  - exposed-services/charts/v1.0.0
   - exposed-services/charts/v2.0.0
+  - gatekeeper
   - kafka
   - kube-monitoring
   - kubeconfig-generator
   - logs
   - logshipper
+  - oidc-discovery-access/charts/1.0.0
   - opensearch
   - perses
-  - plutono
-  - prometheus
   - service-proxy/charts/1.0.0
+  - shoot-grafter
   - thanos
+  - trust-manager
 chart-repos:
   - alerts=https://prometheus-community.github.io/helm-charts
   - audit-logs=https://open-telemetry.github.io/opentelemetry-helm-charts
   - blackbox-exporter=https://prometheus-community.github.io/helm-charts
   - cert-manager=https://charts.jetstack.io
+  - gatekeeper=https://open-policy-agent.github.io/gatekeeper/charts
   - kafka=https://strimzi.io/charts
   - kube-monitoring=https://prometheus-community.github.io/helm-charts
   - kubernetes-operations=https://cloudoperators.github.io/kubernetes-operations
@@ -40,3 +43,4 @@ chart-repos:
   - opensearch=https://opensearch-project.github.io/opensearch-k8s-operator
   - perses=https://perses.github.io/helm-charts
   - thanos=https://thanos-community.github.io/helm-charts/
+  - trust-manager=https://charts.jetstack.io

--- a/.github/workflows/ci-pr-build.yaml
+++ b/.github/workflows/ci-pr-build.yaml
@@ -24,6 +24,8 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          - chartDir: absent-metrics-operator/charts
+            chartName: absent-metrics-operator
           - chartDir: alerts/charts
             chartName: alerts
           - chartDir: audit-logs/charts
@@ -32,8 +34,6 @@ jobs:
             chartName: blackbox-exporter
           - chartDir: cert-manager/charts
             chartName: cert-manager
-          - chartDir: exposed-services/charts/v1.0.0/exposed-service
-            chartName: exposed-services
           - chartDir: exposed-services/charts/v2.0.0/exposed-service
             chartName: exposed-services
           - chartDir: gatekeeper/charts
@@ -52,14 +52,12 @@ jobs:
             chartName: logs
           - chartDir: perses/charts
             chartName: perses
-          - chartDir: plutono/charts
-            chartName: plutono
           - chartDir: service-proxy/charts/1.0.0/service-proxy
             chartName: service-proxy
           - chartDir: thanos/charts
             chartName: thanos
-          - chartDir: repo-guard/charts
-            chartName: repo-guard
+          - chartDir: trust-manager/charts
+            chartName: trust-manager
           - chartDir: shoot-grafter/charts
             chartName: shoot-grafter
           - chartDir: oidc-discovery-access/charts/1.0.0/oidc-discovery-access


### PR DESCRIPTION
Several plugin charts in this repo were not registered in .github/configs/helm-chart-testing.yaml. 

As a result, PRs touching them were silently skipped by ct list-changed / ct lint and the e2e Flux/HelmRelease workflow in .github/workflows/e2e-flux-helm.yaml. 

New plugins like `trust-manager` were getting no lint or e2e coverage at all.
This PR registers the missing charts so they are properly linted and e2e-tested on every PR.