### PR TITLE
feat(gatekeeper-config): add PluginDefinition with admission policies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /exposed-services/        @cloudoperators/greenhouse-backend
 /external-dns/            @cloudoperators/greenhouse-backend
 /gatekeeper/              @cloudoperators/greenhouse-backend
+/gatekeeper-config/       @cloudoperators/greenhouse-backend
 /ingress-nginx/           @cloudoperators/greenhouse-backend
 /kafka/                   @cloudoperators/greenhouse-observability
 /kube-monitoring/         @cloudoperators/greenhouse-observability

--- a/.github/workflows/ci-pr-build.yaml
+++ b/.github/workflows/ci-pr-build.yaml
@@ -38,6 +38,8 @@ jobs:
             chartName: exposed-services
           - chartDir: gatekeeper/charts
             chartName: gatekeeper
+          - chartDir: gatekeeper-config/charts
+            chartName: gatekeeper-config
           - chartDir: kafka/chart
             chartName: kafka
           - chartDir: kube-monitoring/charts

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -15,6 +15,7 @@ on:
       - exposed-services/charts/v1.0.0/exposed-service/**
       - exposed-services/charts/v2.0.0/exposed-service/**
       - gatekeeper/charts/**
+      - gatekeeper-config/charts/**
       - kafka/charts/**
       - kube-monitoring/charts/**
       - kubeconfig-generator/chart/**
@@ -63,6 +64,8 @@ jobs:
             chartName: exposed-services
           - chartDir: gatekeeper/charts
             chartName: gatekeeper
+          - chartDir: gatekeeper-config/charts
+            chartName: gatekeeper-config
           - chartDir: kafka/charts
             chartName: kafka
           - chartDir: kube-monitoring/charts

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -14,6 +14,7 @@ This following table provides an overview of the currently available Plugins in 
 | exposed-service|A test plugin for validating service exposure via Greenhouse|1.0.0|
 | external-dns|The kubernetes-sigs/external-dns plugin.|1.0.0|
 | gatekeeper|Policy controller for Kubernetes admission based on the OPA constraint framework|1.0.0|
+| gatekeeper-config|OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control|1.0.0|
 | heureka||1.0.0|
 | ingress-nginx|Ingress NGINX controller|1.1.0|
 | kube-monitoring|Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.|1.3.4|

--- a/gatekeeper-config/README.md
+++ b/gatekeeper-config/README.md
@@ -1,0 +1,45 @@
+---
+title: OPA Gatekeeper Config
+---
+
+Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control. Provides a library of universal admission policies that can be enabled and tuned per cluster.
+
+Requires the [OPA Gatekeeper](https://github.com/cloudoperators/greenhouse-extensions/tree/main/gatekeeper) PluginDefinition to be installed on the cluster.
+
+## Policies
+
+| Policy | Description |
+|--------|-------------|
+| `deprecatedApiVersion` | Detects Helm release Secrets that contain manifests using deprecated Kubernetes API versions. Requires `helmManifestParserURL`. |
+| `forbiddenClusterwideObjects` | Enforces a configurable allowlist on MutatingWebhookConfiguration and ValidatingWebhookConfiguration objects. |
+| `highCpuRequests` | Flags workloads that request more than `maxCpu` cores in total across containers and initContainers. |
+| `ingressAnnotationsMigration` | Checks that Ingress objects use both old and new annotation prefixes consistently during an ingress-nginx prefix migration. Disabled by default; enable only if running such a migration. |
+| `ingressAnnotations` | Flags Ingress objects using known-dangerous annotation patterns (e.g. insecure snippets disabled due to CVE-2021-25742). |
+| `pciForbiddenImages` | Flags workloads using container images that match a configurable list of forbidden regex patterns. |
+| `podSecurityV2` | Enforces pod security restrictions (host network/PID, privilege escalation, capabilities, hostPath mounts) with a configurable per-namespace allowlist. |
+| `prometheusScrapeAnnotations` | Checks that `prometheus.io/targets` is set correctly on any Pod or Service with `prometheus.io/scrape: "true"`. Requires a Gatekeeper `Config` resource syncing `monitoring.coreos.com/v1` Prometheus objects into the OPA cache; disabled by default. |
+| `unmanagedPods` | Flags Pods that have no `ownerReference` (i.e. not managed by a Deployment, DaemonSet, etc.). |
+| `imagesFromApprovedRegistries` | Flags containers using images that do not start with one of the configured allowed registry prefixes. |
+| `podRequiredLabels` | Flags pods whose template metadata is missing one or more configured required label keys. |
+| `oliLabelsRequired` | Enforces Owner Label Injector labels on Helm releases. Requires gatekeeper-doop. |
+| `outdatedImageBases` | Flags containers whose base image layers are older than one year. Requires gatekeeper-doop. |
+| `vulnerableImages` | Flags containers using images with known vulnerabilities. Requires gatekeeper-doop. |
+
+## Default behavior
+
+All policies default to `enforcementAction: dryrun`. No policy will block admission by default. Change `enforcementAction` to `warn` or `deny` to enforce.
+
+Several policies default to `enabled: false` because they require additional configuration before they can produce useful results. They must be enabled explicitly and the relevant parameters set via Plugin `optionValues`.
+
+## Policies requiring gatekeeper-doop
+
+The following policies require the [gatekeeper-doop](https://github.com/cloudoperators/greenhouse-extensions/tree/main/doop) plugin to be installed and the corresponding service URL configured. They are disabled by default:
+
+- `outdatedImageBases`: set `policies.outdatedImageBases.imageCheckerURL` to the doop-image-checker service URL.
+- `vulnerableImages`: set `policies.vulnerableImages.imageCheckerURL` to the doop-image-checker service URL.
+- `oliLabelsRequired`: set `policies.oliLabelsRequired.helmManifestParserURL` to the helm-manifest-parser service URL.
+- `deprecatedApiVersion`: set `policies.deprecatedApiVersion.helmManifestParserURL` to the helm-manifest-parser service URL.
+
+## Policies requiring a Gatekeeper Config resource
+
+`prometheusScrapeAnnotations` references the OPA inventory (`data.inventory.namespace[_]["monitoring.coreos.com/v1"].Prometheus[_]`). A Gatekeeper `Config` resource syncing the `Prometheus` CRD into the OPA cache must exist in `gatekeeper-system` before this policy is enabled.

--- a/gatekeeper-config/charts/Chart.yaml
+++ b/gatekeeper-config/charts/Chart.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+description: Helm chart deploying OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control.
+name: gatekeeper-config
+version: 1.0.0
+appVersion: 1.0.0
+icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
+keywords:
+  - gatekeeper
+  - opa
+  - policy
+  - admission-control
+sources:
+  - https://github.com/cloudoperators/greenhouse-extensions
+maintainers:
+  - name: mikolajkucinski
+  - name: abhijith-darshan
+  - name: uwe-mayer

--- a/gatekeeper-config/charts/templates/_helpers.tpl
+++ b/gatekeeper-config/charts/templates/_helpers.tpl
@@ -1,0 +1,226 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{/*
+Shared Rego libraries inlined into every ConstraintTemplate.
+
+  add_support_labels: annotates violation messages with the
+    greenhouse.sap/owned-by label so reports can be routed to the right team.
+
+  helm_release: calls the helm-manifest-parser service to decode the
+    `data.release` blob in Helm release Secrets into a JSON manifest.
+
+  image_check: calls the doop-image-checker service to retrieve
+    vulnerability / base-image headers for a container image.
+
+  traversal: walks the Kubernetes ownership chain (Pod, ReplicaSet,
+    Deployment, etc.) so policies can target the workload owner instead of
+    the synthesized Pod.
+*/}}
+
+{{- define "gatekeeper-config.lib.add_support_labels" -}}
+package lib.add_support_labels
+
+# `obj` must be a full Kubernetes object.
+from_k8s_object(obj, msg) := result if {
+	owned_by := object.get(obj, ["metadata", "labels", "greenhouse.sap/owned-by"], "none")
+	result := sprintf("{\"owned_by\":%s} >> %s", [json.marshal(owned_by), msg])
+}
+
+# `body` must be the response body from helm-manifest-parser
+from_helm_release(body, msg) := result if {
+	owned_by := object.get(body, ["owner_info", "owned-by"], "none")
+	result := sprintf("{\"owned_by\":%s} >> %s", [json.marshal(owned_by), msg])
+}
+
+# Adds an additional label to a message that already had support labels added with one of the above methods.
+extra(key, value, msg) := result if {
+	result := sprintf("{%s:%s,%s", [json.marshal(key), json.marshal(value), trim_prefix(msg, "{")])
+}
+{{- end }}
+
+{{- define "gatekeeper-config.lib.traversal" -}}
+package lib.traversal
+
+default find_pod(obj) := {"isFound": false}
+
+find_pod(obj) := result if {
+	obj.kind == "Pod"
+	result := __return_pod_unless_suppressed(obj, __list_suppressing_owners(obj))
+}
+
+find_pod(obj) := result if {
+	obj.kind != "Pod"
+	location := object.get(__pod_template_locations, [obj.kind], [])
+	location != []
+	pod := object.get(obj, location, {})
+	result := __return_pod_unless_suppressed(pod, __list_suppressing_owners(obj))
+}
+
+find_container_specs(obj) := result if {
+	result := __extract_container_specs(find_pod(obj))
+}
+
+__pod_template_locations := {
+	"CronJob": ["spec", "jobTemplate", "spec", "template"],
+	"DaemonSet": ["spec", "template"],
+	"Deployment": ["spec", "template"],
+	"Job": ["spec", "template"],
+	"ReplicaSet": ["spec", "template"],
+	"StatefulSet": ["spec", "template"],
+}
+
+__suppressing_owner_kinds := {
+	"Job": ["CronJob"],
+	"Pod": ["DaemonSet", "Job", "ReplicaSet", "StatefulSet"],
+	"ReplicaSet": ["Deployment"],
+}
+
+__list_suppressing_owners(obj) := result if {
+	possible_owners := object.get(__suppressing_owner_kinds, [obj.kind], [])
+	result := [ref.kind |
+		ref := obj.metadata.ownerReferences[_]
+		ref.kind == possible_owners[_]
+	]
+}
+
+__return_pod_unless_suppressed(obj, owners) := result if {
+	count(owners) > 0
+	result := {"isFound": false}
+}
+
+__return_pod_unless_suppressed(obj, owners) := result if {
+	count(owners) == 0
+	result := object.union(obj, {"isFound": true})
+}
+
+__extract_container_specs(pod) := [] if {
+	not pod.isFound
+}
+
+__extract_container_specs(pod) := result if {
+	pod.isFound
+	result := array.concat(
+		object.get(pod.spec, "containers", []),
+		object.get(pod.spec, "initContainers", []),
+	)
+}
+{{- end }}
+
+{{- define "gatekeeper-config.lib.helm_release" -}}
+package lib.helm_release
+
+# Returns {"error": ""} for non-Helm Secrets so callers can short-circuit without
+# emitting violations. The Constraint should use match.labelSelector to filter
+# down to Helm release Secrets in the first place; this guard is a defence in
+# depth.
+parse_k8s_object(obj, baseURL) := result if {
+	not __is_helm_release(obj)
+	result := {"error": "", "items": [], "owner_info": {}}
+}
+
+parse_k8s_object(obj, baseURL) := result if {
+	__is_helm_release(obj)
+	url := sprintf("%s/v3", [baseURL])
+	resp := http.send({"url": url, "method": "POST", "raise_error": false, "raw_body": obj.data.release, "timeout": "15s"})
+	result := __parse_response(resp)
+}
+
+__is_helm_release(obj) if {
+	obj.kind == "Secret"
+	obj.type == "helm.sh/release.v1"
+}
+
+__is_helm_release(obj) := false if {
+	obj.kind != "Secret"
+}
+
+__is_helm_release(obj) := false if {
+	obj.type != "helm.sh/release.v1"
+}
+
+__parse_response(resp) := result if {
+	resp.status_code == 200
+	result := object.union(resp.body, {"error": ""})
+}
+
+__parse_response(resp) := result if {
+	resp.status_code != 200
+	object.get(resp, ["error", "message"], "") == ""
+	result := {"error": sprintf("helm-manifest-parser returned HTTP status %d, but we expected 200. Please retry in ~5 minutes.", [resp.status_code])}
+}
+
+__parse_response(resp) := result if {
+	resp.status_code != 200
+	msg := object.get(resp, ["error", "message"], "")
+	msg != ""
+	result := {"error": sprintf("Could not reach helm-manifest-parser (%q). Please retry in ~5 minutes.", [msg])}
+}
+{{- end }}
+
+{{- define "gatekeeper-config.lib.image_check" -}}
+package lib.image_check
+
+for_pod(pod, baseURL) := result if {
+	pod.kind != "Pod"
+	result := [{"error": "not a pod"}]
+}
+
+for_pod(pod, baseURL) := result if {
+	pod.kind == "Pod"
+
+	containerStatuses := array.concat(
+		object.get(pod, ["status", "containerStatuses"], []),
+		object.get(pod, ["status", "initContainerStatuses"], []),
+	)
+	result := [__run_check(c, baseURL, true) | c := containerStatuses[_]]
+}
+
+for_pod_template(podTemplate, baseURL) := result if {
+	containerSpecs := array.concat(
+		object.get(podTemplate, ["spec", "containers"], []),
+		object.get(podTemplate, ["spec", "initContainers"], []),
+	)
+	result := [__run_check(c, baseURL, false) | c := containerSpecs[_]]
+}
+
+__run_check(container, baseURL, hasImageID) := result if {
+	imageRef := __get_image_ref(container, hasImageID)
+	url := sprintf("%s/v1/headers?image=%s", [baseURL, imageRef])
+	resp := http.send({"url": url, "method": "GET", "raise_error": false, "timeout": "15s"})
+	result := __parse_response(container, resp)
+}
+
+__get_image_ref(container, hasImageID) := result if {
+	hasImageID
+	result := trim_prefix(container.imageID, "docker-pullable://")
+}
+
+__get_image_ref(container, hasImageID) := result if {
+	not hasImageID
+	result := container.image
+}
+
+__parse_response(container, resp) := result if {
+	resp.status_code == 200
+	result := {
+		"error": "",
+		"containerName": container.name,
+		"containerImage": container.image,
+		"headers": resp.body,
+	}
+}
+
+__parse_response(container, resp) := result if {
+	resp.status_code != 200
+	object.get(resp, ["error", "message"], "") == ""
+	result := {"error": sprintf("doop-image-checker returned HTTP status %d, but we expected 200. Please retry in ~5 minutes.", [resp.status_code])}
+}
+
+__parse_response(container, resp) := result if {
+	resp.status_code != 200
+	msg := object.get(resp, ["error", "message"], "")
+	msg != ""
+	result := {"error": sprintf("Could not reach doop-image-checker (%q). Please retry in ~5 minutes.", [msg])}
+}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-deprecated-api-version-k8s1-32.yaml
+++ b/gatekeeper-config/charts/templates/constraint-deprecated-api-version-k8s1-32.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.policies.deprecatedApiVersion.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkDeprecatedApiVersion
+metadata:
+  name: deprecated-api-version-k8s1-32
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.deprecatedApiVersion.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Secret"]
+    scope: Namespaced
+    labelSelector:
+      matchLabels:
+        owner: helm
+  parameters:
+    helmManifestParserURL: {{ required "policies.deprecatedApiVersion.helmManifestParserURL is required when policies.deprecatedApiVersion.enabled=true" .Values.policies.deprecatedApiVersion.helmManifestParserURL | quote }}
+    kubernetesVersion: '1.32'
+    apiVersions:
+      - flowcontrol.apiserver.k8s.io/v1beta3
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-forbidden-clusterwide-objects.yaml
+++ b/gatekeeper-config/charts/templates/constraint-forbidden-clusterwide-objects.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.policies.forbiddenClusterwideObjects.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkForbiddenClusterwideObjects
+metadata:
+  name: forbidden-clusterwide-objects
+  labels:
+    severity: 'debug'
+spec:
+  enforcementAction: {{ .Values.policies.forbiddenClusterwideObjects.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["admissionregistration.k8s.io"]
+        kinds: ["MutatingWebhookConfiguration", "ValidatingWebhookConfiguration"]
+    scope: Cluster
+  parameters:
+    allowedWebhooks:
+      {{- toYaml .Values.policies.forbiddenClusterwideObjects.allowedWebhooks | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.policies.highCpuRequests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkHighCPURequests
+metadata:
+  name: high-cpu-requests
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.highCpuRequests.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    maxCpu: 6
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-images-from-approved-registries.yaml
+++ b/gatekeeper-config/charts/templates/constraint-images-from-approved-registries.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.policies.imagesFromApprovedRegistries.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkImagesFromApprovedRegistries
+metadata:
+  name: images-from-approved-registries
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.imagesFromApprovedRegistries.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    allowedRegistries:
+      {{- toYaml .Values.policies.imagesFromApprovedRegistries.allowedRegistries | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-ingress-annotations-insecure-snippets.yaml
+++ b/gatekeeper-config/charts/templates/constraint-ingress-annotations-insecure-snippets.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.policies.ingressAnnotations.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkIngressAnnotations
+metadata:
+  name: ingress-annotations-insecure-snippets
+  labels:
+    severity: 'info'
+spec:
+  enforcementAction: {{ .Values.policies.ingressAnnotations.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["networking.k8s.io"]
+        kinds: ["Ingress"]
+    scope: Namespaced
+  parameters:
+    hint: 'disabled due to CVE-2021-25742'
+    regexes:
+      - '^(?:nginx\.)?ingress\.kubernetes\.io/(?:auth|configuration|server|modsecurity)-snippet$'
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-ingress-annotations-migration.yaml
+++ b/gatekeeper-config/charts/templates/constraint-ingress-annotations-migration.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.policies.ingressAnnotationsMigration.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkIngressAnnotationsMigration
+metadata:
+  name: ingress-annotations-migration
+  labels:
+    severity: 'error'
+spec:
+  enforcementAction: {{ .Values.policies.ingressAnnotationsMigration.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["networking.k8s.io"]
+        kinds: ["Ingress"]
+    scope: Namespaced
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-ingress-annotations-wrong-prefix.yaml
+++ b/gatekeeper-config/charts/templates/constraint-ingress-annotations-wrong-prefix.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.policies.ingressAnnotations.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkIngressAnnotations
+metadata:
+  name: ingress-annotations-wrong-prefix
+  labels:
+    severity: 'info'
+spec:
+  enforcementAction: {{ .Values.policies.ingressAnnotations.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["networking.k8s.io"]
+        kinds: ["Ingress"]
+    scope: Namespaced
+  parameters:
+    hint: 'use the prefix "nginx.ingress.kubernetes.io/" instead (the legacy "ingress.kubernetes.io/" prefix is deprecated)'
+    regexes:
+      - '^ingress\.kubernetes\.io/'
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-oli-labels-required.yaml
+++ b/gatekeeper-config/charts/templates/constraint-oli-labels-required.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.policies.oliLabelsRequired.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkOliLabelsRequired
+metadata:
+  name: oli-labels-required
+  labels:
+    severity: 'error'
+spec:
+  enforcementAction: {{ .Values.policies.oliLabelsRequired.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Secret"]
+    scope: Namespaced
+    labelSelector:
+      matchLabels:
+        owner: helm
+    excludedNamespaces:
+      {{- toYaml .Values.policies.oliLabelsRequired.excludedNamespaces | nindent 6 }}
+  parameters:
+    helmManifestParserURL: {{ required "policies.oliLabelsRequired.helmManifestParserURL is required when policies.oliLabelsRequired.enabled=true" .Values.policies.oliLabelsRequired.helmManifestParserURL | quote }}
+    knownExceptions: {{ .Values.policies.oliLabelsRequired.knownExceptions | toJson }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-outdated-image-bases.yaml
+++ b/gatekeeper-config/charts/templates/constraint-outdated-image-bases.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.policies.outdatedImageBases.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkOutdatedImageBases
+metadata:
+  name: outdated-image-bases
+  labels:
+    severity: 'info'
+spec:
+  enforcementAction: {{ .Values.policies.outdatedImageBases.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    doopImageCheckerURL: {{ required "policies.outdatedImageBases.imageCheckerURL is required when policies.outdatedImageBases.enabled=true" .Values.policies.outdatedImageBases.imageCheckerURL | quote }}
+    createdAtHeader: {{ required "policies.outdatedImageBases.createdAtHeader is required when policies.outdatedImageBases.enabled=true" .Values.policies.outdatedImageBases.createdAtHeader | quote }}
+    maxAgeDays: {{ .Values.policies.outdatedImageBases.maxAgeDays }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-pci-forbidden-images.yaml
+++ b/gatekeeper-config/charts/templates/constraint-pci-forbidden-images.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.policies.pciForbiddenImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkPCIForbiddenImages
+metadata:
+  name: pci-forbidden-images
+  labels:
+    severity: 'error'
+spec:
+  enforcementAction: {{ .Values.policies.pciForbiddenImages.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    patterns:
+      {{- toYaml .Values.policies.pciForbiddenImages.patterns | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-pod-required-labels.yaml
+++ b/gatekeeper-config/charts/templates/constraint-pod-required-labels.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.policies.podRequiredLabels.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkPodRequiredLabels
+metadata:
+  name: pod-required-labels
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.podRequiredLabels.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    requiredLabels:
+      {{- toYaml .Values.policies.podRequiredLabels.requiredLabels | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-pod-security-v2.yaml
+++ b/gatekeeper-config/charts/templates/constraint-pod-security-v2.yaml
@@ -1,0 +1,24 @@
+{{- if .Values.policies.podSecurityV2.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkPodSecurityV2
+metadata:
+  name: pod-security-v2
+  labels:
+    severity: 'debug'
+spec:
+  enforcementAction: {{ .Values.policies.podSecurityV2.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    allowlist:
+      {{- toYaml .Values.policies.podSecurityV2.allowlist | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-prometheus-scrape-annotations.yaml
+++ b/gatekeeper-config/charts/templates/constraint-prometheus-scrape-annotations.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.policies.prometheusScrapeAnnotations.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkPrometheusScrapeAnnotations
+metadata:
+  name: prometheus-scrape-annotations
+  labels:
+    severity: 'debug'
+spec:
+  enforcementAction: {{ .Values.policies.prometheusScrapeAnnotations.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod", "Service"]
+    scope: Namespaced
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-unmanaged-pods.yaml
+++ b/gatekeeper-config/charts/templates/constraint-unmanaged-pods.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.policies.unmanagedPods.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkUnmanagedPods
+metadata:
+  name: unmanaged-pods
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.unmanagedPods.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    scope: Namespaced
+  parameters:
+    allowedNamePatterns:
+      {{- toYaml .Values.policies.unmanagedPods.allowedNamePatterns | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod-owner.yaml
+++ b/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod-owner.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.policies.vulnerableImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkVulnerableImages
+metadata:
+  name: vulnerable-images-on-pod-owner
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.vulnerableImages.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    doopImageCheckerURL: {{ required "policies.vulnerableImages.imageCheckerURL is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.imageCheckerURL | quote }}
+    vulnStatusHeader: {{ required "policies.vulnerableImages.vulnStatusHeader is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.vulnStatusHeader | quote }}
+    reportingLevel: "pod-owner"
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod.yaml
+++ b/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.policies.vulnerableImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkVulnerableImages
+metadata:
+  name: vulnerable-images-on-pod
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.vulnerableImages.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    scope: Namespaced
+  parameters:
+    doopImageCheckerURL: {{ required "policies.vulnerableImages.imageCheckerURL is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.imageCheckerURL | quote }}
+    vulnStatusHeader: {{ required "policies.vulnerableImages.vulnStatusHeader is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.vulnStatusHeader | quote }}
+    reportingLevel: "pod"
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-deprecated-api-version.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-deprecated-api-version.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.policies.deprecatedApiVersion.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkdeprecatedapiversion
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkDeprecatedApiVersion
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            helmManifestParserURL:
+              type: string
+            kubernetesVersion:
+              type: string
+            apiVersions:
+              type: array
+              items:
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.helm_release" . | indent 16 }}
+            rego: |
+              package deprecatedapiversion
+
+              import data.lib.add_support_labels
+              import data.lib.helm_release
+
+              iro := input.review.object
+
+              release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+
+              violation contains {"msg": release.error} if {
+                  release.error != ""
+              }
+
+              violation contains {"msg": add_support_labels.from_helm_release(release, msg)} if {
+                  release.error == ""
+
+                  obj := release.items[_]
+                  input.parameters.apiVersions[_] == obj.apiVersion
+
+                  msg := sprintf(
+                      "%s %s declared with deprecated API version: %s (will break in k8s v%s)",
+                      [obj.kind, obj.metadata.name, obj.apiVersion, input.parameters.kubernetesVersion],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-forbidden-clusterwide-objects.yaml
@@ -1,0 +1,44 @@
+{{- if .Values.policies.forbiddenClusterwideObjects.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkforbiddenclusterwideobjects
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkForbiddenClusterwideObjects
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedWebhooks:
+              type: array
+              items:
+                description: name of an admission webhook that is allowed to exist
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package forbiddenclusterwideobjects
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  webhook := iro.webhooks[_]
+                  not webhook.name in {n | n := input.parameters.allowedWebhooks[_]}
+                  msg := sprintf("webhook %q does not match the configured allowlist", [webhook.name])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-high-cpu-requests.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.policies.highCpuRequests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkhighcpurequests
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkHighCPURequests
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            maxCpu:
+              type: integer
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package highcpurequests
+
+              import data.lib.add_support_labels
+              import data.lib.traversal
+
+              # canonify_cpu converts a Kubernetes CPU quantity to a number of cores.
+              # Bare numbers and millicore strings ("500m") are supported. Anything
+              # else returns null so the caller can report it as malformed instead of
+              # silently dropping the container from the sum.
+              canonify_cpu(orig) := new if {
+                  is_number(orig)
+                  new := orig
+              }
+
+              canonify_cpu(orig) := new if {
+                  not is_number(orig)
+                  not endswith(orig, "m")
+                  regex.match(`^[0-9]*\.?[0-9]+$`, orig)
+                  new := to_number(orig)
+              }
+
+              canonify_cpu(orig) := new if {
+                  not is_number(orig)
+                  endswith(orig, "m")
+                  regex.match(`^[0-9]*\.?[0-9]+m$`, orig)
+                  new := to_number(replace(orig, "m", "")) / 1000
+              }
+
+              default canonify_cpu(orig) := null
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+
+              # Flag any container whose CPU request cannot be parsed. This is a
+              # separate violation so that operators see the offending value rather
+              # than the sum silently understating real demand.
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  container := array.concat(
+                      object.get(pod.spec, "containers", []),
+                      object.get(pod.spec, "initContainers", []),
+                  )[_]
+                  raw := object.get(container, ["resources", "requests", "cpu"], null)
+                  raw != null
+                  canonify_cpu(raw) == null
+                  msg := sprintf("container %q has a malformed CPU request: %q", [container.name, raw])
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+
+                  values := [v |
+                      c := array.concat(
+                          object.get(pod.spec, "containers", []),
+                          object.get(pod.spec, "initContainers", []),
+                      )[_]
+                      raw := object.get(c, ["resources", "requests", "cpu"], null)
+                      raw != null
+                      v := canonify_cpu(raw)
+                      v != null
+                  ]
+                  total_cpu := sum(values)
+                  total_cpu > input.parameters.maxCpu
+
+                  msg := sprintf("requests %v CPU in total across containers and initContainers", [total_cpu])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-images-from-approved-registries.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-images-from-approved-registries.yaml
@@ -1,0 +1,54 @@
+{{- if .Values.policies.imagesFromApprovedRegistries.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkimagesfromapprovedregistries
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkImagesFromApprovedRegistries
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedRegistries:
+              type: array
+              items:
+                description: allowed registry prefix
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package imagesfromapprovedregistries
+
+              import data.lib.add_support_labels
+              import data.lib.traversal
+
+              iro := input.review.object
+              containers := traversal.find_container_specs(iro)
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  container := containers[_]
+                  image := container.image
+                  not image_from_approved_registry(image)
+                  msg := sprintf("container %q uses an image from an unapproved registry: %s", [container.name, image])
+              }
+
+              image_from_approved_registry(image) if {
+                  prefix := input.parameters.allowedRegistries[_]
+                  startswith(image, prefix)
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-ingress-annotations-migration.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-ingress-annotations-migration.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.policies.ingressAnnotationsMigration.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkingressannotationsmigration
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkIngressAnnotationsMigration
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package ingressannotationsmigration
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+              annotations := object.get(iro, ["metadata", "annotations"], {})
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  iro.kind == "Ingress"
+
+                  oldValue := annotations[oldKey]
+                  startswith(oldKey, "ingress.kubernetes.io/")
+                  subkey := trim_prefix(oldKey, "ingress.kubernetes.io/")
+                  newKey := sprintf("nginx.ingress.kubernetes.io/%s", [subkey])
+                  newValue := object.get(annotations, [newKey], "<unset>")
+
+                  oldValue != newValue
+                  msg := sprintf("has not correctly migrated %s annotation (value in old annotation is %q, value in new annotation is %q)", [oldKey, oldValue, newValue])
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  iro.kind == "Ingress"
+
+                  annotations[newKey]
+                  startswith(newKey, "nginx.ingress.kubernetes.io/")
+                  subkey := trim_prefix(newKey, "nginx.ingress.kubernetes.io/")
+                  oldKey := sprintf("ingress.kubernetes.io/%s", [subkey])
+
+                  object.get(annotations, [oldKey], "<unset>") == "<unset>"
+                  msg := sprintf("has deleted %s annotation too early (still required while the legacy prefix is in use)", [oldKey])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-ingress-annotations.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-ingress-annotations.yaml
@@ -1,0 +1,48 @@
+{{- if .Values.policies.ingressAnnotations.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkingressannotations
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkIngressAnnotations
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            hint:
+              type: string
+            regexes:
+              type: array
+              items:
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package ingressannotations
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+              annotations := object.get(iro, ["metadata", "annotations"], {})
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  iro.kind == "Ingress"
+                  annotations[key]
+                  pattern := input.parameters.regexes[_]
+                  regex.match(pattern, key)
+                  msg := sprintf("has disabled annotation: %q (%s)", [key, input.parameters.hint])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-oli-labels-required.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-oli-labels-required.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.policies.oliLabelsRequired.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkolilabelsrequired
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkOliLabelsRequired
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            helmManifestParserURL:
+              type: string
+            knownExceptions:
+              type: array
+              items:
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.helm_release" . | indent 16 }}
+            rego: |
+              package olilabelsrequired
+
+              import data.lib.add_support_labels
+              import data.lib.helm_release
+
+              iro := input.review.object
+              release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+
+              violation contains {"msg": release.error} if {
+                  release.error != ""
+              }
+
+              # release_key is the "<namespace>/<release-name>" key used to look up
+              # entries in knownExceptions. The release name is read with object.get
+              # so a missing label leaves the key with an empty release name rather
+              # than leaving the rule unbound (which would also break is_exception).
+              release_key := sprintf("%s/%s", [iro.metadata.namespace, object.get(iro.metadata, ["labels", "name"], "")])
+
+              default is_exception := false
+
+              is_exception if {
+                  input.parameters.knownExceptions[_] == release_key
+              }
+
+              violation contains {"msg": add_support_labels.from_helm_release(release, msg)} if {
+                  release.error == ""
+                  not is_exception
+
+                  owned_by := object.get(release, ["owner_info", "owned-by"], "")
+                  owned_by == ""
+
+                  msg := "Helm release is missing greenhouse.sap/owned-by label. Ensure Owner Label Injector is running and has labelled this namespace."
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-outdated-image-bases.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.policies.outdatedImageBases.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkoutdatedimagebases
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkOutdatedImageBases
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            doopImageCheckerURL:
+              type: string
+            createdAtHeader:
+              type: string
+            maxAgeDays:
+              type: integer
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.image_check" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package outdatedimagebases
+
+              import data.lib.add_support_labels
+              import data.lib.image_check
+              import data.lib.traversal
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+              checks := image_check.for_pod_template(pod, input.parameters.doopImageCheckerURL)
+
+              violation contains {"msg": check.error} if {
+                  pod.isFound
+                  check := checks[_]
+                  check.error != ""
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  check := checks[_]
+                  check.error == ""
+                  createdAtAsUnixTime := to_number(trim_space(object.get(check.headers, input.parameters.createdAtHeader, "Unclear")))
+
+                  nowAsUnixTime := time.now_ns() / 1000000000
+                  ageInSeconds := nowAsUnixTime - createdAtAsUnixTime
+                  ageInDays := ageInSeconds / 86400
+                  ageInDays > input.parameters.maxAgeDays
+
+                  msg := sprintf(
+                      "image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
+                      [check.containerImage, check.containerName, ageInDays],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-pci-forbidden-images.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-pci-forbidden-images.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.policies.pciForbiddenImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkpciforbiddenimages
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkPCIForbiddenImages
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            patterns:
+              type: array
+              items:
+                description: regex pattern matched against the container image reference
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package pciforbiddenimages
+
+              import data.lib.add_support_labels
+              import data.lib.traversal
+
+              iro := input.review.object
+              containers := traversal.find_container_specs(iro)
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  container := containers[_]
+
+                  pattern := input.parameters.patterns[_]
+                  regex.match(pattern, container.image)
+
+                  msg := sprintf("container %q uses forbidden image: %s", [container.name, container.image])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-pod-required-labels.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-pod-required-labels.yaml
@@ -1,0 +1,57 @@
+{{- if .Values.policies.podRequiredLabels.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkpodrequiredlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkPodRequiredLabels
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            requiredLabels:
+              type: array
+              items:
+                description: required label key
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package podrequiredlabels
+
+              import data.lib.add_support_labels
+              import data.lib.traversal
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+
+              # The labels that matter for ownership/routing are on the pod
+              # template metadata, not the workload metadata, so the lookup
+              # uses `pod` rather than `iro`.
+              #
+              # `object.get(..., null) == null` is the right idiom for "label
+              # missing": `not object.get(...)` is a no-op because null is a
+              # defined value (so `not null` is false, not true), which would
+              # make this rule silently never fire.
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  labelKey := input.parameters.requiredLabels[_]
+                  object.get(pod, ["metadata", "labels", labelKey], null) == null
+                  msg := sprintf("pod is missing required label: %s", [labelKey])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-pod-security-v2.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-pod-security-v2.yaml
@@ -1,0 +1,303 @@
+{{- if .Values.policies.podSecurityV2.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkpodsecurityv2
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkPodSecurityV2
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowlist:
+              type: array
+              items:
+                description: positive allowlist entry
+                type: object
+                properties:
+                  matchNamespace:
+                    type: string
+                  matchRepository:
+                    type: string
+                  justification:
+                    type: string
+                  mayUseHostNetwork:
+                    type: boolean
+                  mayUseHostPID:
+                    type: boolean
+                  mayUsePrivilegeEscalation:
+                    type: boolean
+                  mayBePrivileged:
+                    type: boolean
+                  mayUseCapabilities:
+                    type: array
+                    items:
+                      description: capability
+                      type: string
+                  mayReadHostPathVolumes:
+                    type: array
+                    items:
+                      description: host path of the volume
+                      type: string
+                  mayWriteHostPathVolumes:
+                    type: array
+                    items:
+                      description: host path of the volume
+                      type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package podsecurityv2
+
+              import data.lib.add_support_labels
+              import data.lib.traversal
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+              containers := traversal.find_container_specs(iro)
+
+              ########################################################################
+              # allowlists: match pods that may use certain privileged features
+              #
+              # By default, everything is forbidden;
+              # positive allowlist entries from the config are evaluated at the end
+
+              default isPodAllowedToUseHostNetwork := false
+              default isPodAllowedToUseHostPID := false
+              default isContainerAllowedToUsePrivilegeEscalation(container) := false
+              default isContainerAllowedToBePrivileged(container) := false
+              default isContainerAllowedToUseCapability(container, capability) := false
+              default isContainerAllowedToAccessHostPath(container, hostPath, readOnly) := false
+
+              # Blanket allowance for readonly access to paths known not to contain credentials.
+              isContainerAllowedToAccessHostPath(container, hostPath, readOnly) if {
+                  readOnly
+                  normalizedHostPath := normalize_path(hostPath)
+                  normalizedHostPath in ["/etc/machine-id", "/lib/modules"]
+              }
+
+              ########################################################################
+              # generate violations for all pods using privileged security features
+              # without being allowlisted
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  object.get(pod.spec, ["hostNetwork"], false)
+                  not isPodAllowedToUseHostNetwork
+                  msg := "pod is not allowed to set spec.hostNetwork = true"
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  object.get(pod.spec, ["hostPID"], false)
+                  not isPodAllowedToUseHostPID
+                  msg := "pod is not allowed to set spec.hostPID = true"
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  container := containers[_]
+                  object.get(container, ["securityContext", "allowPrivilegeEscalation"], false)
+                  not isContainerAllowedToUsePrivilegeEscalation(container)
+                  msg := sprintf("pod is not allowed to set spec.containers[%q].securityContext.allowPrivilegeEscalation = true (image = %q)", [container.name, extract_repository(container.image)])
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  container := containers[_]
+                  object.get(container, ["securityContext", "privileged"], false)
+                  not isContainerAllowedToBePrivileged(container)
+                  msg := sprintf("pod is not allowed to set spec.containers[%q].securityContext.privileged = true (image = %q)", [container.name, extract_repository(container.image)])
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  container := containers[_]
+                  capabilities := object.get(container, ["securityContext", "capabilities", "add"], [])
+                  capability := capabilities[_]
+                  not isContainerAllowedToUseCapability(container, capability)
+                  msg := sprintf("pod is not allowed to set spec.containers[%q].securityContext.capabilities.add = [%q] (image = %q)", [container.name, capability, extract_repository(container.image)])
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  volume := pod.spec.volumes[_]
+                  hostPath := object.get(volume, ["hostPath", "path"], null)
+                  hostPath != null
+
+                  container := containers[_]
+                  volumeMount := container.volumeMounts[_]
+                  volume.name == volumeMount.name
+                  readOnly := object.get(volumeMount, ["readOnly"], false)
+
+                  not isContainerAllowedToAccessHostPath(container, hostPath, readOnly)
+                  msg := sprintf("container %q in this pod is not allowed to mount hostPath volumes with path %q (readonly = %s) (image = %q)", [container.name, hostPath, readOnly, extract_repository(container.image)])
+              }
+
+              ########################################################################
+              # evaluate allowlist entries in config
+
+              isPodAllowedToUseHostNetwork if {
+                  every container in containers {
+                      some entry in input.parameters.allowlist
+                      isMatchingContainer(entry, container)
+                      entry.mayUseHostNetwork
+                  }
+              }
+
+              isPodAllowedToUseHostPID if {
+                  every container in containers {
+                      some entry in input.parameters.allowlist
+                      isMatchingContainer(entry, container)
+                      entry.mayUseHostPID
+                  }
+              }
+
+              isContainerAllowedToUsePrivilegeEscalation(container) if {
+                  entry := input.parameters.allowlist[_]
+                  isMatchingContainer(entry, container)
+                  entry.mayUsePrivilegeEscalation
+              }
+
+              isContainerAllowedToBePrivileged(container) if {
+                  entry := input.parameters.allowlist[_]
+                  isMatchingContainer(entry, container)
+                  entry.mayBePrivileged
+              }
+
+              isContainerAllowedToUseCapability(container, capability) if {
+                  entry := input.parameters.allowlist[_]
+                  isMatchingContainer(entry, container)
+                  capability in entry.mayUseCapabilities
+              }
+
+              isContainerAllowedToAccessHostPath(container, hostPath, readOnly) if {
+                  entry := input.parameters.allowlist[_]
+                  isMatchingContainer(entry, container)
+                  readOnly
+                  normalizedHostPath := normalize_path(hostPath)
+                  some allowedPath in entry.mayReadHostPathVolumes
+                  normalizedAllowedPath := normalize_path(allowedPath)
+                  is_path_prefix(normalizedAllowedPath, normalizedHostPath)
+              }
+
+              isContainerAllowedToAccessHostPath(container, hostPath, readOnly) if {
+                  entry := input.parameters.allowlist[_]
+                  isMatchingContainer(entry, container)
+                  normalizedHostPath := normalize_path(hostPath)
+                  some allowedPath in entry.mayWriteHostPathVolumes
+                  normalizedAllowedPath := normalize_path(allowedPath)
+                  is_path_prefix(normalizedAllowedPath, normalizedHostPath)
+              }
+
+              ########################################################################
+              # helper functions
+
+              is_path_prefix(prefix, path) if {
+                  prefix == "/"
+              }
+
+              is_path_prefix(prefix, path) if {
+                  path == prefix
+              }
+
+              is_path_prefix(prefix, path) if {
+                  prefix != "/"
+                  startswith(path, sprintf("%s/", [prefix]))
+              }
+
+              normalize_path(path) := result if {
+                  path == "/"
+                  result := path
+              }
+
+              normalize_path(path) := result if {
+                  path != "/"
+                  endswith(path, "/")
+                  result := substring(path, 0, count(path) - 1)
+              }
+
+              normalize_path(path) := result if {
+                  path != "/"
+                  not endswith(path, "/")
+                  result := path
+              }
+
+              extract_repository(image) := result if {
+                  slash_index := indexof(image, "/")
+                  dot_index := indexof(image, ".")
+                  colon_index := indexof(image, ":")
+                  at_index := indexof(image, "@")
+
+                  start := start_position(slash_index, dot_index)
+                  end := end_position(colon_index, at_index, count(image))
+
+                  result := substring(image, start, end - start)
+              }
+
+              start_position(slash_index, dot_index) = result if {
+                  dot_index == -1
+                  result := 0
+              }
+
+              start_position(slash_index, dot_index) = result if {
+                  dot_index != -1
+                  dot_index > slash_index
+                  result := 0
+              }
+
+              start_position(slash_index, dot_index) = result if {
+                  dot_index != -1
+                  dot_index < slash_index
+                  result := slash_index + 1
+              }
+
+              end_position(colon_index, at_index, length) = result if {
+                  colon_index != -1
+                  at_index != -1
+                  result := min([colon_index, at_index])
+              }
+
+              end_position(colon_index, at_index, length) = result if {
+                  colon_index != -1
+                  at_index == -1
+                  result := colon_index
+              }
+
+              end_position(colon_index, at_index, length) = result if {
+                  colon_index == -1
+                  at_index != -1
+                  result := at_index
+              }
+
+              end_position(colon_index, at_index, length) = result if {
+                  colon_index == -1
+                  at_index == -1
+                  result := length
+              }
+
+              isMatchingContainer(entry, container) if {
+                  entry.matchNamespace != "*"
+                  iro.metadata.namespace == entry.matchNamespace
+                  repo := extract_repository(container.image)
+                  repo == entry.matchRepository
+              }
+
+              isMatchingContainer(entry, container) if {
+                  entry.matchNamespace == "*"
+                  repo := extract_repository(container.image)
+                  repo == entry.matchRepository
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-prometheus-scrape-annotations.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-prometheus-scrape-annotations.yaml
@@ -1,0 +1,52 @@
+{{- if .Values.policies.prometheusScrapeAnnotations.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkprometheusscrapeannotations
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkPrometheusScrapeAnnotations
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package prometheusscrapeannotations
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+
+              # Requires a Gatekeeper Config resource syncing
+              # monitoring.coreos.com/v1 Prometheus objects into the OPA cache.
+              # The policy defaults to disabled until that Config exists.
+              is_valid_target contains target if {
+                  target := data.inventory.namespace[_]["monitoring.coreos.com/v1"].Prometheus[_].metadata.name
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  regex.match("^(?:Service|Pod)$", iro.kind)
+                  anno := object.get(iro, ["metadata", "annotations"], {})
+                  object.get(anno, "prometheus.io/scrape", "false") == "true"
+
+                  targets := regex.split(`\s*,\s*`, object.get(anno, "prometheus.io/targets", ""))
+                  count(targets) != count({t | t := targets[_]; is_valid_target[_] == t})
+
+                  all_valid_targets := {t | is_valid_target[t]}
+
+                  msg := sprintf(
+                      "has prometheus.io/scrape annotation, but prometheus.io/targets annotation is missing or does not have a valid value (got: %s, valid: %s)",
+                      [json.marshal(sort(targets)), json.marshal(sort(all_valid_targets))],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-unmanaged-pods.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-unmanaged-pods.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.policies.unmanagedPods.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkunmanagedpods
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkUnmanagedPods
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedNamePatterns:
+              type: array
+              items:
+                description: per-namespace name pattern that exempts a Pod from this policy
+                type: object
+                properties:
+                  namespace:
+                    type: string
+                  namePattern:
+                    type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package unmanagedpods
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  iro.kind == "Pod"
+                  object.get(iro.metadata, ["ownerReferences"], []) == []
+                  not is_allowed_by_exception
+                  msg := "pod is not owned by a managing construct"
+              }
+
+              default is_allowed_by_exception := false
+
+              is_allowed_by_exception if {
+                  entry := input.parameters.allowedNamePatterns[_]
+                  iro.metadata.namespace == entry.namespace
+                  regex.match(sprintf("^(?:%s)$", [entry.namePattern]), iro.metadata.name)
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-vulnerable-images.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-vulnerable-images.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.policies.vulnerableImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkvulnerableimages
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkVulnerableImages
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            doopImageCheckerURL:
+              type: string
+            vulnStatusHeader:
+              type: string
+            reportingLevel:
+              type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.image_check" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package vulnerableimages
+
+              import data.lib.add_support_labels
+              import data.lib.image_check
+              import data.lib.traversal
+
+              iro := input.review.object
+              phase := object.get(iro, ["status", "phase"], "Running") # only relevant for iro.kind == "Pod"
+              pod := traversal.find_pod(iro)
+              checks := __run_image_check(phase)
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod"
+                  phase != "Succeeded"
+                  phase != "Failed"
+                  result = image_check.for_pod(iro, input.parameters.doopImageCheckerURL)
+              }
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod"
+
+                  # ignore pods that have already finished running, but still exist
+                  # as a k8s object (e.g. leftovers of completed or failed jobs)
+                  phase in ["Succeeded", "Failed"]
+                  result = []
+              }
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod-owner"
+                  pod.isFound
+                  result = image_check.for_pod_template(pod, input.parameters.doopImageCheckerURL)
+              }
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod-owner"
+                  not pod.isFound
+
+                  # ignore pod owners that are suppressed, e.g. ReplicaSets within Deployments
+                  result = []
+              }
+
+              violation contains {"msg": check.error} if {
+                  check := checks[_]
+                  check.error != ""
+              }
+
+              violation contains {"msg": add_support_labels.extra("status", status, add_support_labels.from_k8s_object(iro, msg))} if {
+                  check := checks[_]
+                  check.error == ""
+                  status := trim_space(object.get(check.headers, input.parameters.vulnStatusHeader, "Unclear"))
+
+                  # report everything with a definite vulnerability
+                  status != "Clean"
+                  status != "Unknown"
+
+                  msg := sprintf(
+                      "image %s for container %q has \"%s: %s\"",
+                      [check.containerImage, check.containerName, input.parameters.vulnStatusHeader, status],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/values.yaml
+++ b/gatekeeper-config/charts/values.yaml
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+policies:
+  # requires gatekeeper-doop: helmManifestParserURL must be set
+  deprecatedApiVersion:
+    enabled: false
+    enforcementAction: dryrun
+    helmManifestParserURL: ""
+
+  forbiddenClusterwideObjects:
+    enabled: false
+    enforcementAction: dryrun
+    allowedWebhooks: []
+
+  highCpuRequests:
+    enabled: true
+    enforcementAction: dryrun
+
+  ingressAnnotationsMigration:
+    enabled: false
+    enforcementAction: dryrun
+
+  ingressAnnotations:
+    enabled: true
+    enforcementAction: dryrun
+
+  pciForbiddenImages:
+    enabled: false
+    enforcementAction: dryrun
+    patterns: []
+
+  podSecurityV2:
+    enabled: false
+    enforcementAction: dryrun
+    allowlist: []
+
+  prometheusScrapeAnnotations:
+    enabled: false
+    enforcementAction: dryrun
+
+  unmanagedPods:
+    enabled: true
+    enforcementAction: dryrun
+    allowedNamePatterns: []
+
+  imagesFromApprovedRegistries:
+    enabled: false
+    enforcementAction: dryrun
+    allowedRegistries: []
+
+  podRequiredLabels:
+    enabled: false
+    enforcementAction: dryrun
+    requiredLabels: []
+
+  # requires gatekeeper-doop: helmManifestParserURL must be set
+  oliLabelsRequired:
+    enabled: false
+    enforcementAction: dryrun
+    helmManifestParserURL: ""
+    knownExceptions: []
+    excludedNamespaces: []
+
+  # requires gatekeeper-doop: imageCheckerURL must be set
+  outdatedImageBases:
+    enabled: false
+    enforcementAction: dryrun
+    imageCheckerURL: ""
+    createdAtHeader: ""
+    maxAgeDays: 365
+
+  # requires gatekeeper-doop: imageCheckerURL must be set
+  vulnerableImages:
+    enabled: false
+    enforcementAction: dryrun
+    imageCheckerURL: ""
+    vulnStatusHeader: ""

--- a/gatekeeper-config/plugindefinition.yaml
+++ b/gatekeeper-config/plugindefinition.yaml
@@ -1,0 +1,278 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: gatekeeper-config
+spec:
+  version: 1.0.0
+  displayName: Gatekeeper Config
+  description: |
+    Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes
+    admission control. Provides a library of universal admission policies that
+    can be enabled and tuned per cluster.
+  icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/gatekeeper-config/README.md
+  helmChart:
+    name: gatekeeper-config
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    version: 1.0.0
+  options:
+    - name: policies.deprecatedApiVersion.enabled
+      displayName: Deprecated API version policy enabled
+      description: Enable the deprecated-api-version policy. Requires gatekeeper-doop (helm-manifest-parser).
+      default: false
+      required: false
+      type: bool
+    - name: policies.deprecatedApiVersion.enforcementAction
+      displayName: Deprecated API version enforcement action
+      description: Gatekeeper enforcementAction for deprecated-api-version (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.deprecatedApiVersion.helmManifestParserURL
+      displayName: Helm manifest parser URL (deprecated-api-version)
+      description: URL of the helm-manifest-parser service. Required when deprecated-api-version is enabled.
+      required: false
+      type: string
+
+    - name: policies.forbiddenClusterwideObjects.enabled
+      displayName: Forbidden clusterwide objects policy enabled
+      description: Enable the forbidden-clusterwide-objects policy.
+      default: false
+      required: false
+      type: bool
+    - name: policies.forbiddenClusterwideObjects.enforcementAction
+      displayName: Forbidden clusterwide objects enforcement action
+      description: Gatekeeper enforcementAction for forbidden-clusterwide-objects (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.forbiddenClusterwideObjects.allowedWebhooks
+      displayName: Allowed admission webhooks
+      description: List of admission webhook names allowed to exist in the cluster. Required when forbidden-clusterwide-objects is enabled.
+      required: false
+      type: list
+
+    - name: policies.highCpuRequests.enabled
+      displayName: High CPU requests policy enabled
+      description: Enable the high-cpu-requests policy.
+      default: true
+      required: false
+      type: bool
+    - name: policies.highCpuRequests.enforcementAction
+      displayName: High CPU requests enforcement action
+      description: Gatekeeper enforcementAction for high-cpu-requests (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+
+    - name: policies.ingressAnnotationsMigration.enabled
+      displayName: Ingress annotations migration policy enabled
+      description: Enable the ingress-annotations-migration policy. Opt in only while running an ingress-nginx prefix migration.
+      default: false
+      required: false
+      type: bool
+    - name: policies.ingressAnnotationsMigration.enforcementAction
+      displayName: Ingress annotations migration enforcement action
+      description: Gatekeeper enforcementAction for ingress-annotations-migration (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+
+    - name: policies.ingressAnnotations.enabled
+      displayName: Ingress annotations policy enabled
+      description: Enable the ingress-annotations policy.
+      default: true
+      required: false
+      type: bool
+    - name: policies.ingressAnnotations.enforcementAction
+      displayName: Ingress annotations enforcement action
+      description: Gatekeeper enforcementAction for ingress-annotations (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+
+    - name: policies.pciForbiddenImages.enabled
+      displayName: PCI forbidden images policy enabled
+      description: Enable the pci-forbidden-images policy.
+      default: false
+      required: false
+      type: bool
+    - name: policies.pciForbiddenImages.enforcementAction
+      displayName: PCI forbidden images enforcement action
+      description: Gatekeeper enforcementAction for pci-forbidden-images (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.pciForbiddenImages.patterns
+      displayName: Forbidden image patterns
+      description: List of regex patterns matched against container image references. Required when pci-forbidden-images is enabled.
+      required: false
+      type: list
+
+    - name: policies.podSecurityV2.enabled
+      displayName: Pod security V2 policy enabled
+      description: Enable the pod-security-v2 policy.
+      default: false
+      required: false
+      type: bool
+    - name: policies.podSecurityV2.enforcementAction
+      displayName: Pod security V2 enforcement action
+      description: Gatekeeper enforcementAction for pod-security-v2 (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.podSecurityV2.allowlist
+      displayName: Pod security V2 allowlist
+      description: List of allowlist entries; each entry permits specific privileged features for a workload matched by namespace and image repository. Required when pod-security-v2 is enabled.
+      required: false
+      type: list
+
+    - name: policies.prometheusScrapeAnnotations.enabled
+      displayName: Prometheus scrape annotations policy enabled
+      description: Enable the prometheus-scrape-annotations policy. Requires a Gatekeeper Config resource syncing monitoring.coreos.com/v1 Prometheus into the OPA cache.
+      default: false
+      required: false
+      type: bool
+    - name: policies.prometheusScrapeAnnotations.enforcementAction
+      displayName: Prometheus scrape annotations enforcement action
+      description: Gatekeeper enforcementAction for prometheus-scrape-annotations (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+
+    - name: policies.unmanagedPods.enabled
+      displayName: Unmanaged pods policy enabled
+      description: Enable the unmanaged-pods policy.
+      default: true
+      required: false
+      type: bool
+    - name: policies.unmanagedPods.enforcementAction
+      displayName: Unmanaged pods enforcement action
+      description: Gatekeeper enforcementAction for unmanaged-pods (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.unmanagedPods.allowedNamePatterns
+      displayName: Allowed unmanaged-pod name patterns
+      description: List of {namespace, namePattern} entries that exempt matching Pods from the unmanaged-pods policy.
+      required: false
+      type: list
+
+    - name: policies.imagesFromApprovedRegistries.enabled
+      displayName: Images from approved registries policy enabled
+      description: Enable the images-from-approved-registries policy.
+      default: false
+      required: false
+      type: bool
+    - name: policies.imagesFromApprovedRegistries.enforcementAction
+      displayName: Images from approved registries enforcement action
+      description: Gatekeeper enforcementAction for images-from-approved-registries (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.imagesFromApprovedRegistries.allowedRegistries
+      displayName: Allowed registry prefixes
+      description: List of allowed container image registry prefixes. Required when images-from-approved-registries is enabled.
+      required: false
+      type: list
+
+    - name: policies.podRequiredLabels.enabled
+      displayName: Pod required labels policy enabled
+      description: Enable the pod-required-labels policy.
+      default: false
+      required: false
+      type: bool
+    - name: policies.podRequiredLabels.enforcementAction
+      displayName: Pod required labels enforcement action
+      description: Gatekeeper enforcementAction for pod-required-labels (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.podRequiredLabels.requiredLabels
+      displayName: Required pod label keys
+      description: List of label keys that every pod template must have. Required when pod-required-labels is enabled.
+      required: false
+      type: list
+
+    - name: policies.oliLabelsRequired.enabled
+      displayName: OLI labels required policy enabled
+      description: Enable the oli-labels-required policy. Requires gatekeeper-doop (helm-manifest-parser).
+      default: false
+      required: false
+      type: bool
+    - name: policies.oliLabelsRequired.enforcementAction
+      displayName: OLI labels required enforcement action
+      description: Gatekeeper enforcementAction for oli-labels-required (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.oliLabelsRequired.helmManifestParserURL
+      displayName: Helm manifest parser URL (oli-labels-required)
+      description: URL of the helm-manifest-parser service. Required when oli-labels-required is enabled.
+      required: false
+      type: string
+    - name: policies.oliLabelsRequired.knownExceptions
+      displayName: OLI labels known exceptions
+      description: Helm releases temporarily exempt from the policy, in "namespace/release-name" format.
+      required: false
+      type: list
+    - name: policies.oliLabelsRequired.excludedNamespaces
+      displayName: OLI labels excluded namespaces
+      description: Namespaces excluded from the oli-labels-required policy (e.g. greenhouse-system, flux-system, cert-manager when running with enforcementAction=deny).
+      required: false
+      type: list
+
+    - name: policies.outdatedImageBases.enabled
+      displayName: Outdated image bases policy enabled
+      description: Enable the outdated-image-bases policy. Requires gatekeeper-doop.
+      default: false
+      required: false
+      type: bool
+    - name: policies.outdatedImageBases.enforcementAction
+      displayName: Outdated image bases enforcement action
+      description: Gatekeeper enforcementAction for outdated-image-bases (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.outdatedImageBases.imageCheckerURL
+      displayName: Image checker URL (outdated-image-bases)
+      description: URL of the doop-image-checker service. Required when outdated-image-bases is enabled.
+      required: false
+      type: string
+    - name: policies.outdatedImageBases.createdAtHeader
+      displayName: Image creation timestamp header
+      description: Name of the HTTP response header from doop-image-checker that carries the minimum layer creation timestamp (Unix seconds).
+      required: false
+      type: string
+    - name: policies.outdatedImageBases.maxAgeDays
+      displayName: Outdated image bases max age (days)
+      description: Containers whose base image is older than this many days are flagged.
+      default: 365
+      required: false
+      type: int
+
+    - name: policies.vulnerableImages.enabled
+      displayName: Vulnerable images policy enabled
+      description: Enable the vulnerable-images policy. Requires gatekeeper-doop.
+      default: false
+      required: false
+      type: bool
+    - name: policies.vulnerableImages.enforcementAction
+      displayName: Vulnerable images enforcement action
+      description: Gatekeeper enforcementAction for vulnerable-images (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.vulnerableImages.imageCheckerURL
+      displayName: Image checker URL (vulnerable-images)
+      description: URL of the doop-image-checker service. Required when vulnerable-images is enabled.
+      required: false
+      type: string
+    - name: policies.vulnerableImages.vulnStatusHeader
+      displayName: Vulnerability status header
+      description: Name of the HTTP response header from doop-image-checker that carries the vulnerability status. Required when vulnerable-images is enabled.
+      required: false
+      type: string

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - exposed-services/plugindefinition.yaml
   - external-dns/plugindefinition.yaml
   - gatekeeper/plugindefinition.yaml
+  - gatekeeper-config/plugindefinition.yaml
   - repo-guard/plugindefinition.yaml
   - ingress-nginx/plugindefinition.yaml
   - kafka/plugindefinition.yaml


### PR DESCRIPTION
## Pull Request Details

Add a new `gatekeeper-config` PluginDefinition that delivers OPA Gatekeeper admission policies (ConstraintTemplates + Constraints). Complements the `gatekeeper` PluginDefinition (#1572), which deploys the controller itself.

- policies ported from `sapcc/helm-charts`, all toggle-able via `optionValues`.
- Defaults: `enabled: true`, `enforcementAction: dryrun`
- doop-dependent policies (`outdated-image-bases`, `vulnerable-images`, `oli-labels-required`) default to disabled.
- `oli-labels-required` is new (replaces the legacy `owner-info-on-helm-releases` check)

## Breaking Changes

None.

## Issues Fixed

N/A

## Other Relevant Information

Depends on the `gatekeeper` PluginDefinition (#1572) for the controller.
