### PR TITLE
fix(audit-logs): disable failover connector sending_queue

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.1.0
+version: 0.1.1
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -141,6 +141,8 @@ spec:
           - [logs/{{ $name }}_failover_a]
           - [logs/{{ $name }}_failover_b]
         retry_interval: 1m
+        sending_queue:
+          enabled: false
     service:
       extensions:
         - basicauth/failover_a

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.1.0
+    version: 0.1.1
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.0
+        version: 0.1.1
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
## Pull Request Details

The failover connector defaults its `QueueSettings` to an enabled async queue. Even without `sending_queue` in our config, this default queue activates and breaks the synchronous error chain the ingester depends on. The queue accepts records and returns success to the receiver, then errors are swallowed inside the queue's consumers ("sending queue is full" + "Exporting failed. Rejecting data" with no path back to the kafkareceiver).

Set `sending_queue.enabled: false` on the failover connector to fall back to the raw, synchronous path.