### PR TITLE
feat(gatekeeper-config): foundation chart with two universal policies

### DIFF
--- a/.github/workflows/gatekeeper-config-tests.yaml
+++ b/.github/workflows/gatekeeper-config-tests.yaml
@@ -5,6 +5,11 @@ on:
     paths:
       - gatekeeper-config/**
       - .github/workflows/gatekeeper-config-tests.yaml
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref }}
+  cancel-in-progress: true
 
 jobs:
   gator-verify:
@@ -26,4 +31,15 @@ jobs:
           gator version
 
       - name: Run gator tests
-        run: gatekeeper-config/tests/run.sh
+        run: gatekeeper-config/tests/run.sh | tee /tmp/gator.log
+
+      - name: Summarize results
+        if: always()
+        run: |
+          PASSED=$(grep -c -- "--- PASS:" /tmp/gator.log) || PASSED=0
+          FAILED=$(grep -c -- "--- FAIL:" /tmp/gator.log) || FAILED=0
+          {
+            echo "## gator results"
+            echo ""
+            echo "${PASSED} passed, ${FAILED} failed"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/gatekeeper-config-tests.yaml
+++ b/.github/workflows/gatekeeper-config-tests.yaml
@@ -1,0 +1,29 @@
+name: gatekeeper-config tests
+
+on:
+  pull_request:
+    paths:
+      - gatekeeper-config/**
+      - .github/workflows/gatekeeper-config-tests.yaml
+
+jobs:
+  gator-verify:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Helm
+        uses: azure/setup-helm@dda3372f752e03dde6b3237bc9431cdc2f7a02a2 # v5.0.0
+        with:
+          version: "v3.19.2"
+
+      - name: Install gator
+        env:
+          GATOR_VERSION: v3.22.2
+        run: |
+          curl -sL "https://github.com/open-policy-agent/gatekeeper/releases/download/${GATOR_VERSION}/gator-${GATOR_VERSION}-linux-amd64.tar.gz" \
+            | sudo tar xz -C /usr/local/bin gator
+          gator version
+
+      - name: Run gator tests
+        run: gatekeeper-config/tests/run.sh

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -15,6 +15,7 @@ on:
       - exposed-services/charts/v1.0.0/exposed-service/**
       - exposed-services/charts/v2.0.0/exposed-service/**
       - gatekeeper/charts/**
+      - gatekeeper-config/charts/**
       - kafka/charts/**
       - kube-monitoring/charts/**
       - kubeconfig-generator/chart/**
@@ -63,6 +64,8 @@ jobs:
             chartName: exposed-services
           - chartDir: gatekeeper/charts
             chartName: gatekeeper
+          - chartDir: gatekeeper-config/charts
+            chartName: gatekeeper-config
           - chartDir: kafka/charts
             chartName: kafka
           - chartDir: kube-monitoring/charts

--- a/gatekeeper-config/README.md
+++ b/gatekeeper-config/README.md
@@ -20,3 +20,21 @@ All policies default to `enforcementAction: dryrun`. No policy will block admiss
 ## Adding more policies
 
 The chart is structured so that additional ConstraintTemplate/Constraint pairs can be added incrementally as standalone Helm templates that include the shared Rego libraries from `_helpers.tpl`. Each policy is gated on `policies.<name>.enabled` and exposes its parameters as PluginDefinition options.
+
+## Running tests
+
+Policy logic is unit-tested with [gator](https://open-policy-agent.github.io/gatekeeper/website/docs/gator) so that ConstraintTemplate Rego can be tested without a Kubernetes cluster.
+
+To run the suite locally:
+
+```sh
+# install gator and pin to the same version as the gatekeeper operator chart
+GATOR_VERSION=v3.22.2
+curl -sL "https://github.com/open-policy-agent/gatekeeper/releases/download/${GATOR_VERSION}/gator-${GATOR_VERSION}-$(uname -s | tr '[:upper:]' '[:lower:]')-$(uname -m | sed 's/x86_64/amd64/').tar.gz" \
+  | sudo tar xz -C /usr/local/bin gator
+
+# render the chart with test values and run gator
+./tests/run.sh
+```
+
+Adding a policy means adding a fixture directory under `tests/fixtures/<policy>/` and a section in `tests/suite.yaml`.

--- a/gatekeeper-config/README.md
+++ b/gatekeeper-config/README.md
@@ -1,0 +1,22 @@
+---
+title: OPA Gatekeeper Config
+---
+
+Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control. Provides a library of universal admission policies that can be enabled and tuned per cluster.
+
+Requires the [OPA Gatekeeper](https://github.com/cloudoperators/greenhouse-extensions/tree/main/gatekeeper) PluginDefinition to be installed on the cluster.
+
+## Policies
+
+| Policy | Description |
+|--------|-------------|
+| `highCpuRequests` | Flags workloads that request more than `maxCpu` cores in total across containers and initContainers. |
+| `unmanagedPods` | Flags Pods that have no `ownerReference` (i.e. not managed by a Deployment, DaemonSet, etc.). |
+
+## Default behavior
+
+All policies default to `enforcementAction: dryrun`. No policy will block admission by default. Change `enforcementAction` to `warn` or `deny` to enforce.
+
+## Adding more policies
+
+The chart is structured so that additional ConstraintTemplate/Constraint pairs can be added incrementally as standalone Helm templates that include the shared Rego libraries from `_helpers.tpl`. Each policy is gated on `policies.<name>.enabled` and exposes its parameters as PluginDefinition options.

--- a/gatekeeper-config/charts/Chart.yaml
+++ b/gatekeeper-config/charts/Chart.yaml
@@ -1,0 +1,20 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+description: Helm chart deploying OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control.
+name: gatekeeper-config
+version: 0.1.0
+appVersion: 0.1.0
+icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
+keywords:
+  - gatekeeper
+  - opa
+  - policy
+  - admission-control
+sources:
+  - https://github.com/cloudoperators/greenhouse-extensions
+maintainers:
+  - name: mikolajkucinski
+  - name: abhijith-darshan
+  - name: uwe-mayer

--- a/gatekeeper-config/charts/templates/_helpers.tpl
+++ b/gatekeeper-config/charts/templates/_helpers.tpl
@@ -1,0 +1,102 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{/*
+Shared Rego libraries inlined into every ConstraintTemplate.
+
+  add_support_labels: annotates violation messages with the
+    greenhouse.sap/owned-by label so reports can be routed to the right team.
+
+  traversal: walks the Kubernetes ownership chain (Pod, ReplicaSet,
+    Deployment, etc.) so policies can target the workload owner instead of
+    the synthesized Pod.
+*/}}
+
+{{- define "gatekeeper-config.lib.add_support_labels" -}}
+package lib.add_support_labels
+
+# `obj` must be a full Kubernetes object.
+from_k8s_object(obj, msg) := result if {
+	owned_by := object.get(obj, ["metadata", "labels", "greenhouse.sap/owned-by"], "none")
+	result := sprintf("{\"owned_by\":%s} >> %s", [json.marshal(owned_by), msg])
+}
+
+# `body` must be the response body from helm-manifest-parser
+from_helm_release(body, msg) := result if {
+	owned_by := object.get(body, ["owner_info", "owned-by"], "none")
+	result := sprintf("{\"owned_by\":%s} >> %s", [json.marshal(owned_by), msg])
+}
+
+# Adds an additional label to a message that already had support labels added with one of the above methods.
+extra(key, value, msg) := result if {
+	result := sprintf("{%s:%s,%s", [json.marshal(key), json.marshal(value), trim_prefix(msg, "{")])
+}
+{{- end }}
+
+{{- define "gatekeeper-config.lib.traversal" -}}
+package lib.traversal
+
+default find_pod(obj) := {"isFound": false}
+
+find_pod(obj) := result if {
+	obj.kind == "Pod"
+	result := __return_pod_unless_suppressed(obj, __list_suppressing_owners(obj))
+}
+
+find_pod(obj) := result if {
+	obj.kind != "Pod"
+	location := object.get(__pod_template_locations, [obj.kind], [])
+	location != []
+	pod := object.get(obj, location, {})
+	result := __return_pod_unless_suppressed(pod, __list_suppressing_owners(obj))
+}
+
+find_container_specs(obj) := result if {
+	result := __extract_container_specs(find_pod(obj))
+}
+
+__pod_template_locations := {
+	"CronJob": ["spec", "jobTemplate", "spec", "template"],
+	"DaemonSet": ["spec", "template"],
+	"Deployment": ["spec", "template"],
+	"Job": ["spec", "template"],
+	"ReplicaSet": ["spec", "template"],
+	"StatefulSet": ["spec", "template"],
+}
+
+__suppressing_owner_kinds := {
+	"Job": ["CronJob"],
+	"Pod": ["DaemonSet", "Job", "ReplicaSet", "StatefulSet"],
+	"ReplicaSet": ["Deployment"],
+}
+
+__list_suppressing_owners(obj) := result if {
+	possible_owners := object.get(__suppressing_owner_kinds, [obj.kind], [])
+	result := [ref.kind |
+		ref := obj.metadata.ownerReferences[_]
+		ref.kind == possible_owners[_]
+	]
+}
+
+__return_pod_unless_suppressed(obj, owners) := result if {
+	count(owners) > 0
+	result := {"isFound": false}
+}
+
+__return_pod_unless_suppressed(obj, owners) := result if {
+	count(owners) == 0
+	result := object.union(obj, {"isFound": true})
+}
+
+__extract_container_specs(pod) := [] if {
+	not pod.isFound
+}
+
+__extract_container_specs(pod) := result if {
+	pod.isFound
+	result := array.concat(
+		object.get(pod.spec, "containers", []),
+		object.get(pod.spec, "initContainers", []),
+	)
+}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.policies.highCpuRequests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkHighCPURequests
+metadata:
+  name: high-cpu-requests
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.highCpuRequests.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    maxCpu: 6
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
@@ -19,5 +19,5 @@ spec:
         kinds: ["Job", "CronJob"]
     scope: Namespaced
   parameters:
