### PR TITLE
feat(opensearch): add coordinator service to opensearch-http-cert SAN

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.4
+version: 0.2.5
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/templates/certificates.yaml
+++ b/opensearch/chart/templates/certificates.yaml
@@ -80,6 +80,10 @@ spec:
     - {{ printf "%s.%s" $clusterName .Release.Namespace | quote }}
     - {{ printf "%s.%s.svc" $clusterName .Release.Namespace | quote }}
     - {{ printf "%s.%s.svc.cluster.local" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s-coordinator" $clusterName | quote }}
+    - {{ printf "%s-coordinator.%s" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s-coordinator.%s.svc" $clusterName .Release.Namespace | quote }}
+    - {{ printf "%s-coordinator.%s.svc.cluster.local" $clusterName .Release.Namespace | quote }}
   usages:
 {{ toYaml .Values.certManager.defaults.usages | indent 4 }}
 

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.4
+  version: 0.2.5
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.4
+    version: 0.2.5


### PR DESCRIPTION
## Pull Request Details

Extends the in-cluster opensearch-http-cert Certificate SAN to include <cluster>-coordinator.* hostnames so clients can connect via the dedicated coordinator service.