### PR TITLE
feat(kafka): add cert-manager Certificate for external listener

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -42,6 +42,19 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| certManager.defaults.duration | string | `"4800h"` |  |
+| certManager.defaults.privateKey.algorithm | string | `"RSA"` |  |
+| certManager.defaults.privateKey.encoding | string | `"PKCS8"` |  |
+| certManager.defaults.privateKey.size | int | `2048` |  |
+| certManager.defaults.usages[0] | string | `"digital signature"` |  |
+| certManager.defaults.usages[1] | string | `"key encipherment"` |  |
+| certManager.defaults.usages[2] | string | `"server auth"` |  |
+| certManager.defaults.usages[3] | string | `"client auth"` |  |
+| certManager.enabled | bool | `false` |  |
+| certManager.externalCert.dnsNames | list | `[]` | SANs covering bootstrap and per-broker hosts. Required when enabled. |
+| certManager.externalCert.name | string | `"kafka-external-cert"` |  |
+| certManager.externalCert.secretName | string | `"kafka-external-cert"` |  |
+| certManager.issuer | object | `{}` | issuerRef (group, kind, name). Required when enabled. |
 | commonLabels | object | `{}` | common labels to apply to all resources. |
 | cruiseControl.enabled | bool | `false` | Enable Cruise Control |
 | cruiseControl.resources | object | requests: 512Mi memory, 500m CPU; limits: 1Gi memory, 1 CPU | Cruise Control resource configuration |

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.6
+version: 0.1.7
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/external-cert.yaml
+++ b/kafka/charts/templates/external-cert.yaml
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.certManager.enabled }}
+{{- if not .Values.certManager.issuer }}
+{{- fail "certManager.enabled is true but certManager.issuer is empty. Provide an issuerRef (group/kind/name) for the external Kafka certificate." }}
+{{- end }}
+{{- if not .Values.certManager.externalCert.dnsNames }}
+{{- fail "certManager.externalCert.dnsNames is empty. Set the cluster-specific DNS names for the Kafka external listener." }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ .Values.certManager.externalCert.name }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+spec:
+  secretName: {{ .Values.certManager.externalCert.secretName }}
+  duration: {{ .Values.certManager.defaults.duration }}
+  dnsNames:
+{{ toYaml .Values.certManager.externalCert.dnsNames | indent 4 }}
+  issuerRef:
+{{ toYaml .Values.certManager.issuer | indent 4 }}
+  privateKey:
+{{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
+  usages:
+{{ toYaml .Values.certManager.defaults.usages | indent 4 }}
+{{- end }}

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -221,6 +221,32 @@ topics:
     # -- Max message size (1 MB)
     maxMessageBytes: 1048576
 
+# cert-manager Certificate for the Kafka external listener.
+# `issuer` and `externalCert.dnsNames` are environment-specific.
+certManager:
+  enabled: false
+
+  # -- issuerRef (group, kind, name). Required when enabled.
+  issuer: {}
+
+  externalCert:
+    name: kafka-external-cert
+    secretName: kafka-external-cert
+    # -- SANs covering bootstrap and per-broker hosts. Required when enabled.
+    dnsNames: []
+
+  defaults:
+    duration: 4800h
+    privateKey:
+      algorithm: RSA
+      encoding: PKCS8
+      size: 2048
+    usages:
+      - digital signature
+      - key encipherment
+      - server auth
+      - client auth
+
 # -- Extra Kubernetes manifests to deploy alongside the chart.
 # Each entry can be a raw YAML string or a map object.
 extraManifests: []

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.6
+  version: 0.1.7
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.6
+    version: 0.1.7
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

- Adds an optional `Certificate` template for cert-manager for the Kafka external listener, gated by `certManager.enabled`
- `certManager.issuer` and `certManager.externalCert.dnsNames` are environment-specific and supplied via values overrides 