-    maxCpu: 6
+    maxCpu: {{ .Values.policies.highCpuRequests.maxCpu }}
 {{- end }}

--- a/gatekeeper-config/charts/templates/constraint-libtest-add-support-labels.yaml
+++ b/gatekeeper-config/charts/templates/constraint-libtest-add-support-labels.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.tests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkLibtestAddSupportLabels
+metadata:
+  name: libtest-add-support-labels
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    scope: Namespaced
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-libtest-traversal.yaml
+++ b/gatekeeper-config/charts/templates/constraint-libtest-traversal.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.tests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkLibtestTraversal
+metadata:
+  name: libtest-traversal
+spec:
+  enforcementAction: dryrun
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-unmanaged-pods.yaml
+++ b/gatekeeper-config/charts/templates/constraint-unmanaged-pods.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.policies.unmanagedPods.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkUnmanagedPods
+metadata:
+  name: unmanaged-pods
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.unmanagedPods.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    scope: Namespaced
+  parameters:
+    allowedNamePatterns:
+      {{- toYaml .Values.policies.unmanagedPods.allowedNamePatterns | nindent 6 }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-high-cpu-requests.yaml
@@ -44,14 +44,14 @@ spec:
               }
 
               canonify_cpu(orig) := new if {
-                  not is_number(orig)
+                  is_string(orig)
                   not endswith(orig, "m")
                   regex.match(`^[0-9]*\.?[0-9]+$`, orig)
                   new := to_number(orig)
               }
 
               canonify_cpu(orig) := new if {
-                  not is_number(orig)
+                  is_string(orig)
                   endswith(orig, "m")
                   regex.match(`^[0-9]*\.?[0-9]+m$`, orig)
                   new := to_number(replace(orig, "m", "")) / 1000

--- a/gatekeeper-config/charts/templates/constrainttemplate-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-high-cpu-requests.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.policies.highCpuRequests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkhighcpurequests
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkHighCPURequests
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            maxCpu:
+              type: integer
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package highcpurequests
+
+              import data.lib.add_support_labels
+              import data.lib.traversal
+
+              # canonify_cpu converts a Kubernetes CPU quantity to a number of cores.
+              # Bare numbers and millicore strings ("500m") are supported. Anything
+              # else returns null so the caller can report it as malformed instead of
+              # silently dropping the container from the sum.
+              canonify_cpu(orig) := new if {
+                  is_number(orig)
+                  new := orig
+              }
+
+              canonify_cpu(orig) := new if {
+                  not is_number(orig)
+                  not endswith(orig, "m")
+                  regex.match(`^[0-9]*\.?[0-9]+$`, orig)
+                  new := to_number(orig)
+              }
+
+              canonify_cpu(orig) := new if {
+                  not is_number(orig)
+                  endswith(orig, "m")
+                  regex.match(`^[0-9]*\.?[0-9]+m$`, orig)
+                  new := to_number(replace(orig, "m", "")) / 1000
+              }
+
+              default canonify_cpu(orig) := null
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+
+              # Flag any container whose CPU request cannot be parsed. This is a
+              # separate violation so that operators see the offending value rather
+              # than the sum silently understating real demand.
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  container := array.concat(
+                      object.get(pod.spec, "containers", []),
+                      object.get(pod.spec, "initContainers", []),
+                  )[_]
+                  raw := object.get(container, ["resources", "requests", "cpu"], null)
+                  raw != null
+                  canonify_cpu(raw) == null
+                  msg := sprintf("container %q has a malformed CPU request: %q", [container.name, raw])
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+
+                  values := [v |
+                      c := array.concat(
+                          object.get(pod.spec, "containers", []),
+                          object.get(pod.spec, "initContainers", []),
+                      )[_]
+                      raw := object.get(c, ["resources", "requests", "cpu"], null)
+                      raw != null
+                      v := canonify_cpu(raw)
+                      v != null
+                  ]
+                  total_cpu := sum(values)
+                  total_cpu > input.parameters.maxCpu
+
+                  msg := sprintf("requests %v CPU in total across containers and initContainers", [total_cpu])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-libtest-add-support-labels.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-libtest-add-support-labels.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.tests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gklibtestaddsupportlabels
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkLibtestAddSupportLabels
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package libtestaddsupportlabels
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  iro.kind == "Pod"
+                  msg := "test for from_k8s_object()"
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-libtest-traversal.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-libtest-traversal.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.tests.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gklibtesttraversal
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkLibtestTraversal
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package libtesttraversal
+
+              import data.lib.traversal
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+              container_specs := traversal.find_container_specs(iro)
+              container_names := concat(", ", sort([sprintf("%q", [c.name]) | c := container_specs[_]]))
+
+              violation contains {"msg": msg} if {
+                  not pod.isFound
+                  count(container_specs) == 0
+                  msg := "no relevant pod found"
+              }
+
+              violation contains {"msg": msg} if {
+                  pod.isFound
+                  marker := object.get(pod, ["metadata", "labels", "marker"], "")
+                  msg := sprintf("found a relevant pod with marker %q and containers %s", [marker, container_names])
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-unmanaged-pods.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-unmanaged-pods.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.policies.unmanagedPods.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkunmanagedpods
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkUnmanagedPods
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            allowedNamePatterns:
+              type: array
+              items:
+                description: per-namespace name pattern that exempts a Pod from this policy
+                type: object
+                properties:
+                  namespace:
+                    type: string
+                  namePattern:
+                    type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+            rego: |
+              package unmanagedpods
+
+              import data.lib.add_support_labels
+
+              iro := input.review.object
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  iro.kind == "Pod"
+                  object.get(iro.metadata, ["ownerReferences"], []) == []
+                  not is_allowed_by_exception
+                  msg := "pod is not owned by a managing construct"
+              }
+
+              default is_allowed_by_exception := false
+
+              is_allowed_by_exception if {
+                  entry := input.parameters.allowedNamePatterns[_]
+                  iro.metadata.namespace == entry.namespace
+                  regex.match(sprintf("^(?:%s)$", [entry.namePattern]), iro.metadata.name)
+              }
+{{- end }}

--- a/gatekeeper-config/charts/values.yaml
+++ b/gatekeeper-config/charts/values.yaml
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+policies:
+  highCpuRequests:
+    enabled: true
+    enforcementAction: dryrun
+
+  unmanagedPods:
+    enabled: true
+    enforcementAction: dryrun
+    allowedNamePatterns: []

--- a/gatekeeper-config/charts/values.yaml
+++ b/gatekeeper-config/charts/values.yaml
@@ -11,3 +11,6 @@ policies:
     enabled: true
     enforcementAction: dryrun
     allowedNamePatterns: []
+
+tests:
+  enabled: false

--- a/gatekeeper-config/charts/values.yaml
+++ b/gatekeeper-config/charts/values.yaml
@@ -5,6 +5,7 @@ policies:
   highCpuRequests:
     enabled: true
     enforcementAction: dryrun
+    maxCpu: 6
 
   unmanagedPods:
     enabled: true

--- a/gatekeeper-config/plugindefinition.yaml
+++ b/gatekeeper-config/plugindefinition.yaml
@@ -1,0 +1,51 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: gatekeeper-config
+spec:
+  version: 0.1.0
+  displayName: Gatekeeper Config
+  description: |
+    Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes
+    admission control. Provides a library of universal admission policies that
+    can be enabled and tuned per cluster.
+  icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/gatekeeper-config/README.md
+  helmChart:
+    name: gatekeeper-config
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    version: 0.1.0
+  options:
+    - name: policies.highCpuRequests.enabled
+      displayName: High CPU requests policy enabled
+      description: Enable the high-cpu-requests policy.
+      default: true
+      required: false
+      type: bool
+    - name: policies.highCpuRequests.enforcementAction
+      displayName: High CPU requests enforcement action
+      description: Gatekeeper enforcementAction for high-cpu-requests (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+
+    - name: policies.unmanagedPods.enabled
+      displayName: Unmanaged pods policy enabled
+      description: Enable the unmanaged-pods policy.
+      default: true
+      required: false
+      type: bool
+    - name: policies.unmanagedPods.enforcementAction
+      displayName: Unmanaged pods enforcement action
+      description: Gatekeeper enforcementAction for unmanaged-pods (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.unmanagedPods.allowedNamePatterns
+      displayName: Allowed unmanaged-pod name patterns
+      description: List of {namespace, namePattern} entries that exempt matching Pods from the unmanaged-pods policy.
+      required: false
+      type: list

--- a/gatekeeper-config/plugindefinition.yaml
+++ b/gatekeeper-config/plugindefinition.yaml
@@ -31,6 +31,12 @@ spec:
       default: dryrun
       required: false
       type: string
+    - name: policies.highCpuRequests.maxCpu
+      displayName: High CPU requests max CPU
+      description: Maximum total CPU (cores) a workload may request across all containers and initContainers before being flagged.
+      default: 6
+      required: false
+      type: int
 
     - name: policies.unmanagedPods.enabled
       displayName: Unmanaged pods policy enabled

--- a/gatekeeper-config/tests/.gitignore
+++ b/gatekeeper-config/tests/.gitignore
@@ -1,0 +1,1 @@
+rendered/

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-close-violation.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-close-violation.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    greenhouse.sap/owned-by: my-team
+spec:
+  containers:
+  - name: dummy-big
+    image: alpine:3
+    args: ["sleep", "86400"]
+    resources:
+      requests:
+        cpu: "5.8"
+        memory: 2Gi
+  - name: dummy-small
+    image: alpine:3
+    args: ["sleep", "86400"]
+    resources:
+      requests:
+        cpu: 64m
+        memory: 64Mi

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-close-violation.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-close-violation.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-failure.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-failure.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    greenhouse.sap/owned-by: my-team
+spec:
+  containers:
+  - name: dummy-big
+    image: alpine:3
+    args: ["sleep", "86400"]
+    resources:
+      requests:
+        cpu: "6"
+        memory: 2Gi
+  - name: dummy-small
+    image: alpine:3
+    args: ["sleep", "86400"]
+    resources:
+      requests:
+        cpu: 64m
+        memory: 64Mi

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-failure.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-failure.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-malformed-cpu.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-malformed-cpu.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-malformed-cpu.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-malformed-cpu.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    greenhouse.sap/owned-by: my-team
+spec:
+  containers:
+  - name: dummy
+    image: alpine:3
+    args: ["sleep", "86400"]
+    resources:
+      requests:
+        cpu: "500xyz"
+        memory: 2Gi

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-no-limits.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-no-limits.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    greenhouse.sap/owned-by: my-team
+spec:
+  containers:
+  - name: dummy-1
+    image: alpine:3
+    args: ["sleep", "86400"]
+  - name: dummy-2
+    image: alpine:3
+    args: ["sleep", "86400"]

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-no-limits.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-no-limits.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-only-one-limit.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-only-one-limit.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-only-one-limit.yaml
+++ b/gatekeeper-config/tests/fixtures/high-cpu-requests/pod-only-one-limit.yaml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    greenhouse.sap/owned-by: my-team
+spec:
+  containers:
+  - name: dummy-1
+    image: alpine:3
+    args: ["sleep", "86400"]
+    resources:
+      requests:
+        cpu: "5"
+        memory: 2Gi
+  - name: dummy-2
+    image: alpine:3
+    args: ["sleep", "86400"]

--- a/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-filled.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-filled.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-filled.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-filled.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+  labels:
+    greenhouse.sap/owned-by: my-team
+spec:
+  containers:
+  - name: dummy
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-missing.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-missing.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  containers:
+  - name: dummy
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-missing.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-add-support-labels/pod-missing.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/cronjob.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/cronjob.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: batch/v1
 kind: CronJob
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/cronjob.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  schedule: "* * * * *"
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          labels:
+            marker: "pod in cronjob"
+        spec:
+          containers:
+          - name: alpine
+            image: alpine:3
+          initContainers:
+          - name: init-busybox
+            image: busybox:1

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/daemonset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/daemonset.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: DaemonSet
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/daemonset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/daemonset.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "pod in daemonset"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3
+      initContainers:
+      - name: init-busybox
+        image: busybox:1

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/deployment.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/deployment.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/deployment.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/deployment.yaml
@@ -1,0 +1,17 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "pod in deployment"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3
+      initContainers:
+      - name: init-busybox
+        image: busybox:1

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/job-in-cronjob.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/job-in-cronjob.yaml
@@ -1,0 +1,20 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cronjob-spawned
+  namespace: default
+  ownerReferences:
+  - apiVersion: batch/v1
+    kind: CronJob
+    name: parent-cronjob
+    uid: 00000000-0000-0000-0000-000000000003
+    controller: true
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "job in cronjob (suppressed)"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/job-in-cronjob.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/job-in-cronjob.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/job.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/job.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: batch/v1
 kind: Job
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/job.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/job.yaml
@@ -1,0 +1,14 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "pod in job"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-daemonset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-daemonset.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-daemonset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-daemonset.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ds-pod-xyz
+  namespace: default
+  labels:
+    marker: "pod in daemonset (suppressed)"
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: DaemonSet
+    name: parent-ds
+    uid: 00000000-0000-0000-0000-000000000001
+    controller: true
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-job.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-job.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: job-pod-xyz
+  namespace: default
+  labels:
+    marker: "pod in job (suppressed)"
+  ownerReferences:
+  - apiVersion: batch/v1
+    kind: Job
+    name: parent-job
+    uid: 00000000-0000-0000-0000-000000000002
+    controller: true
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-job.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-job.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-replicaset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-replicaset.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: rs-pod-xyz
+  namespace: default
+  labels:
+    marker: "pod in replicaset (suppressed)"
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: ReplicaSet
+    name: parent-rs
+    uid: 00000000-0000-0000-0000-000000000004
+    controller: true
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-replicaset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-replicaset.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-statefulset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-statefulset.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-statefulset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-statefulset.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sts-pod-0
+  namespace: default
+  labels:
+    marker: "pod in statefulset (suppressed)"
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: StatefulSet
+    name: parent-sts
+    uid: 00000000-0000-0000-0000-000000000005
+    controller: true
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-unknown-owner.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-unknown-owner.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: custom-owned-pod
+  namespace: default
+  labels:
+    marker: "pod in unknown owner"
+  ownerReferences:
+  - apiVersion: dummy/v1
+    kind: SomethingThatCreatesPods
+    name: custom-controller
+    uid: 00000000-0000-0000-0000-000000000006
+    controller: true
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-unknown-owner.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-in-unknown-owner.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-minimal.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-minimal.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: minimal-pod
+  namespace: default
+  labels:
+    marker: "minimal pod"
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod-minimal.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod-minimal.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/pod.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/pod.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: individual-pod
+  namespace: default
+  labels:
+    marker: "individual pod"
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3
+  initContainers:
+  - name: init-busybox
+    image: busybox:1

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset-in-deployment.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset-in-deployment.yaml
@@ -1,0 +1,20 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: deployment-spawned
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: parent-deployment
+    uid: 00000000-0000-0000-0000-000000000007
+    controller: true
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "replicaset in deployment (suppressed)"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset-in-deployment.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset-in-deployment.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/replicaset.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "pod in replicaset"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/statefulset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/statefulset.yaml
@@ -1,0 +1,14 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: dummy
+  namespace: default
+spec:
+  template:
+    metadata:
+      labels:
+        marker: "pod in statefulset"
+    spec:
+      containers:
+      - name: alpine
+        image: alpine:3

--- a/gatekeeper-config/tests/fixtures/libtest-traversal/statefulset.yaml
+++ b/gatekeeper-config/tests/fixtures/libtest-traversal/statefulset.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-in-deployment.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-in-deployment.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-in-deployment.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-in-deployment.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: managed-pod-abc123
+  namespace: default
+  ownerReferences:
+  - apiVersion: apps/v1
+    kind: ReplicaSet
+    name: managed-rs
+    uid: 00000000-0000-0000-0000-000000000000
+    controller: true
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3.18
+    command: [sleep, inf]

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-with-prefix-bypass.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-with-prefix-bypass.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-with-prefix-bypass.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-with-prefix-bypass.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: evil-recycler-for-foo
+  namespace: default
+spec:
+  containers:
+  - name: evil
+    image: alpine:3.18
+    command: [sleep, inf]

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-without-owner.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-without-owner.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-without-owner.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pod-without-owner.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: bare-pod
+  namespace: default
+spec:
+  containers:
+  - name: alpine
+    image: alpine:3.18
+    command: [sleep, inf]

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pv-recycler-pod.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pv-recycler-pod.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: recycler-for-pv-001
+  namespace: default
+spec:
+  containers:
+  - name: pv-recycler
+    image: registry.k8s.io/debian-base:v2.0.0
+    command: [/bin/sh]
+    args: [-c, "test -e /scrub && find /scrub -mindepth 1 -delete"]

--- a/gatekeeper-config/tests/fixtures/unmanaged-pods/pv-recycler-pod.yaml
+++ b/gatekeeper-config/tests/fixtures/unmanaged-pods/pv-recycler-pod.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 apiVersion: v1
 kind: Pod
 metadata:

--- a/gatekeeper-config/tests/run.sh
+++ b/gatekeeper-config/tests/run.sh
@@ -1,4 +1,7 @@
 #!/usr/bin/env bash
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 # Usage: ./run.sh [extra gator args]
 set -euo pipefail
 

--- a/gatekeeper-config/tests/run.sh
+++ b/gatekeeper-config/tests/run.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+# Usage: ./run.sh [extra gator args]
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+rm -rf rendered
+helm template ../charts -f values-test.yaml --output-dir rendered >/dev/null
+
+gator verify -v . "$@"

--- a/gatekeeper-config/tests/suite.yaml
+++ b/gatekeeper-config/tests/suite.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 kind: Suite
 apiVersion: test.gatekeeper.sh/v1alpha1
 metadata:

--- a/gatekeeper-config/tests/suite.yaml
+++ b/gatekeeper-config/tests/suite.yaml
@@ -1,0 +1,154 @@
+kind: Suite
+apiVersion: test.gatekeeper.sh/v1alpha1
+metadata:
+  name: gatekeeper-config-tests
+tests:
+
+# --- library tests ---
+
+- name: libtest-add-support-labels
+  template: rendered/gatekeeper-config/templates/constrainttemplate-libtest-add-support-labels.yaml
+  constraint: rendered/gatekeeper-config/templates/constraint-libtest-add-support-labels.yaml
+  cases:
+  - name: pod-with-owned-by-label
+    object: fixtures/libtest-add-support-labels/pod-filled.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"owned_by":"my-team"\} >> test for from_k8s_object\(\)$'
+  - name: pod-without-owned-by-label
+    object: fixtures/libtest-add-support-labels/pod-missing.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"owned_by":"none"\} >> test for from_k8s_object\(\)$'
+
+- name: libtest-traversal
+  template: rendered/gatekeeper-config/templates/constrainttemplate-libtest-traversal.yaml
+  constraint: rendered/gatekeeper-config/templates/constraint-libtest-traversal.yaml
+  cases:
+  - name: cronjob
+    object: fixtures/libtest-traversal/cronjob.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in cronjob" and containers "alpine", "init-busybox"$'
+  - name: daemonset
+    object: fixtures/libtest-traversal/daemonset.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in daemonset" and containers "alpine", "init-busybox"$'
+  - name: deployment
+    object: fixtures/libtest-traversal/deployment.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in deployment" and containers "alpine", "init-busybox"$'
+  - name: job
+    object: fixtures/libtest-traversal/job.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in job" and containers "alpine"$'
+  - name: replicaset
+    object: fixtures/libtest-traversal/replicaset.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in replicaset" and containers "alpine"$'
+  - name: statefulset
+    object: fixtures/libtest-traversal/statefulset.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in statefulset" and containers "alpine"$'
+  - name: standalone-pod
+    object: fixtures/libtest-traversal/pod.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "individual pod" and containers "alpine", "init-busybox"$'
+  - name: pod-minimal
+    object: fixtures/libtest-traversal/pod-minimal.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "minimal pod" and containers "alpine"$'
+  - name: pod-in-daemonset-suppressed
+    object: fixtures/libtest-traversal/pod-in-daemonset.yaml
+    assertions:
+    - violations: 1
+      message: '^no relevant pod found$'
+  - name: pod-in-job-suppressed
+    object: fixtures/libtest-traversal/pod-in-job.yaml
+    assertions:
+    - violations: 1
+      message: '^no relevant pod found$'
+  - name: pod-in-replicaset-suppressed
+    object: fixtures/libtest-traversal/pod-in-replicaset.yaml
+    assertions:
+    - violations: 1
+      message: '^no relevant pod found$'
+  - name: pod-in-statefulset-suppressed
+    object: fixtures/libtest-traversal/pod-in-statefulset.yaml
+    assertions:
+    - violations: 1
+      message: '^no relevant pod found$'
+  - name: pod-with-unknown-owner-not-suppressed
+    object: fixtures/libtest-traversal/pod-in-unknown-owner.yaml
+    assertions:
+    - violations: 1
+      message: '^found a relevant pod with marker "pod in unknown owner" and containers "alpine"$'
+  - name: job-in-cronjob-suppressed
+    object: fixtures/libtest-traversal/job-in-cronjob.yaml
+    assertions:
+    - violations: 1
+      message: '^no relevant pod found$'
+  - name: replicaset-in-deployment-suppressed
+    object: fixtures/libtest-traversal/replicaset-in-deployment.yaml
+    assertions:
+    - violations: 1
+      message: '^no relevant pod found$'
+
+# --- policy tests ---
+
+- name: high-cpu-requests
+  template: rendered/gatekeeper-config/templates/constrainttemplate-high-cpu-requests.yaml
+  constraint: rendered/gatekeeper-config/templates/constraint-high-cpu-requests.yaml
+  cases:
+  - name: pod-over-threshold
+    object: fixtures/high-cpu-requests/pod-failure.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"owned_by":"my-team"\} >> requests 6\.064 CPU in total across containers and initContainers$'
+  - name: pod-just-under-threshold
+    object: fixtures/high-cpu-requests/pod-close-violation.yaml
+    assertions:
+    - violations: 0
+  - name: pod-only-one-request
+    object: fixtures/high-cpu-requests/pod-only-one-limit.yaml
+    assertions:
+    - violations: 0
+  - name: pod-no-requests
+    object: fixtures/high-cpu-requests/pod-no-limits.yaml
+    assertions:
+    - violations: 0
+  - name: pod-malformed-cpu-value
+    object: fixtures/high-cpu-requests/pod-malformed-cpu.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"owned_by":"my-team"\} >> container "dummy" has a malformed CPU request: "500xyz"$'
+
+- name: unmanaged-pods
+  template: rendered/gatekeeper-config/templates/constrainttemplate-unmanaged-pods.yaml
+  constraint: rendered/gatekeeper-config/templates/constraint-unmanaged-pods.yaml
+  cases:
+  - name: bare-pod-flagged
+    object: fixtures/unmanaged-pods/pod-without-owner.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"owned_by":"none"\} >> pod is not owned by a managing construct$'
+  - name: pod-with-owner-skipped
+    object: fixtures/unmanaged-pods/pod-in-deployment.yaml
+    assertions:
+    - violations: 0
+  - name: recycler-pod-exempt-via-pattern
+    object: fixtures/unmanaged-pods/pv-recycler-pod.yaml
+    assertions:
+    - violations: 0
+  - name: anchoring-blocks-prefix-bypass
+    object: fixtures/unmanaged-pods/pod-with-prefix-bypass.yaml
+    assertions:
+    - violations: 1
+      message: '^\{"owned_by":"none"\} >> pod is not owned by a managing construct$'

