### PR TITLE
feat(audit-logs): add extraManifests support for admission policies

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -116,6 +116,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.prometheus.serviceMonitor | object | `{"enabled":false}` | Activates the pod-monitoring for the Logs Collector. |
 | auditLogs.region | string | `nil` | Region label for Logging |
 | commonLabels | string | `nil` | Common labels to apply to all resources |
+| extraManifests | list | `[]` | Extra Kubernetes manifests to include in the Helm release. Each entry is rendered as-is (map) or with `tpl` (string). Useful for ConfigMaps that satisfy cluster admission policies. |
 
 ### Examples
 

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.1.1
+version: 0.1.2
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/extra-manifests.yaml
+++ b/audit-logs/charts/templates/extra-manifests.yaml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- range .Values.extraManifests }}
+{{- if kindIs "map" . }}
+---
+{{ toYaml . }}
+{{- else if kindIs "string" . }}
+---
+{{ tpl . $ }}
+{{- else }}
+{{- fail (printf "extraManifests: unsupported entry type %s (expected string or map)" (kindOf .)) }}
+{{- end }}
+{{- end }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -4,6 +4,9 @@
 # -- Common labels to apply to all resources
 commonLabels:
 
+# -- Extra Kubernetes manifests to include in the Helm release. Each entry is rendered as-is (map) or with `tpl` (string). Useful for ConfigMaps that satisfy cluster admission policies.
+extraManifests: []
+
 auditLogs:
 
   nodeSelector: {}

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.1.1
+    version: 0.1.2
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.1
+        version: 0.1.2
     options:
         - name: auditLogs.region
           description: Region label for logging
@@ -170,3 +170,7 @@ spec:
           description: Map of ingest collectors keyed by name. Each entry renders one OpenTelemetryCollector named `audit-ingester-<name>` consuming a single Kafka topic and writing to OpenSearch index `<name>`. See chart values.yaml for the entry schema.
           required: false
           type: map
+        - name: extraManifests
+          description: Extra Kubernetes manifests to include in the Helm release. Useful for ConfigMaps that satisfy cluster admission policies.
+          required: false
+          type: list


### PR DESCRIPTION
## Pull Request Details

Add `extraManifests` support to the logs chart, mirroring the existing pattern in the opensearch chart. Enables PluginPresets to inject ConfigMaps required by cluster admission policies (e.g. Gatekeeper policy)