### PR TITLE
feat(opensearch): bootstrap dashboards saved objects via Job

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -182,6 +182,25 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.ismPolicies | list | See values.yaml | List of OpenSearchISMPolicy. Includes 7-day retention policy for logs* indices. |
 | cluster.nameOverride | string | `""` |  |
 | cluster.roles | list | See values.yaml | List of OpensearchRole. Includes read and write roles for logs* indices. |
+| cluster.savedObjects | object | disabled | Bootstrap OpenSearch Dashboards saved objects (index patterns, dashboards, visualizations). Runs as a post-install/upgrade Helm hook Job that POSTs to the Dashboards API. |
+| cluster.savedObjects.backoffLimit | int | `6` | Job backoff limit. |
+| cluster.savedObjects.caSecret | object | `{"key":"ca.crt","name":""}` | CA bundle Secret for HTTPS `dashboardsHost`. |
+| cluster.savedObjects.configMapName | string | `""` | Override ConfigMap name (default `opensearch-saved-objects`). |
+| cluster.savedObjects.credentialsSecret | object | `{"name":"dashboards-credentials","passwordKey":"password","usernameKey":"username"}` | Credentials Secret for a user that can write `.kibana*`. |
+| cluster.savedObjects.cronJob | object | `{"backoffLimit":3,"enabled":false,"name":"","schedule":"30 0,6,12,18 * * *"}` | Optional CronJob that re-runs the install script on a schedule. |
+| cluster.savedObjects.dashboardsHost | string | `""` | Dashboards URL. Defaults to the in-cluster Service. |
+| cluster.savedObjects.enabled | bool | `false` | Enable the saved-objects bootstrap Job. |
+| cluster.savedObjects.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/curlimages/curl","tag":"8.10.1"}` | Job image. Needs `curl` and a POSIX `sh`. |
+| cluster.savedObjects.imports | list | `[]` | NDJSON saved-object bundles to import. Each entry references a key in an existing ConfigMap (created out of band). |
+| cluster.savedObjects.indexPatterns | list | `[]` | Index patterns to upsert by id. |
+| cluster.savedObjects.jobName | string | `""` | Override Job name (default `opensearch-saved-objects`). |
+| cluster.savedObjects.nodeSelector | object | `{}` | Job pod nodeSelector. |
+| cluster.savedObjects.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext. |
+| cluster.savedObjects.resources | object | `{}` | Job pod resources. |
+| cluster.savedObjects.tlsSkipVerify | bool | `false` | Skip TLS verification (only relevant for HTTPS `dashboardsHost`). |
+| cluster.savedObjects.tolerations | list | `[]` | Job pod tolerations. |
+| cluster.savedObjects.ttlSecondsAfterFinished | int | `86400` | Seconds to keep finished Job pods before garbage collection. |
+| cluster.savedObjects.waitTimeoutSeconds | int | `300` | Seconds to wait for Dashboards readiness before failing. |
 | cluster.serviceAccount.annotations | object | `{}` | Service Account annotations |
 | cluster.serviceAccount.create | bool | `false` | Create Service Account |
 | cluster.serviceAccount.name | string | `""` | Service Account name. Set `general.serviceAccount` to use this Service Account for the Opensearch cluster |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -187,7 +187,6 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.savedObjects.caSecret | object | `{"key":"ca.crt","name":""}` | CA bundle Secret for the Dashboards cert. Defaults to `opensearch-http-cert` (rendered by this chart). |
 | cluster.savedObjects.configMapName | string | `""` | Override ConfigMap name (default `opensearch-saved-objects`). |
 | cluster.savedObjects.credentialsSecret | object | `{"name":"dashboards-credentials","passwordKey":"password","usernameKey":"username"}` | Credentials Secret for a user that can write `.kibana*`. |
