### PR TITLE
feat(opensearch): enable HTTP cert hot reload via security API

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -124,7 +124,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.cluster.dashboards.tls.secret | object | `{"name":"opensearch-http-cert"}` | Optional, name of a TLS secret that contains ca.crt, tls.key and tls.crt data. If ca.crt is in a different secret provide it via the caSecret field |
 | cluster.cluster.dashboards.tolerations | list | `[]` | dashboards pod tolerations |
 | cluster.cluster.dashboards.version | string | `"3.7.0"` | dashboards version |
-| cluster.cluster.general.additionalConfig | object | `{}` | Extra items to add to the opensearch.yml |
+| cluster.cluster.general.additionalConfig | object | `{"plugins.security.ssl_cert_reload_enabled":"true"}` | Extra items to add to the opensearch.yml. |
 | cluster.cluster.general.additionalVolumes | list | `[]` | Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema) |
 | cluster.cluster.general.drainDataNodes | bool | `false` | Controls whether to drain data notes on rolling restart operations |
 | cluster.cluster.general.httpPort | int | `9200` | Opensearch service http port |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.2
+version: 0.2.3
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -227,8 +227,9 @@ cluster:
 
     # OpenSearchCluster general configuration
     general:
-      # -- Extra items to add to the opensearch.yml
-      additionalConfig: {}
+      # -- Extra items to add to the opensearch.yml.
+      additionalConfig:
+        plugins.security.ssl_cert_reload_enabled: "true"
 
       # -- Additional volumes to mount to all pods in the cluster. Supported volume types configMap, emptyDir, secret (with default Kubernetes configuration schema)
       additionalVolumes: []

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.2
+  version: 0.2.3
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.2
+    version: 0.2.3


### PR DESCRIPTION
## Pull Request Details

Set `plugins.security.ssl_cert_reload_enabled=true` so we can hot reload certs after cert-manager renews the secret, instead of restarting all data nodes.
