### PR TITLE
fix(alerts): add missing required field

### DIFF
--- a/alerts/charts/Chart.yaml
+++ b/alerts/charts/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: alerts
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 7.0.0
+version: 7.0.1
 keywords:
   - prometheus-alertmanager
 dependencies:

--- a/alerts/plugindefinition.yaml
+++ b/alerts/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: alerts
 spec:
-  version: 8.0.0
+  version: 8.0.1
   weight: 0
   displayName: Alerts
   description: Deploy and manage prometheus alertmanager instances
@@ -16,7 +16,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/alerts
     name: alerts
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 7.0.0
+    version: 7.0.1
   options:
     - name: global.caCert
       description: Additional caCert to add to the CA bundle
@@ -57,6 +57,7 @@ spec:
       type: map
     - name: alerts.dashboard.create
       description: Whether to install the default dashboards for self-monitoring Prometheus Alertmanger.
+      required: false
       default: true
       type: bool
     - name: alerts.alertmanager.enabled


### PR DESCRIPTION
catalog reconciliation failed with `PluginDefinition.greenhouse.sap "alerts" is invalid: spec.options[7].required: Required value`