### PR TITLE
feat(kafka): bump Kafka to 4.2.0

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -71,9 +71,10 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | kafka.replicas | int | `3` | Number of Kafka broker/controller replicas (for KRaft mode) |
 | kafka.resources | object | requests: 2Gi memory, 1 CPU; limits: 4Gi memory, 2 CPU | Resource configuration for Kafka brokers |
 | kafka.storage | object | JBOD with 100Gi persistent volume per broker | Storage configuration for Kafka brokers |
-| kafka.version | string | `"4.1.0"` | Kafka version |
+| kafka.version | string | `"4.2.0"` | Kafka version |
 | kafkaExporter.enabled | bool | `true` | Enable Kafka Exporter |
 | kafkaExporter.groupRegex | string | `".*"` | Consumer group regex for metrics export |
+| kafkaExporter.image | string | `""` | Override the kafka-exporter image. When empty, the operator default is used. |
 | kafkaExporter.resources | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | Kafka Exporter resource configuration |
 | kafkaExporter.topicRegex | string | `".*"` | Topic regex for metrics export |
 | monitoring.additionalRuleLabels | object | `{}` | Additional labels for PrometheusRule alerts |

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.7
+version: 0.1.8
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -13,7 +13,7 @@ maintainers:
 home: https://github.com/cloudoperators/greenhouse-extensions/tree/main/kafka
 sources:
   - https://github.com/strimzi/strimzi-kafka-operator
-appVersion: 4.1.0
+appVersion: 4.2.0
 dependencies:
   - name: strimzi-kafka-operator
     alias: operator

--- a/kafka/charts/templates/kafka.yaml
+++ b/kafka/charts/templates/kafka.yaml
@@ -34,6 +34,9 @@ spec:
   {{- end }}
   {{- if .Values.kafkaExporter.enabled }}
   kafkaExporter:
+    {{- with .Values.kafkaExporter.image }}
+    image: {{ . | quote }}
+    {{- end }}
     topicRegex: {{ .Values.kafkaExporter.topicRegex | quote }}
     groupRegex: {{ .Values.kafkaExporter.groupRegex | quote }}
     resources:

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -23,7 +23,7 @@ kafka:
   name: kafka
 
   # -- Kafka version
-  version: "4.1.0"
+  version: "4.2.0"
 
   # -- Number of Kafka broker/controller replicas (for KRaft mode)
   replicas: 3
@@ -117,6 +117,9 @@ entityOperator:
 kafkaExporter:
   # -- Enable Kafka Exporter
   enabled: true
+
+  # -- Override the kafka-exporter image. When empty, the operator default is used.
+  image: ""
 
   # -- Consumer group regex for metrics export
   groupRegex: ".*"

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -13,7 +13,7 @@ spec:
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.7
+    version: 0.1.8
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.7
+  version: 0.1.8
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'


### PR DESCRIPTION
## Pull Request Details

Bumps the Kafka version to 4.2.0 so brokers and Strimzi's default kafka-exporter (which tracks the latest Kafka release) stay aligned. Also adds an optional `kafkaExporter.image` field to be able to pin the exporter to a specific tag. 
