### PR TITLE
fix(logs): fix length of portname

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.3.0
+version: 0.3.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -34,7 +34,7 @@ spec:
 {{- end }}
   ports:
 {{- if .Values.openTelemetry.externalCollector.externalConfig.enabled }}
-    - name: alertmanagerwebhook
+    - name: am-webhook
       port: {{ .Values.openTelemetry.externalCollector.externalConfig.alertmanager_port }}
       protocol: TCP
     - name: deploymentstcp

--- a/logs/charts/templates/external-service.yaml
+++ b/logs/charts/templates/external-service.yaml
@@ -20,7 +20,7 @@ spec:
 {{- end }}
   ports:
 {{- if .Values.openTelemetry.externalCollector.externalConfig.enabled }}
-    - name: alertmanagerwebhook
+    - name: am-webhook
       protocol: TCP
       port: {{ .Values.openTelemetry.externalCollector.externalConfig.alertmanager_port }}
       targetPort: {{ .Values.openTelemetry.externalCollector.externalConfig.alertmanager_port }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.14.0
+  version: 0.14.1
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.0
+    version: 0.3.1
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Fix for `Error: UPGRADE FAILED: failed to create resource: admission webhook "vopentelemetrycollectorcreateupdatebeta.kb.io" denied the request: the OpenTelemetry Spec Ports configuration is incorrect, port name 'alertmanagerwebhook' errors: [must be no more than 15 characters], num '1515' errors: []`
by shortening the port name alertmanagerwebhook (20 chars) to am-webhook (10 chars) to comply with the Kubernetes 15-character port name limit. 