### PR TITLE
chore(kube-monitoring): updated severities

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 13.4.0
+version: 13.4.1
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -6,6 +6,19 @@ global:
 
 # kube-prometheus-stack configuration scoped to kube-monitoring
 kubeMonitoring:
+  # Update severities for open source community rules
+  # @ignored
+  customRules:
+    PrometheusDuplicateTimestamps:
+      severity: info
+    PrometheusBadConfig:
+      severity: warning
+    PrometheusRuleFailures:
+      severity: warning
+    PrometheusTargetSyncFailure:
+      severity: warning
+    PrometheusErrorSendingAlertsToAnyAlertmanager:
+      severity: warning
   # Create open source community rules for monitoring the cluster
   # @ignored
   defaultRules:

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 14.4.0
+  version: 14.4.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 13.4.0
+    version: 13.4.1
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
more strict critical severity alerting, only for service down

lowering severity of critical rules not affecting metrics scraping

+ duplicate scraping will not lead do short term critical alert, lowering to info