### PR TITLE
fix(opensearch): align cert SANs with the actual Service name

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.1
+version: 0.2.2
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -35,11 +35,11 @@ spec:
 {{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-transport-cert
   dnsNames:
-    - {{ $clusterName }}
-    - {{ printf "%s-discovery" $clusterName }}
-    - {{ printf "%s.%s" $clusterName .Release.Namespace }}
-    - {{ printf "%s.%s.svc" $clusterName .Release.Namespace }}
-    - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace }}
+    - {{ $clusterName | quote }}
+    - {{ printf "%s-discovery" $clusterName | quote }}
+    - {{ printf "%s.%s" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s.%s.svc" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace | quote }}
   usages:
 {{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 ---
@@ -76,10 +76,10 @@ spec:
 {{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-http-cert
   dnsNames:
-    - {{ $clusterName }}
-    - {{ printf "%s.%s" $clusterName .Release.Namespace }}
-    - {{ printf "%s.%s.svc" $clusterName .Release.Namespace }}
-    - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace }}
+    - {{ $clusterName | quote }}
+    - {{ printf "%s.%s" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s.%s.svc" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace | quote }}
   usages:
 {{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.certManager.enable }}
+{{- $clusterName := default (default .Release.Name .Values.cluster.cluster.name) (.Values.cluster.cluster.general).serviceName | trunc 63 | trimSuffix "-" }}
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: cert-manager.io/v1
@@ -34,11 +35,11 @@ spec:
 {{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-transport-cert
   dnsNames:
-    - opensearch
-    - opensearch-discovery
-    - {{ printf "opensearch.%s" .Release.Namespace }}
-    - {{ printf "opensearch.%s.svc" .Release.Namespace }}
-    - {{ printf "opensearch.%s.svc.cluster.local" .Release.Namespace }}
+    - {{ $clusterName }}
+    - {{ printf "%s-discovery" $clusterName }}
+    - {{ printf "%s.%s" $clusterName .Release.Namespace }}
+    - {{ printf "%s.%s.svc" $clusterName .Release.Namespace }}
+    - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace }}
   usages:
 {{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 ---
@@ -75,10 +76,10 @@ spec:
 {{ toYaml .Values.certManager.defaults.privateKey | indent 4 }}
   secretName: opensearch-http-cert
   dnsNames:
-    - opensearch
-    - {{ printf "opensearch.%s" .Release.Namespace }}
-    - {{ printf "opensearch.%s.svc" .Release.Namespace }}
-    - {{ printf "opensearch.%s.svc.cluster.local" .Release.Namespace }}
+    - {{ $clusterName }}
+    - {{ printf "%s.%s" $clusterName .Release.Namespace }}
+    - {{ printf "%s.%s.svc" $clusterName .Release.Namespace }}
+    - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace }}
   usages:
 {{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.1
+  version: 0.2.2
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.1
+    version: 0.2.2


### PR DESCRIPTION
## Pull Request Details

- HTTP and transport cert SANs were hardcoded to `opensearch.<ns>...`, but the operator names the Service after `general.serviceName`, then `cluster.cluster.name`, then the release name. In-cluster clients that verify TLS hit hostname mismatch.
- Derive `$clusterName` from those three sources in priority order and use it as the SAN base for both `opensearch-transport-cert` and `opensearch-http-cert`.