### PR TITLE
feat(logs): add extraManifests support for admission policies

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -91,6 +91,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 |-----|------|---------|-------------|
 | commonLabels | object | `{}` | common labels to apply to all resources. |
 | customCRDs.enabled | bool | `true` | The required CRDs used by this dependency are version-controlled in this repository under ./charts/crds. |
+| extraManifests | list | `[]` | Extra Kubernetes manifests to include in the Helm release. Each entry is rendered as-is (map) or with `tpl` (string). Useful for ConfigMaps that satisfy cluster admission policies. |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
 | openTelemetry.collectorImage | object | `{"repository":"ghcr.io/cloudoperators/opentelemetry-collector-contrib","tag":"a8981ba"}` | OpenTelemetry Collector image configuration |
 | openTelemetry.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | Image repository for OpenTelemetry Collector |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.1
+version: 0.4.2
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/extra-manifests.yaml
+++ b/logs/charts/templates/extra-manifests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- range .Values.extraManifests }}
+{{- if kindIs "map" . }}
+---
+{{ toYaml . }}
+{{- else if kindIs "string" . }}
+---
+{{ tpl . $ }}
+{{- else }}
+{{- fail (printf "extraManifests: unsupported entry type %s (expected string or map)" (kindOf .)) }}
+{{- end }}
+{{- end }}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -4,6 +4,9 @@
 # -- common labels to apply to all resources.
 commonLabels: {}
 
+# -- Extra Kubernetes manifests to include in the Helm release. Each entry is rendered as-is (map) or with `tpl` (string). Useful for ConfigMaps that satisfy cluster admission policies.
+extraManifests: []
+
 # opentelemetry-operator is an upstream dependency, it is required that it is a separate block. This is customised configuration of the dependency.
 opentelemetry-operator:
   # -- Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.1
+  version: 0.15.2
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.1
+    version: 0.4.2
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.
@@ -168,3 +168,7 @@ spec:
       name: openTelemetry.collectorImage.repository
       required: false
       type: string
+    - description: Extra Kubernetes manifests to include in the Helm release. Useful for ConfigMaps that satisfy cluster admission policies.
+      name: extraManifests
+      required: false
+      type: list


### PR DESCRIPTION
## Pull Request Details

Add `extraManifests` support to the logs chart, mirroring the existing pattern in the opensearch chart. Enables PluginPresets to inject ConfigMaps required by cluster admission policies (e.g. Gatekeeper policy)