--- a/gatekeeper-config/tests/values-test.yaml
+++ b/gatekeeper-config/tests/values-test.yaml
@@ -1,0 +1,12 @@
+policies:
+  highCpuRequests:
+    enabled: true
+    maxCpu: 6
+  unmanagedPods:
+    enabled: true
+    allowedNamePatterns:
+      - namespace: default
+        namePattern: "recycler-for-.*"
+
+tests:
+  enabled: true

--- a/gatekeeper-config/tests/values-test.yaml
+++ b/gatekeeper-config/tests/values-test.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
 policies:
   highCpuRequests:
     enabled: true

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -9,6 +9,7 @@ resources:
   - exposed-services/plugindefinition.yaml
   - external-dns/plugindefinition.yaml
   - gatekeeper/plugindefinition.yaml
+  - gatekeeper-config/plugindefinition.yaml
   - repo-guard/plugindefinition.yaml
   - ingress-nginx/plugindefinition.yaml
   - kafka/plugindefinition.yaml


### PR DESCRIPTION
## Pull Request Details

Add the `gatekeeper-config` PluginDefinition skeleton plus two universal admission policies. This is the foundation of a larger migration of OPA Gatekeeper policies into a Greenhouse PluginDefinition. 

**Differences vs upstream:**

| Policy / Lib | Upstream | This PR |
|---|---|---|
| `high-cpu-requests` | Only `containers` and silently drops malformed CPU values. | Includes `initContainers` and explicit violation on unparseable CPU. |
| `unmanaged-pods` | Hardcoded `^recycler-for-` exemption in `default` namespace. | `allowedNamePatterns` parameter (regex to prevent prefix bypass) |
| `_helpers.tpl::add_support_labels` | Writes `ccloud/support-group` + `ccloud/service` into messages. | Writes single `greenhouse.sap/owned-by`. |

## Breaking Changes

None. This adds a new PluginDefinition.

## Issues Fixed

- Partial progress on [#1420](https://github.com/cloudoperators/greenhouse-extensions/issues/1420)

## Other Relevant Information

None.