-| cluster.savedObjects.cronJob | object | `{"backoffLimit":3,"enabled":false,"name":"","schedule":"30 0,6,12,18 * * *"}` | Optional CronJob that re-runs the install script on a schedule. |
 | cluster.savedObjects.dashboardsHost | string | `""` | Dashboards URL. Defaults to the in-cluster HTTPS Service. |
 | cluster.savedObjects.enabled | bool | `false` | Enable the saved-objects bootstrap Job. |
 | cluster.savedObjects.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/curlimages/curl","tag":"8.10.1"}` | Job image. Needs `curl` and a POSIX `sh`. |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -184,11 +184,11 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.roles | list | See values.yaml | List of OpensearchRole. Includes read and write roles for logs* indices. |
 | cluster.savedObjects | object | disabled | Bootstrap OpenSearch Dashboards saved objects (index patterns, dashboards, visualizations). Runs as a post-install/upgrade Helm hook Job that POSTs to the Dashboards API. |
 | cluster.savedObjects.backoffLimit | int | `6` | Job backoff limit. |
-| cluster.savedObjects.caSecret | object | `{"key":"ca.crt","name":""}` | CA bundle Secret for HTTPS `dashboardsHost`. |
+| cluster.savedObjects.caSecret | object | `{"key":"ca.crt","name":""}` | CA bundle Secret for the Dashboards cert. Defaults to `opensearch-http-cert` (rendered by this chart). |
 | cluster.savedObjects.configMapName | string | `""` | Override ConfigMap name (default `opensearch-saved-objects`). |
 | cluster.savedObjects.credentialsSecret | object | `{"name":"dashboards-credentials","passwordKey":"password","usernameKey":"username"}` | Credentials Secret for a user that can write `.kibana*`. |
 | cluster.savedObjects.cronJob | object | `{"backoffLimit":3,"enabled":false,"name":"","schedule":"30 0,6,12,18 * * *"}` | Optional CronJob that re-runs the install script on a schedule. |
-| cluster.savedObjects.dashboardsHost | string | `""` | Dashboards URL. Defaults to the in-cluster Service. |
+| cluster.savedObjects.dashboardsHost | string | `""` | Dashboards URL. Defaults to the in-cluster HTTPS Service. |
 | cluster.savedObjects.enabled | bool | `false` | Enable the saved-objects bootstrap Job. |
 | cluster.savedObjects.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/curlimages/curl","tag":"8.10.1"}` | Job image. Needs `curl` and a POSIX `sh`. |
 | cluster.savedObjects.imports | list | `[]` | NDJSON saved-object bundles to import. Each entry references a key in an existing ConfigMap (created out of band). |
@@ -197,7 +197,6 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.savedObjects.nodeSelector | object | `{}` | Job pod nodeSelector. |
 | cluster.savedObjects.podSecurityContext | object | `{"runAsNonRoot":true,"runAsUser":65534}` | Pod-level securityContext. |
 | cluster.savedObjects.resources | object | `{}` | Job pod resources. |
-| cluster.savedObjects.tlsSkipVerify | bool | `false` | Skip TLS verification (only relevant for HTTPS `dashboardsHost`). |
 | cluster.savedObjects.tolerations | list | `[]` | Job pod tolerations. |
 | cluster.savedObjects.ttlSecondsAfterFinished | int | `86400` | Seconds to keep finished Job pods before garbage collection. |
 | cluster.savedObjects.waitTimeoutSeconds | int | `300` | Seconds to wait for Dashboards readiness before failing. |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.5
+version: 0.2.6
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/ci/test-values.yaml
+++ b/opensearch/chart/ci/test-values.yaml
@@ -44,6 +44,26 @@ cluster:
         opensearch.requestHeadersAllowlist: '["securitytenant","Authorization"]'
         opensearch_security.auth.type: "basicauth"
 
+    # Single nodePool with 3 replicas for local testing. Avoids the
+    # cluster-bootstrap deadlock that single-node installs hit when the
+    # security plugin can't place the .opendistro_security replica.
+    nodePools:
+      - component: nodes
+        diskSize: 5Gi
+        jvm: -Xmx512m -Xms512m
+        replicas: 3
+        resources:
+          requests:
+            cpu: 200m
+            memory: 1Gi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+        roles:
+          - cluster_manager
+          - data
+          - ingest
+
     ingress:
       opensearch:
         enabled: true

--- a/opensearch/chart/ci/test-values.yaml
+++ b/opensearch/chart/ci/test-values.yaml
@@ -35,6 +35,8 @@ cluster:
       password: "CHANGE_ME_FailoverUser2025$%"
   snapshotLifecycle:
     enabled: false
