### PR TITLE
chore(repo-guard): bump to 4.9.0

### DIFF
--- a/repo-guard/plugindefinition.yaml
+++ b/repo-guard/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: repo-guard
 spec:
-  version: "4.2.0"
+  version: "4.9.0"
   displayName: Repo Guard
   description: Repo Guard automates GitHub organization management using Kubernetes Custom Resources (CRDs)
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/repo-guard/refs/heads/main/README.md
   helmChart:
     name: repo-guard
     repository: oci://ghcr.io/cloudoperators/charts
-    version: 4.2.0
+    version: 4.9.0
   options:
     - name: manager
       description: Manager configuration


### PR DESCRIPTION
## Summary
- Bumps repo-guard extension from `4.2.0` to `4.9.0`
- Updates both `spec.version` and `spec.helmChart.version` in `plugindefinition.yaml`

## Test plan
- [ ] Verify the Helm chart `4.9.0` is available at `oci://ghcr.io/cloudoperators/charts`
- [ ] Confirm the plugin deploys successfully with the new version