### PR TITLE
fix(logs): disable failover connector sending_queue

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.0
+version: 0.4.1
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -141,6 +141,8 @@ spec:
           - [logs/{{ $name }}_failover_a]
           - [logs/{{ $name }}_failover_b]
         retry_interval: 1m
+        sending_queue:
+          enabled: false
     service:
       extensions:
         - basicauth/failover_a

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.0
+  version: 0.15.1
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.0
+    version: 0.4.1
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

The failover connector defaults its `QueueSettings` to an enabled async queue. Even without `sending_queue` in our config, this default queue activates and breaks the synchronous error chain the ingester depends on. The queue accepts records and returns success to the receiver, then errors are swallowed inside the queue's consumers ("sending queue is full" + "Exporting failed. Rejecting data" with no path back to the kafkareceiver).

Set `sending_queue.enabled: false` on the failover connector to fall back to the raw, synchronous path.