### PR TITLE
fix(kafka): guard PodMonitor labels against empty map

### DIFF
--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.8
+version: 0.1.9
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/pod-monitor.yaml
+++ b/kafka/charts/templates/pod-monitor.yaml
@@ -7,7 +7,9 @@ metadata:
   name: {{ .Values.kafka.name }}
   labels:
     {{- include "kafka.labels" . | nindent 4 }}
-    {{- toYaml .Values.monitoring.podMonitor.labels | nindent 4 }}
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:
@@ -27,7 +29,9 @@ metadata:
   name: {{ .Values.kafka.name }}-exporter
   labels:
     {{- include "kafka.labels" . | nindent 4 }}
-    {{- toYaml .Values.monitoring.podMonitor.labels | nindent 4 }}
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 spec:
   selector:
     matchLabels:

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.8
+  version: 0.1.9
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.8
+    version: 0.1.9
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

podMonitor labels are normally overridden when kafka is deployed as a standalone Plugin via Greenhouse, so the empty-map default never showed. But when kafka is pulled in as a dependency of another plugin (e.g. logs in #1720), nothing overrides it, `toYaml {}` renders as `{}`, producing invalid YAML and breaking the install. Wrapped both occurrences in `{{- with ... }}` so the line is omitted when labels are empty.