### PR TITLE
feat(audit-logs): add extraProcessors and exporter mapping

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.1.2
+version: 0.1.3
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -93,6 +93,10 @@ spec:
           - action: insert
             key: region
             value: ${region}
+{{- range $cfg.extraProcessors }}
+      {{ .name }}:
+        {{- toYaml .config | nindent 8 }}
+{{- end }}
     extensions:
       basicauth/failover_a:
         client_auth:
@@ -114,6 +118,10 @@ spec:
             insecure: {{ $cfg.opensearch.tls.insecure }}
           endpoint: {{ $cfg.opensearch.endpoint | quote }}
         logs_index: {{ $name | quote }}
+{{- with $cfg.opensearch.mapping }}
+        mapping:
+          {{- toYaml . | nindent 10 }}
+{{- end }}
         retry_on_failure:
           enabled: true
           initial_interval: 1s
@@ -129,6 +137,10 @@ spec:
             insecure: {{ $cfg.opensearch.tls.insecure }}
           endpoint: {{ $cfg.opensearch.endpoint | quote }}
         logs_index: {{ $name | quote }}
+{{- with $cfg.opensearch.mapping }}
+        mapping:
+          {{- toYaml . | nindent 10 }}
+{{- end }}
         retry_on_failure:
           enabled: true
           initial_interval: 1s
@@ -169,7 +181,7 @@ spec:
       pipelines:
         logs/{{ $name }}:
           receivers: [kafka/{{ $name }}]
-          processors: [memory_limiter, attributes/cluster]
+          processors: [memory_limiter, attributes/cluster{{- range $cfg.extraProcessors }}, {{ .name }}{{- end }}]
           exporters: [failover/opensearch_{{ $name }}]
         logs/{{ $name }}_failover_a:
           receivers: [failover/opensearch_{{ $name }}]

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -111,10 +111,12 @@ auditLogs:
     #     enabled: bool                         # render this collector
     #     topic: <kafka-topic>                  # single Kafka topic consumed by this collector
     #     initialOffset: latest | earliest      # optional, defaults to latest
+    #     extraProcessors: <list>               # optional, ordered list of {name, config} entries; each is added to processors: and appended to the pipeline in this order
     #     kafka: { brokers, protocol_version, encoding }  # optional override of auditLogs.logsCollector.kafka
     #     opensearch:
     #       endpoint: <url>
     #       tls: { caSecret, caSecretKey, insecure }
+    #       mapping: { mode: bodymap }          # optional, opensearchexporter mapping block (e.g. bodymap to write the parsed body as the document root)
     #       failover_username_a / failover_password_a / failover_username_b / failover_password_b
     # Each entry renders one OpenTelemetryCollector named "audit-ingester-<name>" with
     # group_id "audit-ingester-<name>" and indexes documents into OpenSearch index "<name>".

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.1.2
+    version: 0.1.3
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.2
+        version: 0.1.3
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
## Pull Request Details

Logstash producers emit plain JSON over Kafka (not OTLP). The kafkareceiver's `encoding: json` (OTLP unmarshaler) stuffs the payload into `body` as a string and leaves the log record's timestamp at epoch zero, so docs land in OpenSearch with `@timestamp: 1970-01-01`. With `extraProcessors` we add a `transform` that parses `body` into a map and `mapping.mode: bodymap` makes the exporter write that map as the document root (restoring the flat shape pull-based ingestion used to produce.)
