### PR TITLE
chore: update opensearch plugins to SAP-cloud-infrastructure org releases

### DIFF
--- a/opensearch/build/Dockerfile
+++ b/opensearch/build/Dockerfile
@@ -4,9 +4,9 @@ FROM opensearchproject/opensearch@sha256:57bd3c879ad27123a9a6cd75e2adba504189d31
 LABEL source_repository="https://github.com/cloudoperators/greenhouse-extensions.git"
 
 # Don't change the order!
-# Will change the plugins repository to one of SAP repos ASAP.
+# Plugins sourced from SAP-cloud-infrastructure org releases.
 RUN /usr/share/opensearch/bin/opensearch-plugin remove opensearch-security-analytics \
  && /usr/share/opensearch/bin/opensearch-plugin remove opensearch-alerting \
- && /usr/share/opensearch/bin/opensearch-plugin install --batch https://github.com/thecodingshrimp/opensearch-plugins-alerting/releases/download/v2-custom/opensearch-alerting-3.6.0.0-v2-SNAPSHOT.zip \
- && /usr/share/opensearch/bin/opensearch-plugin install --batch https://github.com/thecodingshrimp/opensearch-plugin-security-analytics/releases/download/v2-custom/opensearch-security-analytics-3.6.0.0-v2-SNAPSHOT.zip
+ && /usr/share/opensearch/bin/opensearch-plugin install --batch https://github.com/SAP-cloud-infrastructure/opensearch-alerting/releases/download/3.6.0.0-sci-v2/opensearch-alerting-3.6.0.0-sci-v2-SNAPSHOT.zip \
+ && /usr/share/opensearch/bin/opensearch-plugin install --batch https://github.com/SAP-cloud-infrastructure/opensearch-security-analytics/releases/download/3.6.0.0-sci-v2/opensearch-security-analytics-3.6.0.0-sci-v2-SNAPSHOT.zip
 


### PR DESCRIPTION
## Summary

- Replaces plugin download URLs from personal GitHub (`thecodingshrimp`) with official SAP-cloud-infrastructure org releases
- Updates `opensearch-alerting` → `SAP-cloud-infrastructure/opensearch-alerting` release `3.6.0.0-sci-v2-SNAPSHOT`
- Updates `opensearch-security-analytics` → `SAP-cloud-infrastructure/opensearch-security-analytics` release `3.6.0.0-sci-v2-SNAPSHOT`

Note: used custom common-utils available at SAP-cloud-infrastructure/opensearch-common-utils