### PR TITLE
fix(perses): perses-content alert fix

### DIFF
--- a/perses/charts/Chart.yaml
+++ b/perses/charts/Chart.yaml
@@ -3,7 +3,7 @@ name: perses
 description: A Helm chart for Perses
 icon: https://avatars.githubusercontent.com/u/77209215?s=200&v=4
 type: application
-version: 0.21.1
+version: 0.21.2
 maintainers:
   - name: richardtief
   - name: ibakshay

--- a/perses/charts/templates/rule-content-sync.yaml
+++ b/perses/charts/templates/rule-content-sync.yaml
@@ -15,9 +15,9 @@ spec:
         - alert: PersesContentSyncJobFailed
           annotations:
             summary: "Perses content sync job failed"
-            description: "The Perses content sync Job {{`{{ $labels.job_name }}`}} in namespace {{`{{ $labels.namespace }}`}} has failed. The Perses provisioning PVC has not been updated; new dashboards and datasources will not appear until the sync succeeds."
+            description: "The Perses content sync Job in namespace {{`{{ $labels.namespace }}`}} has failed. The Perses provisioning PVC has not been updated; new dashboards and datasources will not appear until the sync succeeds."
           expr: |
-            max by (namespace, job_name) (
+            max by (namespace) (
               kube_job_failed{job_name=~"{{ include "release.name" . }}-content-sync-.*",condition="true"}
             ) > 0
           for: 5m

--- a/perses/plugindefinition.yaml
+++ b/perses/plugindefinition.yaml
@@ -3,7 +3,7 @@ kind: PluginDefinition
 metadata:
   name: perses
 spec:
-  version: 0.14.1
+  version: 0.14.2
   displayName: Perses
   description: "Perses is a dashboard tooling to visualize metrics and traces produced by observability tools such as Prometheus/Thanos/Jaeger"
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/perses/README.md
@@ -11,7 +11,7 @@ spec:
   helmChart:
     name: perses
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.21.1
+    version: 0.21.2
   options:
     - description: "The image version of the Perses app. If not provided, the latest version will be used"
       name: perses.image.version


### PR DESCRIPTION
The alert was grouped by `job_name`, causing a new alert instance to be created for each CronJob execution. As a result, the alert could remain in `Pending` indefinitely and never satisfy the configured `for` duration.
