### PR TITLE
feat(audit-logs): add Kafka to OpenSearch ingest collectors

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -75,6 +75,14 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.elastic.endpoint | string | `nil` | Endpoint URL for Elastic |
 | auditLogs.elastic.labels | list | `[]` | Labels to be added to Elastic logs |
 | auditLogs.elastic.tls | object | `{"crt":null,"key":null}` | TLS certificate for Elastic |
+| auditLogs.ingesterCollector | object | see values.yaml | Kafka -> OpenSearch ingest collectors for audit logs. One Deployment per entry. |
+| auditLogs.ingesterCollector.collectors | object | `{}` | Map of ingest collectors keyed by name. Configured via PluginPreset. |
+| auditLogs.ingesterCollector.enabled | bool | `false` | Enable the ingest collectors block. |
+| auditLogs.ingesterCollector.image.repository | string | `""` | Image repository override; falls back to auditLogs.collectorImage.repository. |
+| auditLogs.ingesterCollector.image.tag | string | `""` | Image tag override; falls back to auditLogs.collectorImage.tag. |
+| auditLogs.ingesterCollector.prometheus.podMonitor.enabled | bool | `true` | Render a PodMonitor per enabled ingest collector. |
+| auditLogs.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
+| auditLogs.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
 | auditLogs.logsCollector.auditd.enabled | bool | `true` | Activates the ingestion of auditd logs. |
 | auditLogs.logsCollector.containerd.enabled | bool | `false` | Activates ingestion of container stdout/stderr logs from /var/log/pods |
 | auditLogs.logsCollector.enabled | bool | `true` | Activates the standard configuration for Logs. |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.0.25
+version: 0.1.0
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/ci/test-values.yaml
+++ b/audit-logs/charts/ci/test-values.yaml
@@ -13,3 +13,30 @@ auditLogs:
     enabled: false
   cluster: test
   region: test
