### PR TITLE
feat(kafka): add toggles for topic/user operator and cruise control

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -59,8 +59,10 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | cruiseControl.enabled | bool | `false` | Enable Cruise Control |
 | cruiseControl.resources | object | requests: 512Mi memory, 500m CPU; limits: 1Gi memory, 1 CPU | Cruise Control resource configuration |
 | entityOperator.enabled | bool | `true` | Enable Entity Operator |
-| entityOperator.topicOperator | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | Topic Operator resource configuration |
-| entityOperator.userOperator | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | User Operator resource configuration |
+| entityOperator.topicOperator.enabled | bool | `true` | Enable Topic Operator |
+| entityOperator.topicOperator.resources | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | Topic Operator resource configuration |
+| entityOperator.userOperator.enabled | bool | `false` | Enable User Operator |
+| entityOperator.userOperator.resources | object | requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU | User Operator resource configuration |
 | extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart. Each entry can be a raw YAML string or a map object. |
 | kafka.config | object | See values.yaml for production defaults | Kafka broker configuration |
 | kafka.enabled | bool | `true` | Enable or disable Kafka cluster deployment |

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.9
+version: 0.1.10
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/kafka.yaml
+++ b/kafka/charts/templates/kafka.yaml
@@ -23,14 +23,18 @@ spec:
           name: {{ .Values.kafka.name }}-metrics
           key: kafka-metrics-config.yml
     {{- end }}
-  {{- if .Values.entityOperator.enabled }}
+  {{- if and .Values.entityOperator.enabled (or .Values.entityOperator.topicOperator.enabled .Values.entityOperator.userOperator.enabled) }}
   entityOperator:
+    {{- if .Values.entityOperator.topicOperator.enabled }}
     topicOperator:
       resources:
         {{- toYaml .Values.entityOperator.topicOperator.resources | nindent 8 }}
+    {{- end }}
+    {{- if .Values.entityOperator.userOperator.enabled }}
     userOperator:
       resources:
         {{- toYaml .Values.entityOperator.userOperator.resources | nindent 8 }}
+    {{- end }}
   {{- end }}
   {{- if .Values.kafkaExporter.enabled }}
   kafkaExporter:

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -91,9 +91,12 @@ entityOperator:
   # -- Enable Entity Operator
   enabled: true
 
-  # -- Topic Operator resource configuration
-  # @default -- requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU
+  # Topic Operator configuration
   topicOperator:
+    # -- Enable Topic Operator
+    enabled: true
+    # -- Topic Operator resource configuration
+    # @default -- requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU
     resources:
       requests:
         memory: "128Mi"
@@ -102,9 +105,12 @@ entityOperator:
         memory: "256Mi"
         cpu: "200m"
 
-  # -- User Operator resource configuration
-  # @default -- requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU
+  # User Operator configuration
   userOperator:
+    # -- Enable User Operator
+    enabled: false
+    # -- User Operator resource configuration
+    # @default -- requests: 128Mi memory, 100m CPU; limits: 256Mi memory, 200m CPU
     resources:
       requests:
         memory: "128Mi"

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.9
+  version: 0.1.10
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.9
+    version: 0.1.10
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."
@@ -35,6 +35,21 @@ spec:
       required: false
       type: bool
       default: true
+    - name: cruiseControl.enabled
+      description: "Enable or disable Cruise Control for cluster rebalancing."
+      required: false
+      type: bool
+      default: false
+    - name: entityOperator.topicOperator.enabled
+      description: "Enable or disable the Strimzi Topic Operator."
+      required: false
+      type: bool
+      default: true
+    - name: entityOperator.userOperator.enabled
+      description: "Enable or disable the Strimzi User Operator."
+      required: false
+      type: bool
+      default: false
     - name: monitoring.additionalRuleLabels
       description: "Additional labels for PrometheusRule alerts."
       required: false


### PR DESCRIPTION
## Summary

- Make `entityOperator.topicOperator` and `entityOperator.userOperator` independently toggleable
- Default `userOperator.enabled` to `false`(the User Operator hangs at AdminClient init in some clusters and is not needed unless `KafkaUser` resources are managed)
- Surface `cruiseControl.enabled` for the management of Kafka