### PR TITLE
fix(logs): increase opensearch exporter timeout from 10s to 30s

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.3.4
+version: 0.3.5
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.3.3
+version: 0.3.4
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-config.tpl
+++ b/logs/charts/templates/_external-config.tpl
@@ -44,7 +44,7 @@ opensearch/failover_a_external_{{ toString . }}:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 opensearch/failover_b_external_{{ toString . }}:
   http:
     auth:
@@ -56,7 +56,7 @@ opensearch/failover_b_external_{{ toString . }}:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 {{- end }}
 {{- end }}
 {{- end }}

--- a/logs/charts/templates/_openstack-config.tpl
+++ b/logs/charts/templates/_openstack-config.tpl
@@ -196,7 +196,7 @@ opensearch/storage_failover_a:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 opensearch/storage_failover_b:
   http:
     auth:
@@ -208,7 +208,7 @@ opensearch/storage_failover_b:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 {{- end }}
 
 {{- define "openstack.pipeline" }}

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -57,7 +57,7 @@ opensearch/failover_a_syslog:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 opensearch/failover_b_syslog:
   http:
     auth:
@@ -69,7 +69,7 @@ opensearch/failover_b_syslog:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 {{- end }}
 {{- end }}
 

--- a/logs/charts/templates/_traces-config.tpl
+++ b/logs/charts/templates/_traces-config.tpl
@@ -50,7 +50,7 @@ failover/opensearch_traces:
   sending_queue:
     block_on_overflow: true
     enabled: true
-    num_consumers: 10
+    num_consumers: 2
     queue_size: 10000
     sizer: requests
 {{- end }}

--- a/logs/charts/templates/_traces-config.tpl
+++ b/logs/charts/templates/_traces-config.tpl
@@ -24,7 +24,7 @@ opensearch/failover_a_traces:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 opensearch/failover_b_traces:
   http:
     auth:
@@ -36,7 +36,7 @@ opensearch/failover_b_traces:
     initial_interval: 1s
     max_interval: 5s
     max_elapsed_time: 30s
-  timeout: 10s
+  timeout: 30s
 {{- end }}
 {{- end }}
 

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -350,7 +350,7 @@ spec:
         sending_queue:
           block_on_overflow: true
           enabled: true
-          num_consumers: 10
+          num_consumers: 2
           queue_size: 10000
           sizer: requests
       failover/opensearch_cronus:
@@ -373,7 +373,7 @@ spec:
         sending_queue:
           block_on_overflow: true
           enabled: true
-          num_consumers: 10
+          num_consumers: 2
           queue_size: 10000
           sizer: requests
 {{- end }}

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -267,7 +267,7 @@ spec:
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: 30s
       opensearch/failover_b:
         http:
           auth:
@@ -279,7 +279,7 @@ spec:
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: 30s
       opensearch/cronus_failover_a:
         http:
           auth:
@@ -291,7 +291,7 @@ spec:
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: 30s
       opensearch/cronus_failover_b:
         http:
           auth:
@@ -303,7 +303,7 @@ spec:
           initial_interval: 1s
           max_interval: 5s
           max_elapsed_time: 30s
-        timeout: 10s
+        timeout: 30s
 {{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled }}
     {{- include "openstack.exporter" . | nindent 6 -}}
 {{- end }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.14.3
+  version: 0.14.4
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.3
+    version: 0.3.4
 
   options:
     - default: true

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.14.4
+  version: 0.14.5
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.4
+    version: 0.3.5
 
   options:
     - default: true


### PR DESCRIPTION
## Summary

- Increases the OpenSearch exporter `timeout` from `10s` to `30s` and changes the `num_of_consumers` to `2` across all opensearch exporter definitions in the logs plugin
- Prevents permanent data loss (`Dropping data`) when OpenSearch is temporarily slow to respond

## Problem

The `opensearch/storage_failover_a` exporter (and potentially others) is hitting `context deadline exceeded` errors under load, causing the queue sender to drop batches permanently:

```
error: "not retryable error: Permanent error: flush: context deadline exceeded"
dropped_items: 100
```

The current 10s timeout is too aggressive for bulk flush operations when OpenSearch is under pressure.

## Changes

| File | Exporters affected |
|------|-------------------|
| `logs-collector.yaml` | `opensearch/failover_a`, `failover_b`, `cronus_failover_a`, `cronus_failover_b` |
| `_openstack-config.tpl` | `opensearch/storage_failover_a`, `storage_failover_b` |
| `_external-config.tpl` | `opensearch/failover_a_external_*`, `failover_b_external_*` |
| `_syslog-config.tpl` | `opensearch/failover_a_syslog`, `failover_b_syslog` |
| `_traces-config.tpl` | `opensearch/failover_a_traces`, `failover_b_traces` |

## Notes

- The `retry_on_failure.max_elapsed_time` is already set to `30s`, so increasing the flush timeout to match is consistent
- The batch processor timeout in `metrics-collector.yaml` was intentionally left unchanged (different purpose)