+  logsCollector:
+    kafka:
+      enabled: true
+      brokers:
+        - kafka.test.svc.cluster.local:9092
+      protocol_version: "3.9.0"
+      encoding: otlp_proto
+  ingesterCollector:
+    enabled: true
+    replicas: 1
+    prometheus:
+      podMonitor:
+        enabled: false
+    collectors:
+      audit:
+        enabled: true
+        topic: audit
+        opensearch:
+          endpoint: https://opensearch.test.svc.cluster.local:9200
+          tls:
+            caSecret: opensearch-ca
+            caSecretKey: ca.crt
+            insecure: true
+          failover_username_a: test
+          failover_password_a: test
+          failover_username_b: test
+          failover_password_b: test

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -1,0 +1,180 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.auditLogs.ingesterCollector.enabled -}}
+{{- $root := . -}}
+{{- range $name, $cfg := .Values.auditLogs.ingesterCollector.collectors -}}
+{{- if and $cfg.enabled $cfg.topic }}
+---
+apiVersion: opentelemetry.io/v1beta1
+kind: OpenTelemetryCollector
+metadata:
+  name: audit-ingester-{{ $name }}
+  labels:
+  {{- include "plugin.labels" $root | nindent 4 }}
+  {{- if $root.Values.auditLogs.customLabels }}
+  {{ toYaml $root.Values.auditLogs.customLabels | nindent 4 }}
+  {{- end }}
+spec:
+  mode: deployment
+  replicas: {{ $root.Values.auditLogs.ingesterCollector.replicas }}
+  podAnnotations:
+    kubectl.kubernetes.io/default-container: "otc-container"
+    secret.reloader.stakater.com/reload: "audit-ingester-{{ $name }}-auth"
+  terminationGracePeriodSeconds: 30
+  {{- with $root.Values.auditLogs.ingesterCollector.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  env:
+    - name: cluster
+      value: "{{ $root.Values.auditLogs.cluster }}"
+    - name: region
+      value: "{{ $root.Values.auditLogs.region }}"
+  envFrom:
+    - secretRef:
+        name: audit-ingester-{{ $name }}-auth
+{{- if $root.Values.auditLogs.ingesterCollector.prometheus.podMonitor.enabled }}
+  ports:
+    - name: prometheus
+      port: 8888
+{{- end }}
+  image: {{ (default (dict) $cfg.image).repository | default $root.Values.auditLogs.ingesterCollector.image.repository | default $root.Values.auditLogs.collectorImage.repository }}:{{ (default (dict) $cfg.image).tag | default $root.Values.auditLogs.ingesterCollector.image.tag | default $root.Values.auditLogs.collectorImage.tag }}
+  volumeMounts:
+    - name: opensearch-ca
+      mountPath: /etc/ssl/opensearch
+      readOnly: true
+  volumes:
+    - name: opensearch-ca
+      secret:
+        secretName: {{ $cfg.opensearch.tls.caSecret | quote }}
+  config:
+{{- $kafka := $root.Values.auditLogs.logsCollector.kafka -}}
+{{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) -}}
+{{- $kafka = $cfg.kafka -}}
+{{- end }}
+    receivers:
+      kafka/{{ $name }}:
+        brokers:
+{{- range $kafka.brokers }}
+          - {{ . }}
+{{- end }}
+        protocol_version: {{ $kafka.protocol_version }}
+        logs:
+          topics:
+            - {{ $cfg.topic | quote }}
+          encoding: {{ $kafka.encoding }}
+        group_id: {{ printf "audit-ingester-%s" $name | quote }}
+        initial_offset: {{ $cfg.initialOffset | default "latest" | quote }}
+        autocommit:
+          enable: true
+          interval: 1s
+        message_marking:
+          after: true
+          on_error: false
+          on_permanent_error: false
+        error_backoff:
+          enabled: true
+          initial_interval: 1s
+          max_interval: 30s
+          max_elapsed_time: 3m
+    processors:
+      memory_limiter:
+        check_interval: 5s
+        limit_percentage: 80
+        spike_limit_percentage: 30
+      attributes/cluster:
+        actions:
+          - action: insert
+            key: k8s.cluster.name
+            value: ${cluster}
+          - action: insert
+            key: region
+            value: ${region}
+    extensions:
+      basicauth/failover_a:
+        client_auth:
+          username: ${failover_username_a}
+          password: ${failover_password_a}
+      basicauth/failover_b:
+        client_auth:
+          username: ${failover_username_b}
+          password: ${failover_password_b}
+    exporters:
+      debug:
+        verbosity: basic
+      opensearch/{{ $name }}_failover_a:
+        http:
+          auth:
+            authenticator: basicauth/failover_a
+          tls:
+            ca_file: /etc/ssl/opensearch/{{ $cfg.opensearch.tls.caSecretKey }}
+            insecure: {{ $cfg.opensearch.tls.insecure }}
+          endpoint: {{ $cfg.opensearch.endpoint | quote }}
+        logs_index: {{ $name | quote }}
+        retry_on_failure:
+          enabled: true
+          initial_interval: 1s
+          max_interval: 5s
+          max_elapsed_time: 30s
+        timeout: 10s
+      opensearch/{{ $name }}_failover_b:
+        http:
+          auth:
+            authenticator: basicauth/failover_b
+          tls:
+            ca_file: /etc/ssl/opensearch/{{ $cfg.opensearch.tls.caSecretKey }}
+            insecure: {{ $cfg.opensearch.tls.insecure }}
+          endpoint: {{ $cfg.opensearch.endpoint | quote }}
+        logs_index: {{ $name | quote }}
+        retry_on_failure:
+          enabled: true
+          initial_interval: 1s
+          max_interval: 5s
+          max_elapsed_time: 30s
+        timeout: 10s
+    connectors:
+      failover/opensearch_{{ $name }}:
+        priority_levels:
+          - [logs/{{ $name }}_failover_a]
+          - [logs/{{ $name }}_failover_b]
+        retry_interval: 1m
+    service:
+      extensions:
+        - basicauth/failover_a
+        - basicauth/failover_b
+{{- if $root.Values.auditLogs.ingesterCollector.prometheus.podMonitor.enabled }}
+      telemetry:
+        metrics:
+          level: detailed
+          readers:
+            - pull:
+                exporter:
+                  prometheus:
+                    host: 0.0.0.0
+                    port: 8888
+                    without_type_suffix: false
+                    with_resource_constant_labels:
+                      included:
+                        - k8s_cluster_name
+                        - region
+        resource:
+          k8s_cluster_name: ${cluster}
+          region: ${region}
+{{- end }}
+      pipelines:
+        logs/{{ $name }}:
+          receivers: [kafka/{{ $name }}]
+          processors: [memory_limiter, attributes/cluster]
+          exporters: [failover/opensearch_{{ $name }}]
+        logs/{{ $name }}_failover_a:
+          receivers: [failover/opensearch_{{ $name }}]
+          exporters: [opensearch/{{ $name }}_failover_a]
+        logs/{{ $name }}_failover_b:
+          receivers: [failover/opensearch_{{ $name }}]
+          exporters: [opensearch/{{ $name }}_failover_b]
+{{- end }}
+{{- end }}
+{{- end }}

--- a/audit-logs/charts/templates/pmon-ingester.yaml
+++ b/audit-logs/charts/templates/pmon-ingester.yaml
@@ -1,0 +1,36 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.auditLogs.ingesterCollector.enabled .Values.auditLogs.ingesterCollector.prometheus.podMonitor.enabled -}}
+{{- $root := . -}}
+{{- range $name, $cfg := .Values.auditLogs.ingesterCollector.collectors -}}
+{{- if and $cfg.enabled $cfg.topic }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: opentelemetry-collector-audit-ingester-{{ $name }}
+  labels:
+    {{- include "plugin.labels" $root | nindent 4 }}
+    {{- if $root.Values.auditLogs.customLabels }}
+    {{ toYaml $root.Values.auditLogs.customLabels | nindent 4 }}
+    {{- end }}
+    {{- include "plugin.prometheusLabels" $root | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+    - interval: 60s
+      scrapeTimeout: 50s
+      path: /metrics
+      scheme: http
+      port: prometheus
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: opentelemetry-collector
+      app.kubernetes.io/instance: {{ $root.Release.Namespace }}.audit-ingester-{{ $name }}
+      app.kubernetes.io/managed-by: opentelemetry-operator
+      app.kubernetes.io/part-of: opentelemetry
+{{- end }}
+{{- end }}
+{{- end }}

--- a/audit-logs/charts/templates/secret-ingester.yaml
+++ b/audit-logs/charts/templates/secret-ingester.yaml
@@ -1,0 +1,28 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- if .Values.auditLogs.ingesterCollector.enabled -}}
+{{- $root := . -}}
+{{- range $name, $cfg := .Values.auditLogs.ingesterCollector.collectors -}}
+{{- if and $cfg.enabled $cfg.topic }}
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: audit-ingester-{{ $name }}-auth
+  labels:
+  {{- include "plugin.labels" $root | nindent 4 }}
+  {{- if $root.Values.auditLogs.customLabels }}
+  {{ toYaml $root.Values.auditLogs.customLabels | nindent 4 }}
+  {{- end }}
+type: Opaque
+stringData:
+  failover_username_a: {{ required (printf "collector %q is missing opensearch.failover_username_a" $name) $cfg.opensearch.failover_username_a | quote }}
+  failover_password_a: {{ required (printf "collector %q is missing opensearch.failover_password_a" $name) $cfg.opensearch.failover_password_a | quote }}
+  failover_username_b: {{ required (printf "collector %q is missing opensearch.failover_username_b" $name) $cfg.opensearch.failover_username_b | quote }}
+  failover_password_b: {{ required (printf "collector %q is missing opensearch.failover_password_b" $name) $cfg.opensearch.failover_password_b | quote }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -85,6 +85,39 @@ auditLogs:
     # -- Labels to be added to Elastic logs
     labels: []
 
+  # -- Kafka -> OpenSearch ingest collectors for audit logs. One Deployment per entry.
+  # @default -- see values.yaml
+  ingesterCollector:
+    # -- Enable the ingest collectors block.
+    enabled: false
+    # -- Replica count per ingest collector Deployment.
+    replicas: 1
+    image:
+      # -- Image repository override; falls back to auditLogs.collectorImage.repository.
+      repository: ""
+      # -- Image tag override; falls back to auditLogs.collectorImage.tag.
+      tag: ""
+    # -- Pod resources per ingest collector Deployment.
+    resources: {}
+    prometheus:
+      podMonitor:
+        # -- Render a PodMonitor per enabled ingest collector.
+        enabled: true
+    # Entry shape:
+    #   <name>:
+    #     enabled: bool                         # render this collector
+    #     topic: <kafka-topic>                  # single Kafka topic consumed by this collector
+    #     initialOffset: latest | earliest      # optional, defaults to latest
+    #     kafka: { brokers, protocol_version, encoding }  # optional override of auditLogs.logsCollector.kafka
+    #     opensearch:
+    #       endpoint: <url>
+    #       tls: { caSecret, caSecretKey, insecure }
+    #       failover_username_a / failover_password_a / failover_username_b / failover_password_b
+    # Each entry renders one OpenTelemetryCollector named "audit-ingester-<name>" with
+    # group_id "audit-ingester-<name>" and indexes documents into OpenSearch index "<name>".
+    # -- Map of ingest collectors keyed by name. Configured via PluginPreset.
+    collectors: {}
+
 
   prometheus:
     # -- Activates the service-monitoring for the Logs Collector.

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.0.25
+    version: 0.1.0
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.0.25
+        version: 0.1.0
     options:
         - name: auditLogs.region
           description: Region label for logging
@@ -88,6 +88,11 @@ spec:
           description: Collector image tag
           required: false
           type: string
+        - name: auditLogs.logsCollector.enabled
+          default: true
+          description: Top-level toggle for the producer-side audit logs collector. Set to false in consumer-only PluginPresets to skip rendering the producer DaemonSet.
+          required: false
+          type: bool
         - name: auditLogs.logsCollector.auditd.enabled
           description: Enable auditd ingestion
           required: false
@@ -142,3 +147,26 @@ spec:
           description: Skip server certificate verification (leave false for production)
           required: false
           type: bool
+        - name: auditLogs.ingesterCollector.enabled
+          default: false
+          description: Top-level toggle for the Kafka -> OpenSearch audit ingest collectors
+          required: false
+          type: bool
+        - name: auditLogs.ingesterCollector.replicas
+          default: 1
+          description: Replica count per ingest collector Deployment
+          required: false
+          type: int
+        - name: auditLogs.ingesterCollector.resources
+          description: Pod resources per ingest collector Deployment
+          required: false
+          type: map
+        - name: auditLogs.ingesterCollector.prometheus.podMonitor.enabled
+          default: true
+          description: Render a PodMonitor per enabled ingest collector
+          required: false
+          type: bool
+        - name: auditLogs.ingesterCollector.collectors
+          description: Map of ingest collectors keyed by name. Each entry renders one OpenTelemetryCollector named `audit-ingester-<name>` consuming a single Kafka topic and writing to OpenSearch index `<name>`. See chart values.yaml for the entry schema.
+          required: false
+          type: map


### PR DESCRIPTION
## Pull Request Details

Add a Kafka to OpenSearch ingester collector to the audit-logs chart. Kafka is the durable buffer, the ingester only commits a Kafka offset after OpenSearch has acknowledged the write.

- Synchronous error chain: no async queue or batch processor, so export errors reach the Kafka receiver instead of being swallowed.
- The receiver commits only after a successful export.
- Bounded retry window (3 minutes) on the receiver. If OpenSearch is down longer, the receiver rewinds and retries from the same offset (no data loss or silent skip)
- Short failover re-probe interval (1 minute) so OpenSearch recovery is detected quickly

### Out of scope

- No on-disk queue / StatefulSet. Kafka is already the durable buffer.
- No dead-letter topic. Would need per-record routing and a consumer