### PR TITLE
fix(opensearch): use plain HTTP for in-cluster saved-objects Job

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -184,10 +184,9 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.roles | list | See values.yaml | List of OpensearchRole. Includes read and write roles for logs* indices. |
 | cluster.savedObjects | object | disabled | Bootstrap OpenSearch Dashboards saved objects (index patterns, dashboards, visualizations). Runs as a post-install/upgrade Helm hook Job that POSTs to the Dashboards API. |
 | cluster.savedObjects.backoffLimit | int | `6` | Job backoff limit. |
-| cluster.savedObjects.caSecret | object | `{"key":"ca.crt","name":""}` | CA bundle Secret for the Dashboards cert. Defaults to `opensearch-http-cert` (rendered by this chart). |
 | cluster.savedObjects.configMapName | string | `""` | Override ConfigMap name (default `opensearch-saved-objects`). |
 | cluster.savedObjects.credentialsSecret | object | `{"name":"dashboards-credentials","passwordKey":"password","usernameKey":"username"}` | Credentials Secret for a user that can write `.kibana*`. |
-| cluster.savedObjects.dashboardsHost | string | `""` | Dashboards URL. Defaults to the in-cluster HTTPS Service. |
+| cluster.savedObjects.dashboardsHost | string | `""` | Dashboards URL. Defaults to the in-cluster HTTP Service. |
 | cluster.savedObjects.enabled | bool | `false` | Enable the saved-objects bootstrap Job. |
 | cluster.savedObjects.image | object | `{"pullPolicy":"IfNotPresent","repository":"docker.io/curlimages/curl","tag":"8.10.1"}` | Job image. Needs `curl` and a POSIX `sh`. |
 | cluster.savedObjects.imports | list | `[]` | NDJSON saved-object bundles to import. Each entry references a key in an existing ConfigMap (created out of band). |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.6
+version: 0.2.7
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/templates/saved-objects.yaml
+++ b/opensearch/chart/templates/saved-objects.yaml
@@ -5,9 +5,7 @@
 {{- $cfg := .Values.cluster.savedObjects }}
 {{- $cmName := $cfg.configMapName | default "opensearch-saved-objects" }}
 {{- $serviceName := (.Values.cluster.cluster.general).serviceName | default .Values.cluster.cluster.name | default .Release.Name }}
-{{- $dashboardsHost := $cfg.dashboardsHost | default (printf "https://%s-dashboards:5601" $serviceName) }}
-{{- $caSecretName := $cfg.caSecret.name | default "opensearch-http-cert" }}
-{{- $caSecretKey := $cfg.caSecret.key | default "ca.crt" }}
+{{- $dashboardsHost := $cfg.dashboardsHost | default (printf "http://%s-dashboards:5601" $serviceName) }}
 {{- if not $cfg.credentialsSecret.name }}
   {{- fail "cluster.savedObjects.credentialsSecret.name is required when savedObjects.enabled is true" }}
 {{- end }}
@@ -43,7 +41,7 @@ data:
     set -eu
     DASHBOARDS="${DASHBOARDS_HOST%/}"
     AUTH="-u ${USERNAME}:${PASSWORD}"
-    CURL="curl -fsS --cacert /certs/{{ $caSecretKey }} ${AUTH} -H osd-xsrf:true"
+    CURL="curl -fsS ${AUTH} -H osd-xsrf:true"
 
     echo "waiting up to ${WAIT_TIMEOUT_SECONDS}s for dashboards at ${DASHBOARDS}"
     deadline=$(( $(date +%s) + WAIT_TIMEOUT_SECONDS ))
@@ -129,9 +127,6 @@ spec:
           volumeMounts:
             - name: scripts
               mountPath: /scripts
-            - name: ca
-              mountPath: /certs
-              readOnly: true
             {{- range $importVolumes }}
             - name: {{ .vol }}
               mountPath: /imports/{{ .cm }}
@@ -142,9 +137,6 @@ spec:
           configMap:
             name: {{ $cmName }}
             defaultMode: 0755
-        - name: ca
-          secret:
-            secretName: {{ $caSecretName }}
         {{- range $importVolumes }}
         - name: {{ .vol }}
           configMap:

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -963,18 +963,13 @@ cluster:
   savedObjects:
     # -- Enable the saved-objects bootstrap Job.
     enabled: false
-    # -- Dashboards URL. Defaults to the in-cluster HTTPS Service.
+    # -- Dashboards URL. Defaults to the in-cluster HTTP Service.
     dashboardsHost: ""
     # -- Credentials Secret for a user that can write `.kibana*`.
     credentialsSecret:
       name: dashboards-credentials
       usernameKey: username
       passwordKey: password
-    # -- CA bundle Secret for the Dashboards cert. Defaults to
-    # `opensearch-http-cert` (rendered by this chart).
-    caSecret:
-      name: ""
-      key: ca.crt
     # -- Job image. Needs `curl` and a POSIX `sh`.
     image:
       repository: docker.io/curlimages/curl

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.6
+  version: 0.2.7
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.6
+    version: 0.2.7


### PR DESCRIPTION
## Pull Request Details

Switch the savedObjects bootstrap Job from HTTPS to plain HTTP for the in-cluster Dashboards Service. The Dashboards Service is HTTP by default (TLS terminates at the ingress, not at the Pod). There is Linkerd is in place, in-cluster traffic will be mTLS-encrypted by the mesh anyway, so plain HTTP at the app layer.