+  savedObjects:
+    enabled: false
   cluster:
     # Override dashboards configuration for local testing with basic auth
     dashboards:

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -84,6 +84,10 @@ spec:
     - {{ printf "%s-coordinator.%s" $clusterName .Release.Namespace | quote }}
     - {{ printf "%s-coordinator.%s.svc" $clusterName .Release.Namespace | quote }}
     - {{ printf "%s-coordinator.%s.svc.cluster.local" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s-dashboards" $clusterName | quote }}
+    - {{ printf "%s-dashboards.%s" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s-dashboards.%s.svc" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s-dashboards.%s.svc.cluster.local" $clusterName .Release.Namespace | quote }}
   usages:
 {{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 

--- a/opensearch/chart/templates/saved-objects.yaml
+++ b/opensearch/chart/templates/saved-objects.yaml
@@ -83,7 +83,7 @@ metadata:
   annotations:
     "helm.sh/hook": post-install,post-upgrade
     "helm.sh/hook-weight": "10"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   backoffLimit: {{ $cfg.backoffLimit | default 6 }}
   ttlSecondsAfterFinished: {{ $cfg.ttlSecondsAfterFinished | default 86400 }}

--- a/opensearch/chart/templates/saved-objects.yaml
+++ b/opensearch/chart/templates/saved-objects.yaml
@@ -5,8 +5,9 @@
 {{- $cfg := .Values.cluster.savedObjects }}
 {{- $cmName := $cfg.configMapName | default "opensearch-saved-objects" }}
 {{- $serviceName := (.Values.cluster.cluster.general).serviceName | default .Values.cluster.cluster.name | default .Release.Name }}
-{{- $scheme := ternary "https" "http" (((.Values.cluster.cluster.dashboards).tls).enable | default false) }}
-{{- $dashboardsHost := $cfg.dashboardsHost | default (printf "%s://%s-dashboards:5601" $scheme $serviceName) }}
+{{- $dashboardsHost := $cfg.dashboardsHost | default (printf "https://%s-dashboards:5601" $serviceName) }}
+{{- $caSecretName := $cfg.caSecret.name | default "opensearch-http-cert" }}
+{{- $caSecretKey := $cfg.caSecret.key | default "ca.crt" }}
 {{- if not $cfg.credentialsSecret.name }}
   {{- fail "cluster.savedObjects.credentialsSecret.name is required when savedObjects.enabled is true" }}
 {{- end }}
@@ -19,11 +20,6 @@
   {{- $_ := required (printf "savedObjects.imports[%d].configMap is required" $i) $im.configMap }}
   {{- $_ := required (printf "savedObjects.imports[%d].key is required" $i) $im.key }}
   {{- $_ := set $importMounts $im.configMap true }}
-{{- end }}
-{{- $insecure := ternary "-k" "" $cfg.tlsSkipVerify }}
-{{- $cacert := "" }}
-{{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
-{{- $cacert = printf "--cacert /certs/%s" ($cfg.caSecret.key | default "ca.crt") }}
 {{- end }}
 ---
 apiVersion: v1
@@ -39,7 +35,7 @@ data:
     set -eu
     DASHBOARDS="${DASHBOARDS_HOST%/}"
     AUTH="-u ${USERNAME}:${PASSWORD}"
-    CURL="curl -fsS {{ $insecure }} {{ $cacert }} ${AUTH} -H osd-xsrf:true"
+    CURL="curl -fsS --cacert /certs/{{ $caSecretKey }} ${AUTH} -H osd-xsrf:true"
 
     echo "waiting up to ${WAIT_TIMEOUT_SECONDS}s for dashboards at ${DASHBOARDS}"
     deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
@@ -125,11 +121,9 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
-            {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
             - name: ca
               mountPath: /certs
               readOnly: true
-            {{- end }}
             {{- range $cm, $_ := $importMounts }}
             - name: import-{{ $cm }}
               mountPath: /imports/{{ $cm }}
@@ -140,11 +134,9 @@ spec:
           configMap:
             name: {{ $cmName }}
             defaultMode: 0755
-        {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
         - name: ca
           secret:
-            secretName: {{ $cfg.caSecret.name }}
-        {{- end }}
+            secretName: {{ $caSecretName }}
         {{- range $cm, $_ := $importMounts }}
         - name: import-{{ $cm }}
           configMap:
@@ -210,11 +202,9 @@ spec:
               volumeMounts:
                 - name: scripts
                   mountPath: /scripts
-                {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
                 - name: ca
                   mountPath: /certs
                   readOnly: true
-                {{- end }}
                 {{- range $cm, $_ := $importMounts }}
                 - name: import-{{ $cm }}
                   mountPath: /imports/{{ $cm }}
@@ -225,11 +215,9 @@ spec:
               configMap:
                 name: {{ $cmName }}
                 defaultMode: 0755
-            {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
             - name: ca
               secret:
-                secretName: {{ $cfg.caSecret.name }}
-            {{- end }}
+                secretName: {{ $caSecretName }}
             {{- range $cm, $_ := $importMounts }}
             - name: import-{{ $cm }}
               configMap:

--- a/opensearch/chart/templates/saved-objects.yaml
+++ b/opensearch/chart/templates/saved-objects.yaml
@@ -1,0 +1,239 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.cluster.savedObjects.enabled }}
+{{- $cfg := .Values.cluster.savedObjects }}
+{{- $cmName := $cfg.configMapName | default "opensearch-saved-objects" }}
+{{- $serviceName := (.Values.cluster.cluster.general).serviceName | default .Values.cluster.cluster.name | default .Release.Name }}
+{{- $scheme := ternary "https" "http" (((.Values.cluster.cluster.dashboards).tls).enable | default false) }}
+{{- $dashboardsHost := $cfg.dashboardsHost | default (printf "%s://%s-dashboards:5601" $scheme $serviceName) }}
+{{- if not $cfg.credentialsSecret.name }}
+  {{- fail "cluster.savedObjects.credentialsSecret.name is required when savedObjects.enabled is true" }}
+{{- end }}
+{{- range $i, $p := $cfg.indexPatterns }}
+  {{- $_ := required (printf "savedObjects.indexPatterns[%d].id is required" $i) $p.id }}
+  {{- $_ := required (printf "savedObjects.indexPatterns[%d].title is required" $i) $p.title }}
+{{- end }}
+{{- $importMounts := dict }}
+{{- range $i, $im := $cfg.imports }}
+  {{- $_ := required (printf "savedObjects.imports[%d].configMap is required" $i) $im.configMap }}
+  {{- $_ := required (printf "savedObjects.imports[%d].key is required" $i) $im.key }}
+  {{- $_ := set $importMounts $im.configMap true }}
+{{- end }}
+{{- $insecure := ternary "-k" "" $cfg.tlsSkipVerify }}
+{{- $cacert := "" }}
+{{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
+{{- $cacert = printf "--cacert /certs/%s" ($cfg.caSecret.key | default "ca.crt") }}
+{{- end }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ $cmName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+data:
+  install.sh: |
+    #!/bin/sh
+    set -eu
+    DASHBOARDS="${DASHBOARDS_HOST%/}"
+    AUTH="-u ${USERNAME}:${PASSWORD}"
+    CURL="curl -fsS {{ $insecure }} {{ $cacert }} ${AUTH} -H osd-xsrf:true"
+
+    echo "waiting up to ${WAIT_TIMEOUT_SECONDS}s for dashboards at ${DASHBOARDS}"
+    deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
+    until ${CURL} "${DASHBOARDS}/api/status" >/dev/null; do
+      if [ $(date +%s) -ge $deadline ]; then
+        echo "dashboards not ready after ${WAIT_TIMEOUT_SECONDS}s, giving up" >&2
+        exit 1
+      fi
+      sleep 3
+    done
+    echo "dashboards ready"
+
+    {{- range $cfg.indexPatterns }}
+    echo "upserting index-pattern {{ .id }}"
+    ${CURL} -H 'Content-Type: application/json' \
+      -X POST "${DASHBOARDS}/api/saved_objects/index-pattern/{{ .id }}?overwrite=true" \
+      -d '{"attributes":{"title":{{ .title | quote }}{{ if .timeFieldName }},"timeFieldName":{{ .timeFieldName | quote }}{{ end }}}}' \
+      >/dev/null
+    {{- end }}
+
+    {{- range $cfg.imports }}
+    echo "importing /imports/{{ .configMap }}/{{ .key }}"
+    ${CURL} -X POST "${DASHBOARDS}/api/saved_objects/_import?overwrite=true" \
+      --form file=@/imports/{{ .configMap }}/{{ .key }} >/dev/null
+    {{- end }}
+
+    echo "done"
+{{- $jobName := $cfg.jobName | default "opensearch-saved-objects" }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $jobName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: {{ $cfg.backoffLimit | default 6 }}
+  ttlSecondsAfterFinished: {{ $cfg.ttlSecondsAfterFinished | default 86400 }}
+  template:
+    spec:
+      restartPolicy: OnFailure
+      {{- with $cfg.podSecurityContext }}
+      securityContext:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cfg.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $cfg.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: install
+          image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+          imagePullPolicy: {{ $cfg.image.pullPolicy | default "IfNotPresent" }}
+          command: ["sh", "/scripts/install.sh"]
+          env:
+            - name: DASHBOARDS_HOST
+              value: {{ $dashboardsHost | quote }}
+            - name: WAIT_TIMEOUT_SECONDS
+              value: {{ $cfg.waitTimeoutSeconds | default 300 | quote }}
+            - name: USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $cfg.credentialsSecret.name }}
+                  key: {{ $cfg.credentialsSecret.usernameKey | default "username" }}
+            - name: PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $cfg.credentialsSecret.name }}
+                  key: {{ $cfg.credentialsSecret.passwordKey | default "password" }}
+          {{- with $cfg.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+            {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
+            - name: ca
+              mountPath: /certs
+              readOnly: true
+            {{- end }}
+            {{- range $cm, $_ := $importMounts }}
+            - name: import-{{ $cm }}
+              mountPath: /imports/{{ $cm }}
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: scripts
+          configMap:
+            name: {{ $cmName }}
+            defaultMode: 0755
+        {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
+        - name: ca
+          secret:
+            secretName: {{ $cfg.caSecret.name }}
+        {{- end }}
+        {{- range $cm, $_ := $importMounts }}
+        - name: import-{{ $cm }}
+          configMap:
+            name: {{ $cm }}
+        {{- end }}
+{{- if $cfg.cronJob.enabled }}
+---
+{{- $cronName := $cfg.cronJob.name | default "opensearch-saved-objects" }}
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ $cronName }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" . | nindent 4 }}
+spec:
+  schedule: {{ $cfg.cronJob.schedule | quote }}
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 1
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      backoffLimit: {{ $cfg.cronJob.backoffLimit | default 3 }}
+      template:
+        spec:
+          restartPolicy: OnFailure
+          {{- with $cfg.podSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cfg.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with $cfg.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: install
+              image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
+              imagePullPolicy: {{ $cfg.image.pullPolicy | default "IfNotPresent" }}
+              command: ["sh", "/scripts/install.sh"]
+              env:
+                - name: DASHBOARDS_HOST
+                  value: {{ $dashboardsHost | quote }}
+                - name: WAIT_TIMEOUT_SECONDS
+                  value: {{ $cfg.waitTimeoutSeconds | default 300 | quote }}
+                - name: USERNAME
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $cfg.credentialsSecret.name }}
+                      key: {{ $cfg.credentialsSecret.usernameKey | default "username" }}
+                - name: PASSWORD
+                  valueFrom:
+                    secretKeyRef:
+                      name: {{ $cfg.credentialsSecret.name }}
+                      key: {{ $cfg.credentialsSecret.passwordKey | default "password" }}
+              {{- with $cfg.resources }}
+              resources:
+                {{- toYaml . | nindent 16 }}
+              {{- end }}
+              volumeMounts:
+                - name: scripts
+                  mountPath: /scripts
+                {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
+                - name: ca
+                  mountPath: /certs
+                  readOnly: true
+                {{- end }}
+                {{- range $cm, $_ := $importMounts }}
+                - name: import-{{ $cm }}
+                  mountPath: /imports/{{ $cm }}
+                  readOnly: true
+                {{- end }}
+          volumes:
+            - name: scripts
+              configMap:
+                name: {{ $cmName }}
+                defaultMode: 0755
+            {{- if and (not $cfg.tlsSkipVerify) $cfg.caSecret.name }}
+            - name: ca
+              secret:
+                secretName: {{ $cfg.caSecret.name }}
+            {{- end }}
+            {{- range $cm, $_ := $importMounts }}
+            - name: import-{{ $cm }}
+              configMap:
+                name: {{ $cm }}
+            {{- end }}
+{{- end }}
+{{- end }}

--- a/opensearch/chart/templates/saved-objects.yaml
+++ b/opensearch/chart/templates/saved-objects.yaml
@@ -21,6 +21,14 @@
   {{- $_ := required (printf "savedObjects.imports[%d].key is required" $i) $im.key }}
   {{- $_ := set $importMounts $im.configMap true }}
 {{- end }}
+{{- /* Build a sorted list of {cm, vol} so the rendered manifest is stable
+     and volume names always satisfy RFC1123 (max 63 chars) regardless of
+     how long the source ConfigMap names are. */ -}}
+{{- $importVolumes := list }}
+{{- range $cm := $importMounts | keys | sortAlpha }}
+  {{- $vol := printf "import-%s" (sha256sum $cm | trunc 8) }}
+  {{- $importVolumes = append $importVolumes (dict "cm" $cm "vol" $vol) }}
+{{- end }}
 ---
 apiVersion: v1
 kind: ConfigMap
@@ -63,7 +71,7 @@ data:
     {{- end }}
 
     echo "done"
-{{- $jobName := $cfg.jobName | default "opensearch-saved-objects" }}
+{{- $jobName := $cfg.jobName | default "opensearch-saved-objects" | trunc 63 | trimSuffix "-" }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -124,9 +132,9 @@ spec:
             - name: ca
               mountPath: /certs
               readOnly: true
-            {{- range $cm, $_ := $importMounts }}
-            - name: import-{{ $cm }}
-              mountPath: /imports/{{ $cm }}
+            {{- range $importVolumes }}
+            - name: {{ .vol }}
+              mountPath: /imports/{{ .cm }}
               readOnly: true
             {{- end }}
       volumes:
@@ -137,14 +145,14 @@ spec:
         - name: ca
           secret:
             secretName: {{ $caSecretName }}
-        {{- range $cm, $_ := $importMounts }}
-        - name: import-{{ $cm }}
+        {{- range $importVolumes }}
+        - name: {{ .vol }}
           configMap:
-            name: {{ $cm }}
+            name: {{ .cm }}
         {{- end }}
 {{- if $cfg.cronJob.enabled }}
 ---
-{{- $cronName := $cfg.cronJob.name | default "opensearch-saved-objects" }}
+{{- $cronName := $cfg.cronJob.name | default "opensearch-saved-objects" | trunc 52 | trimSuffix "-" }}
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -205,9 +213,9 @@ spec:
                 - name: ca
                   mountPath: /certs
                   readOnly: true
-                {{- range $cm, $_ := $importMounts }}
-                - name: import-{{ $cm }}
-                  mountPath: /imports/{{ $cm }}
+                {{- range $importVolumes }}
+                - name: {{ .vol }}
+                  mountPath: /imports/{{ .cm }}
                   readOnly: true
                 {{- end }}
           volumes:
@@ -218,10 +226,10 @@ spec:
             - name: ca
               secret:
                 secretName: {{ $caSecretName }}
-            {{- range $cm, $_ := $importMounts }}
-            - name: import-{{ $cm }}
+            {{- range $importVolumes }}
+            - name: {{ .vol }}
               configMap:
-                name: {{ $cm }}
+                name: {{ .cm }}
             {{- end }}
 {{- end }}
 {{- end }}

--- a/opensearch/chart/templates/saved-objects.yaml
+++ b/opensearch/chart/templates/saved-objects.yaml
@@ -57,7 +57,7 @@ data:
     echo "dashboards ready"
 
     {{- range $cfg.indexPatterns }}
-    echo "upserting index-pattern {{ .id }}"
+    echo "applying index-pattern {{ .id }}"
     ${CURL} -H 'Content-Type: application/json' \
       -X POST "${DASHBOARDS}/api/saved_objects/index-pattern/{{ .id }}?overwrite=true" \
       -d '{"attributes":{"title":{{ .title | quote }}{{ if .timeFieldName }},"timeFieldName":{{ .timeFieldName | quote }}{{ end }}}}' \
@@ -65,7 +65,7 @@ data:
     {{- end }}
 
     {{- range $cfg.imports }}
-    echo "importing /imports/{{ .configMap }}/{{ .key }}"
+    echo "applying /imports/{{ .configMap }}/{{ .key }}"
     ${CURL} -X POST "${DASHBOARDS}/api/saved_objects/_import?overwrite=true" \
       --form file=@/imports/{{ .configMap }}/{{ .key }} >/dev/null
     {{- end }}
@@ -150,86 +150,4 @@ spec:
           configMap:
             name: {{ .cm }}
         {{- end }}
-{{- if $cfg.cronJob.enabled }}
----
-{{- $cronName := $cfg.cronJob.name | default "opensearch-saved-objects" | trunc 52 | trimSuffix "-" }}
-apiVersion: batch/v1
-kind: CronJob
-metadata:
-  name: {{ $cronName }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "opensearch.labels" . | nindent 4 }}
-spec:
-  schedule: {{ $cfg.cronJob.schedule | quote }}
-  concurrencyPolicy: Forbid
-  successfulJobsHistoryLimit: 1
-  failedJobsHistoryLimit: 3
-  jobTemplate:
-    spec:
-      backoffLimit: {{ $cfg.cronJob.backoffLimit | default 3 }}
-      template:
-        spec:
-          restartPolicy: OnFailure
-          {{- with $cfg.podSecurityContext }}
-          securityContext:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with $cfg.nodeSelector }}
-          nodeSelector:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          {{- with $cfg.tolerations }}
-          tolerations:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
-          containers:
-            - name: install
-              image: "{{ $cfg.image.repository }}:{{ $cfg.image.tag }}"
-              imagePullPolicy: {{ $cfg.image.pullPolicy | default "IfNotPresent" }}
-              command: ["sh", "/scripts/install.sh"]
-              env:
-                - name: DASHBOARDS_HOST
-                  value: {{ $dashboardsHost | quote }}
-                - name: WAIT_TIMEOUT_SECONDS
-                  value: {{ $cfg.waitTimeoutSeconds | default 300 | quote }}
-                - name: USERNAME
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ $cfg.credentialsSecret.name }}
-                      key: {{ $cfg.credentialsSecret.usernameKey | default "username" }}
-                - name: PASSWORD
-                  valueFrom:
-                    secretKeyRef:
-                      name: {{ $cfg.credentialsSecret.name }}
-                      key: {{ $cfg.credentialsSecret.passwordKey | default "password" }}
-              {{- with $cfg.resources }}
-              resources:
-                {{- toYaml . | nindent 16 }}
-              {{- end }}
-              volumeMounts:
-                - name: scripts
-                  mountPath: /scripts
-                - name: ca
-                  mountPath: /certs
-                  readOnly: true
-                {{- range $importVolumes }}
-                - name: {{ .vol }}
-                  mountPath: /imports/{{ .cm }}
-                  readOnly: true
-                {{- end }}
-          volumes:
-            - name: scripts
-              configMap:
-                name: {{ $cmName }}
-                defaultMode: 0755
-            - name: ca
-              secret:
-                secretName: {{ $caSecretName }}
-            {{- range $importVolumes }}
-            - name: {{ .vol }}
-              configMap:
-                name: {{ .cm }}
-            {{- end }}
-{{- end }}
 {{- end }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -963,16 +963,15 @@ cluster:
   savedObjects:
     # -- Enable the saved-objects bootstrap Job.
     enabled: false
-    # -- Dashboards URL. Defaults to the in-cluster Service.
+    # -- Dashboards URL. Defaults to the in-cluster HTTPS Service.
     dashboardsHost: ""
     # -- Credentials Secret for a user that can write `.kibana*`.
     credentialsSecret:
       name: dashboards-credentials
       usernameKey: username
       passwordKey: password
-    # -- Skip TLS verification (only relevant for HTTPS `dashboardsHost`).
-    tlsSkipVerify: false
-    # -- CA bundle Secret for HTTPS `dashboardsHost`.
+    # -- CA bundle Secret for the Dashboards cert. Defaults to
+    # `opensearch-http-cert` (rendered by this chart).
     caSecret:
       name: ""
       key: ca.crt

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -1010,12 +1010,6 @@ cluster:
     imports: []
     # - configMap: my-dashboards
     #   key: kvm-overview.ndjson
-    # -- Optional CronJob that re-runs the install script on a schedule.
-    cronJob:
-      enabled: false
-      name: ""
-      schedule: "30 0,6,12,18 * * *"
-      backoffLimit: 3
 
 
 # -- Extra Kubernetes manifests to deploy alongside the chart.

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -956,6 +956,68 @@ cluster:
     #     remote: "31d"
     #     snapshot: "93d"
 
+  # -- Bootstrap OpenSearch Dashboards saved objects (index patterns,
+  # dashboards, visualizations). Runs as a post-install/upgrade Helm
+  # hook Job that POSTs to the Dashboards API.
+  # @default -- disabled
+  savedObjects:
+    # -- Enable the saved-objects bootstrap Job.
+    enabled: false
+    # -- Dashboards URL. Defaults to the in-cluster Service.
+    dashboardsHost: ""
+    # -- Credentials Secret for a user that can write `.kibana*`.
+    credentialsSecret:
+      name: dashboards-credentials
+      usernameKey: username
+      passwordKey: password
+    # -- Skip TLS verification (only relevant for HTTPS `dashboardsHost`).
+    tlsSkipVerify: false
+    # -- CA bundle Secret for HTTPS `dashboardsHost`.
+    caSecret:
+      name: ""
+      key: ca.crt
+    # -- Job image. Needs `curl` and a POSIX `sh`.
+    image:
+      repository: docker.io/curlimages/curl
+      tag: "8.10.1"
+      pullPolicy: IfNotPresent
+    # -- Job pod resources.
+    resources: {}
+    # -- Job pod nodeSelector.
+    nodeSelector: {}
+    # -- Job pod tolerations.
+    tolerations: []
+    # -- Pod-level securityContext.
+    podSecurityContext:
+      runAsNonRoot: true
+      runAsUser: 65534
+    # -- Job backoff limit.
+    backoffLimit: 6
+    # -- Seconds to wait for Dashboards readiness before failing.
+    waitTimeoutSeconds: 300
+    # -- Seconds to keep finished Job pods before garbage collection.
+    ttlSecondsAfterFinished: 86400
+    # -- Override Job name (default `opensearch-saved-objects`).
+    jobName: ""
+    # -- Override ConfigMap name (default `opensearch-saved-objects`).
+    configMapName: ""
+    # -- Index patterns to upsert by id.
+    indexPatterns: []
+    # - id: logs
+    #   title: "logs"
+    #   timeFieldName: "@timestamp"
+    # -- NDJSON saved-object bundles to import. Each entry references a
+    # key in an existing ConfigMap (created out of band).
+    imports: []
+    # - configMap: my-dashboards
+    #   key: kvm-overview.ndjson
+    # -- Optional CronJob that re-runs the install script on a schedule.
+    cronJob:
+      enabled: false
+      name: ""
+      schedule: "30 0,6,12,18 * * *"
+      backoffLimit: 3
+
 
 # -- Extra Kubernetes manifests to deploy alongside the chart.
 # Each entry can be a raw YAML string or a map object.

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.5
+  version: 0.2.6
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.5
+    version: 0.2.6


### PR DESCRIPTION
## Pull Request Details

Adds an optional post-install/upgrade Helm hook Job that creates index patterns and imports dashboards into OpenSearch Dashboards via its API. Removes the manual UI step for setting up index patterns and pre-built dashboards after a cluster is provisioned.
