### PR TITLE
feat(opensearch): add S3 keystore secret for warm nodes and snapshots

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -235,6 +235,9 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | operator.useRoleBindings | bool | `false` |  |
 | operator.webhook.enabled | bool | `true` |  |
 | operator.webhook.failurePolicy | string | `"Ignore"` |  |
+| s3.clients | object | <pre>clients: {}</pre> | Map of S3 client names to credentials. |
+| s3.enabled | bool | `false` | Enable the S3 keystore Secret. When enabled, renders a Secret with `s3.client.<name>.access_key` / `s3.client.<name>.secret_key` entries for the repository-s3 plugin (warm nodes, snapshots). Wire the rendered Secret via `cluster.cluster.general.keystore` and configure endpoints under `cluster.cluster.general.additionalConfig`. |
+| s3.secretName | string | `"opensearch-s3-keystore"` | Name of the rendered Secret. |
 | serviceProxy.dashboards.enabled | bool | `true` | Expose the OpenSearch Dashboards UI through the Greenhouse service-proxy. When enabled, an extra `<cluster.cluster.name>-dashboards-ui` Service is rendered (falling back to `<release>-dashboards-ui` when `cluster.cluster.name` is not set) with the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches. |
 | testFramework.enabled | bool | `true` | Activates the Helm chart testing framework. |
 | testFramework.image.registry | string | `"ghcr.io"` | Defines the image registry for the test framework. |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.1.8
+version: 0.1.9
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/templates/s3-keystore-secret.yaml
+++ b/opensearch/chart/templates/s3-keystore-secret.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.s3.enabled .Values.s3.clients }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Values.s3.secretName | default "opensearch-s3-keystore" }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- range $name, $client := .Values.s3.clients }}
+  s3.client.{{ $name }}.access_key: {{ required (printf "s3.clients.%s.accessKey is required" $name) $client.accessKey | b64enc }}
+  s3.client.{{ $name }}.secret_key: {{ required (printf "s3.clients.%s.secretKey is required" $name) $client.secretKey | b64enc }}
+  {{- end }}
+{{- end }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -35,6 +35,27 @@ serviceProxy:
     # with the `greenhouse.sap/expose: "true"` annotation that the service-proxy watches.
     enabled: true
 
+s3:
+  # -- Enable the S3 keystore Secret. When enabled, renders a Secret with
+  # `s3.client.<name>.access_key` / `s3.client.<name>.secret_key` entries for
+  # the repository-s3 plugin (warm nodes, snapshots). Wire the rendered Secret
+  # via `cluster.cluster.general.keystore` and configure endpoints under
+  # `cluster.cluster.general.additionalConfig`.
+  enabled: false
+
+  # -- Name of the rendered Secret.
+  secretName: "opensearch-s3-keystore"
+
+  # -- Map of S3 client names to credentials.
+  # @default -- <pre>clients: {}</pre>
+  clients: {}
+  #  default:
+  #    accessKey: ""
+  #    secretKey: ""
+  #  ceph:
+  #    accessKey: ""
+  #    secretKey: ""
+
 certManager:
   # -- Enable cert-manager integration for issuing TLS certificates
   enable: true

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.1.8
+  version: 0.1.9
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.8
+    version: 0.1.9


### PR DESCRIPTION
## Pull Request Details

Adds `s3-keystore-secret.yaml` Secret containing access_key / secret_key entries for the repository-s3 plugin (used for warm node storage and S3 snapshot repositories). Credentials are wired into the cluster via cluster.cluster.general.keystore and S3 client endpoints via cluster.cluster.general.additionalConfig set through a PluginPreset.