### PR TITLE
fix(logs): change LB to ClusterIP, adjust naming

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -96,14 +96,14 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | Image repository for OpenTelemetry Collector |
 | openTelemetry.collectorImage.tag | string | `"a8981ba"` | Image tag for OpenTelemetry Collector |
 | openTelemetry.customLabels | object | `{}` | custom Labels applied to servicemonitor, secrets and collectors |
-| openTelemetry.externalCollector | object | `{"enabled":false,"externalConfig":{"alertmanager_port":1515,"deployments_port":1516,"enabled":false},"kafkaTopic":"","kafkaTracesTopic":"","loadBalancerIP":null,"replicas":2,"serviceAnnotations":{},"syslogConfig":{"enabled":false,"tcp_port":514,"udp_port":514},"syslogTLSConfig":{"dnsName":null,"enabled":false,"issuerName":null,"tcp_port":6514},"tracesConfig":{"enabled":false,"otlp_grpc_port":4317,"otlp_http_port":4318}}` | Standalone external OTel Collector as StatefulSet. |
+| openTelemetry.externalCollector | object | `{"enabled":false,"externalConfig":{"alertmanager_port":1515,"deployments_port":1516,"enabled":false},"externalIP":null,"kafkaTopic":"","kafkaTracesTopic":"","replicas":2,"serviceAnnotations":{},"syslogConfig":{"enabled":false,"tcp_port":514,"udp_port":514},"syslogTLSConfig":{"dnsName":null,"enabled":false,"issuerName":null,"tcp_port":6514},"tracesConfig":{"enabled":false,"otlp_grpc_port":4317,"otlp_http_port":4318}}` | Standalone external OTel Collector as StatefulSet. |
 | openTelemetry.externalCollector.enabled | bool | `false` | Enables the standalone external OTel Collector StatefulSet and its PodMonitor. |
 | openTelemetry.externalCollector.externalConfig | object | `{"alertmanager_port":1515,"deployments_port":1516,"enabled":false}` | Activates the external alertmanager webhook and deployment event receivers. |
 | openTelemetry.externalCollector.externalConfig.alertmanager_port | int | `1515` | Port for alertmanager webhook events |
 | openTelemetry.externalCollector.externalConfig.deployments_port | int | `1516` | Port for deployment TCP log events |
+| openTelemetry.externalCollector.externalIP | string | `nil` | External IP exposed on the service |
 | openTelemetry.externalCollector.kafkaTopic | string | `""` | Kafka topic name for external logs — alerts, deployments, syslog (e.g., "logs-external") |
 | openTelemetry.externalCollector.kafkaTracesTopic | string | `""` | Kafka topic name for traces (e.g., "traces") |
-| openTelemetry.externalCollector.loadBalancerIP | string | `nil` | IP address to request from the cloud LoadBalancer (optional, omit for auto-assigned) |
 | openTelemetry.externalCollector.replicas | int | `2` | Number of replicas for the external collector StatefulSet |
 | openTelemetry.externalCollector.serviceAnnotations | object | `{}` | Additional annotations on the external Service |
 | openTelemetry.externalCollector.syslogConfig | object | `{"enabled":false,"tcp_port":514,"udp_port":514}` | Activates syslog TCP/UDP ingestion (rfc5424/rfc3164). |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.3.3
+version: 0.3.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/ci/test-values-all-features.yaml
+++ b/logs/charts/ci/test-values-all-features.yaml
@@ -59,7 +59,7 @@ openTelemetry:
   externalCollector:
     enabled: true
     replicas: 2
-    loadBalancerIP: 10.0.0.1
+    externalIP: 10.0.0.1
     kafkaTopic: "logs"
     kafkaTracesTopic: "traces"
     externalConfig:

--- a/logs/charts/ci/test-values.yaml
+++ b/logs/charts/ci/test-values.yaml
@@ -58,7 +58,7 @@ openTelemetry:
   externalCollector:
     enabled: true
     replicas: 2
-    loadBalancerIP: 10.0.0.1
+    externalIP: 10.0.0.1
     externalConfig:
       enabled: false
       alertmanager_port: 1515

--- a/logs/charts/templates/external-service.yaml
+++ b/logs/charts/templates/external-service.yaml
@@ -14,7 +14,7 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Namespace }}.external
     app.kubernetes.io/managed-by: opentelemetry-operator
   type: ClusterIP
-  externalTrafficPolicy: Cluster
+  externalTrafficPolicy: Local
 {{- if .Values.openTelemetry.externalCollector.externalIP }}
   externalIPs: ["{{ .Values.openTelemetry.externalCollector.externalIP }}"]
 {{- end }}

--- a/logs/charts/templates/external-service.yaml
+++ b/logs/charts/templates/external-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 
 metadata:
-  name: logs-collector-external
+  name: external-collector
 {{- with .Values.openTelemetry.externalCollector.serviceAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -13,10 +13,10 @@ spec:
     app.kubernetes.io/component: opentelemetry-collector
     app.kubernetes.io/instance: {{ .Release.Namespace }}.external
     app.kubernetes.io/managed-by: opentelemetry-operator
-  type: LoadBalancer
+  type: ClusterIP
   externalTrafficPolicy: Local
-{{- if .Values.openTelemetry.externalCollector.loadBalancerIP }}
-  loadBalancerIP: "{{ .Values.openTelemetry.externalCollector.loadBalancerIP }}"
+{{- if .Values.openTelemetry.externalCollector.externalIP }}
+  externalIPs: ["{{ .Values.openTelemetry.externalCollector.externalIP }}"]
 {{- end }}
   ports:
 {{- if .Values.openTelemetry.externalCollector.externalConfig.enabled }}

--- a/logs/charts/templates/external-service.yaml
+++ b/logs/charts/templates/external-service.yaml
@@ -14,7 +14,7 @@ spec:
     app.kubernetes.io/instance: {{ .Release.Namespace }}.external
     app.kubernetes.io/managed-by: opentelemetry-operator
   type: ClusterIP
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
 {{- if .Values.openTelemetry.externalCollector.externalIP }}
   externalIPs: ["{{ .Values.openTelemetry.externalCollector.externalIP }}"]
 {{- end }}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -111,8 +111,8 @@ openTelemetry:
     enabled: false
     # -- Number of replicas for the external collector StatefulSet
     replicas: 2
-    # -- IP address to request from the cloud LoadBalancer (optional, omit for auto-assigned)
-    loadBalancerIP:
+    # -- External IP exposed on the service
+    externalIP:
     # -- Additional annotations on the external Service
     serviceAnnotations: {}
     # -- Kafka topic name for external logs — alerts, deployments, syslog (e.g., "logs-external")

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.14.3
+  version: 0.14.4
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.3
+    version: 0.3.4
 
   options:
     - default: true


### PR DESCRIPTION
## Pull Request Details

- switches the external collector Service from type: LoadBalancer (with loadBalancerIP) to type: ClusterIP with externalIPs, removing the dependency on a cloud load balancer. 
- renames service from logs-collector-external to external-collector. 
- The Helm value loadBalancerIP is replaced by externalIP
- chart/plugin versions are bumped (0.3.3 → 0.3.4 / 0.14.3 → 0.14.4). CI test values and README are updated to match.