### PR TITLE
fix(opensearch): drop orphaned component template

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.9
+version: 0.2.10
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/templates/tests/test-opensearch-config.yaml
+++ b/opensearch/chart/templates/tests/test-opensearch-config.yaml
@@ -50,10 +50,6 @@ data:
       [ "$(kubectl get opensearchismpolicies.opensearch.org -n {{ .Release.Namespace }} --no-headers | wc -l)" -ge 1 ]
     }
 
-    @test "Verify presence of OpenSearchComponentTemplate resource" {
-      [ "$(kubectl get opensearchcomponenttemplates.opensearch.org -n {{ .Release.Namespace }} --no-headers | wc -l)" -ge 1 ]
-    }
-
     @test "Verify presence of OpenSearchTenant resource" {
       [ "$(kubectl get opensearchtenants.opensearch.org -n {{ .Release.Namespace }} --no-headers | wc -l)" -ge 0 ]
     }

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -789,18 +789,7 @@ cluster:
 
   # -- List of OpensearchComponentTemplate.
   # @default -- See values.yaml
-  componentTemplates:
-    - name: logs-attributes-dynamic
-      version: 1
-      allowAutoCreate: true
-      _meta:
-        description: "Enable full dynamic mapping for all attributes.* keys"
-      templateSpec:
-        mappings:
-          properties:
-            attributes:
-              type: object
-              dynamic: true
+  componentTemplates: []
 
   # -- List of OpensearchIndexTemplate. Includes template for logs* data stream.
   # @default -- See values.yaml
@@ -808,8 +797,6 @@ cluster:
     - name: logs-index-template
       indexPatterns:
         - "logs*"
-      composedOf:
-        - logs-attributes-dynamic
       templateSpec:
         settings:
           index:

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,11 +6,11 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.9
+  version: 0.2.10
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.9
+    version: 0.2.10


### PR DESCRIPTION
## Pull Request Details

Drop orphaned `logs-attributes-dynamic` component template and the `composedOf` reference from `logs-index-template`. OpenSearch enables dynamic mapping by default at every level, so the component template explicitly setting dynamic: true was just restating the default. 