### PR TITLE
feat(gatekeeper-config): add doop-dependent policies

### DIFF
--- a/gatekeeper-config/README.md
+++ b/gatekeeper-config/README.md
@@ -20,6 +20,10 @@ Requires the [OPA Gatekeeper](https://github.com/cloudoperators/greenhouse-exten
 | `ingressAnnotations` | Flags Ingresses using insecure nginx snippet annotations or the deprecated `ingress.kubernetes.io/` prefix. |
 | `ingressAnnotationsMigration` | During the nginx annotation prefix migration, flags Ingresses that set only one of the old/new prefix or set both with mismatched values. |
 | `prometheusScrapeAnnotations` | Flags Pods and Services that opt into scraping via `prometheus.io/scrape: "true"` but are not matched by any configured Prometheus CR. |
+| `deprecatedApiVersion` | Flags Helm releases that declare resources using API versions removed in a specific Kubernetes release. Requires `gatekeeper-doop`. |
+| `oliLabelsRequired` | Flags Helm release Secrets without the `greenhouse.sap/owned-by` label injected by Owner Label Injector. Requires `gatekeeper-doop`. |
+| `outdatedImageBases` | Flags workloads whose container base images are older than `maxAgeDays`, as reported by `doop-image-checker`. Requires `gatekeeper-doop`. |
+| `vulnerableImages` | Flags workloads running container images with known vulnerabilities, as reported by `doop-image-checker`. Requires `gatekeeper-doop`. |
 
 ## Default behavior
 

--- a/gatekeeper-config/charts/Chart.yaml
+++ b/gatekeeper-config/charts/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v2
 description: Helm chart deploying OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control.
 name: gatekeeper-config
-version: 0.3.0
-appVersion: 0.3.0
+version: 0.4.0
+appVersion: 0.4.0
 icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
 keywords:
   - gatekeeper

--- a/gatekeeper-config/charts/Chart.yaml
+++ b/gatekeeper-config/charts/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v2
 description: Helm chart deploying OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control.
 name: gatekeeper-config
-version: 0.4.0
-appVersion: 0.4.0
+version: 0.4.1
+appVersion: 0.4.1
 icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
 keywords:
   - gatekeeper

--- a/gatekeeper-config/charts/templates/_helpers.tpl
+++ b/gatekeeper-config/charts/templates/_helpers.tpl
@@ -7,6 +7,12 @@ Shared Rego libraries inlined into every ConstraintTemplate.
   add_support_labels: annotates violation messages with the
     greenhouse.sap/owned-by label so reports can be routed to the right team.
 
+  helm_release: calls the helm-manifest-parser service to decode the
+    `data.release` blob in Helm release Secrets into a JSON manifest.
+
+  image_check: calls the doop-image-checker service to retrieve
+    vulnerability / base-image headers for a container image.
+
   traversal: walks the Kubernetes ownership chain (Pod, ReplicaSet,
     Deployment, etc.) so policies can target the workload owner instead of
     the synthesized Pod.
@@ -98,5 +104,123 @@ __extract_container_specs(pod) := result if {
 		object.get(pod.spec, "containers", []),
 		object.get(pod.spec, "initContainers", []),
 	)
+}
+{{- end }}
+
+{{- define "gatekeeper-config.lib.helm_release" -}}
+package lib.helm_release
+
+# Returns {"error": ""} for non-Helm Secrets so callers can short-circuit without
+# emitting violations. The Constraint should use match.labelSelector to filter
+# down to Helm release Secrets in the first place; this guard is a defence in
+# depth.
+parse_k8s_object(obj, baseURL) := result if {
+	not __is_helm_release(obj)
+	result := {"error": "", "items": [], "owner_info": {}}
+}
+
+parse_k8s_object(obj, baseURL) := result if {
+	__is_helm_release(obj)
+	url := sprintf("%s/v3", [baseURL])
+	resp := http.send({"url": url, "method": "POST", "raise_error": false, "raw_body": obj.data.release, "timeout": "15s"})
+	result := __parse_response(resp)
+}
+
+__is_helm_release(obj) if {
+	obj.kind == "Secret"
+	obj.type == "helm.sh/release.v1"
+}
+
+__is_helm_release(obj) := false if {
+	obj.kind != "Secret"
+}
+
+__is_helm_release(obj) := false if {
+	obj.type != "helm.sh/release.v1"
+}
+
+__parse_response(resp) := result if {
+	resp.status_code == 200
+	result := object.union(resp.body, {"error": ""})
+}
+
+__parse_response(resp) := result if {
+	resp.status_code != 200
+	object.get(resp, ["error", "message"], "") == ""
+	result := {"error": sprintf("helm-manifest-parser returned HTTP status %d, but we expected 200. Please retry in ~5 minutes.", [resp.status_code])}
+}
+
+__parse_response(resp) := result if {
+	resp.status_code != 200
+	msg := object.get(resp, ["error", "message"], "")
+	msg != ""
+	result := {"error": sprintf("Could not reach helm-manifest-parser (%q). Please retry in ~5 minutes.", [msg])}
+}
+{{- end }}
+
+{{- define "gatekeeper-config.lib.image_check" -}}
+package lib.image_check
+
+for_pod(pod, baseURL) := result if {
+	pod.kind != "Pod"
+	result := [{"error": "not a pod"}]
+}
+
+for_pod(pod, baseURL) := result if {
+	pod.kind == "Pod"
+
+	containerStatuses := array.concat(
+		object.get(pod, ["status", "containerStatuses"], []),
+		object.get(pod, ["status", "initContainerStatuses"], []),
+	)
+	result := [__run_check(c, baseURL, true) | c := containerStatuses[_]]
+}
+
+for_pod_template(podTemplate, baseURL) := result if {
+	containerSpecs := array.concat(
+		object.get(podTemplate, ["spec", "containers"], []),
+		object.get(podTemplate, ["spec", "initContainers"], []),
+	)
+	result := [__run_check(c, baseURL, false) | c := containerSpecs[_]]
+}
+
+__run_check(container, baseURL, hasImageID) := result if {
+	imageRef := __get_image_ref(container, hasImageID)
+	url := sprintf("%s/v1/headers?image=%s", [baseURL, imageRef])
+	resp := http.send({"url": url, "method": "GET", "raise_error": false, "timeout": "15s"})
+	result := __parse_response(container, resp)
+}
+
+__get_image_ref(container, hasImageID) := result if {
+	hasImageID
+	result := trim_prefix(container.imageID, "docker-pullable://")
+}
+
+__get_image_ref(container, hasImageID) := result if {
+	not hasImageID
+	result := container.image
+}
+
+__parse_response(container, resp) := result if {
+	resp.status_code == 200
+	result := {
+		"error": "",
+		"containerName": container.name,
+		"containerImage": container.image,
+		"headers": resp.body,
+	}
+}
+
+__parse_response(container, resp) := result if {
+	resp.status_code != 200
+	object.get(resp, ["error", "message"], "") == ""
+	result := {"error": sprintf("doop-image-checker returned HTTP status %d, but we expected 200. Please retry in ~5 minutes.", [resp.status_code])}
+}
+
+__parse_response(container, resp) := result if {
+	resp.status_code != 200
+	msg := object.get(resp, ["error", "message"], "")
+	msg != ""
+	result := {"error": sprintf("Could not reach doop-image-checker (%q). Please retry in ~5 minutes.", [msg])}
 }
 {{- end }}

--- a/gatekeeper-config/charts/templates/_helpers.tpl
+++ b/gatekeeper-config/charts/templates/_helpers.tpl
@@ -126,6 +126,8 @@ parse_k8s_object(obj, baseURL) := result if {
 	result := __parse_response(resp)
 }
 
+is_helm_release(obj) if __is_helm_release(obj)
+
 __is_helm_release(obj) if {
 	obj.kind == "Secret"
 	obj.type == "helm.sh/release.v1"

--- a/gatekeeper-config/charts/templates/constraint-deprecated-api-version-k8s1-32.yaml
+++ b/gatekeeper-config/charts/templates/constraint-deprecated-api-version-k8s1-32.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.policies.deprecatedApiVersion.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkDeprecatedApiVersion
+metadata:
+  name: deprecated-api-version-k8s1-32
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.deprecatedApiVersion.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Secret"]
+    scope: Namespaced
+    labelSelector:
+      matchLabels:
+        owner: helm
+  parameters:
+    helmManifestParserURL: {{ required "policies.deprecatedApiVersion.helmManifestParserURL is required when policies.deprecatedApiVersion.enabled=true" .Values.policies.deprecatedApiVersion.helmManifestParserURL | quote }}
+    kubernetesVersion: '1.32'
+    apiVersions:
+      - flowcontrol.apiserver.k8s.io/v1beta3
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-oli-labels-required.yaml
+++ b/gatekeeper-config/charts/templates/constraint-oli-labels-required.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.policies.oliLabelsRequired.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkOliLabelsRequired
+metadata:
+  name: oli-labels-required
+  labels:
+    severity: 'error'
+spec:
+  enforcementAction: {{ .Values.policies.oliLabelsRequired.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Secret"]
+    scope: Namespaced
+    labelSelector:
+      matchLabels:
+        owner: helm
+    excludedNamespaces:
+      {{- toYaml .Values.policies.oliLabelsRequired.excludedNamespaces | nindent 6 }}
+  parameters:
+    helmManifestParserURL: {{ required "policies.oliLabelsRequired.helmManifestParserURL is required when policies.oliLabelsRequired.enabled=true" .Values.policies.oliLabelsRequired.helmManifestParserURL | quote }}
+    knownExceptions: {{ .Values.policies.oliLabelsRequired.knownExceptions | toJson }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-outdated-image-bases.yaml
+++ b/gatekeeper-config/charts/templates/constraint-outdated-image-bases.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.policies.outdatedImageBases.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkOutdatedImageBases
+metadata:
+  name: outdated-image-bases
+  labels:
+    severity: 'info'
+spec:
+  enforcementAction: {{ .Values.policies.outdatedImageBases.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: [""]
+        kinds: ["Pod"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    doopImageCheckerURL: {{ required "policies.outdatedImageBases.imageCheckerURL is required when policies.outdatedImageBases.enabled=true" .Values.policies.outdatedImageBases.imageCheckerURL | quote }}
+    createdAtHeader: {{ required "policies.outdatedImageBases.createdAtHeader is required when policies.outdatedImageBases.enabled=true" .Values.policies.outdatedImageBases.createdAtHeader | quote }}
+    maxAgeDays: {{ .Values.policies.outdatedImageBases.maxAgeDays }}
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod-owner.yaml
+++ b/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod-owner.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.policies.vulnerableImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkVulnerableImages
+metadata:
+  name: vulnerable-images-on-pod-owner
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.vulnerableImages.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: ["apps"]
+        kinds: ["Deployment", "DaemonSet", "StatefulSet", "ReplicaSet"]
+      - apiGroups: ["batch"]
+        kinds: ["Job", "CronJob"]
+    scope: Namespaced
+  parameters:
+    doopImageCheckerURL: {{ required "policies.vulnerableImages.imageCheckerURL is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.imageCheckerURL | quote }}
+    vulnStatusHeader: {{ required "policies.vulnerableImages.vulnStatusHeader is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.vulnStatusHeader | quote }}
+    reportingLevel: "pod-owner"
+{{- end }}

--- a/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod.yaml
+++ b/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.policies.vulnerableImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: constraints.gatekeeper.sh/v1beta1
+kind: GkVulnerableImages
+metadata:
+  name: vulnerable-images-on-pod
+  labels:
+    severity: 'warning'
+spec:
+  enforcementAction: {{ .Values.policies.vulnerableImages.enforcementAction }}
+  match:
+    kinds:
+      - apiGroups: [""]
+        kinds: ["Pod"]
+    scope: Namespaced
+  parameters:
+    doopImageCheckerURL: {{ required "policies.vulnerableImages.imageCheckerURL is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.imageCheckerURL | quote }}
+    vulnStatusHeader: {{ required "policies.vulnerableImages.vulnStatusHeader is required when policies.vulnerableImages.enabled=true" .Values.policies.vulnerableImages.vulnStatusHeader | quote }}
+    reportingLevel: "pod"
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-deprecated-api-version.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-deprecated-api-version.yaml
@@ -1,0 +1,62 @@
+{{- if .Values.policies.deprecatedApiVersion.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkdeprecatedapiversion
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkDeprecatedApiVersion
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            helmManifestParserURL:
+              type: string
+            kubernetesVersion:
+              type: string
+            apiVersions:
+              type: array
+              items:
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.helm_release" . | indent 16 }}
+            rego: |
+              package deprecatedapiversion
+
+              import data.lib.add_support_labels
+              import data.lib.helm_release
+
+              iro := input.review.object
+
+              release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+
+              violation contains {"msg": release.error} if {
+                  release.error != ""
+              }
+
+              violation contains {"msg": add_support_labels.from_helm_release(release, msg)} if {
+                  release.error == ""
+
+                  obj := release.items[_]
+                  input.parameters.apiVersions[_] == obj.apiVersion
+
+                  msg := sprintf(
+                      "%s %s declared with deprecated API version: %s (will break in k8s v%s)",
+                      [obj.kind, obj.metadata.name, obj.apiVersion, input.parameters.kubernetesVersion],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-oli-labels-required.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-oli-labels-required.yaml
@@ -1,0 +1,69 @@
+{{- if .Values.policies.oliLabelsRequired.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkolilabelsrequired
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkOliLabelsRequired
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            helmManifestParserURL:
+              type: string
+            knownExceptions:
+              type: array
+              items:
+                type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.helm_release" . | indent 16 }}
+            rego: |
+              package olilabelsrequired
+
+              import data.lib.add_support_labels
+              import data.lib.helm_release
+
+              iro := input.review.object
+              release := helm_release.parse_k8s_object(iro, input.parameters.helmManifestParserURL)
+
+              violation contains {"msg": release.error} if {
+                  release.error != ""
+              }
+
+              # release_key is the "<namespace>/<release-name>" key used to look up
+              # entries in knownExceptions. The release name is read with object.get
+              # so a missing label leaves the key with an empty release name rather
+              # than leaving the rule unbound (which would also break is_exception).
+              release_key := sprintf("%s/%s", [iro.metadata.namespace, object.get(iro.metadata, ["labels", "name"], "")])
+
+              default is_exception := false
+
+              is_exception if {
+                  input.parameters.knownExceptions[_] == release_key
+              }
+
+              violation contains {"msg": add_support_labels.from_helm_release(release, msg)} if {
+                  release.error == ""
+                  not is_exception
+
+                  owned_by := object.get(release, ["owner_info", "owned-by"], "")
+                  owned_by == ""
+
+                  msg := "Helm release is missing greenhouse.sap/owned-by label. Ensure Owner Label Injector is running and has labelled this namespace."
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-oli-labels-required.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-oli-labels-required.yaml
@@ -61,6 +61,8 @@ spec:
                   release.error == ""
                   not is_exception
 
+                  helm_release.is_helm_release(iro)
+
                   owned_by := object.get(release, ["owner_info", "owned-by"], "")
                   owned_by == ""
 

--- a/gatekeeper-config/charts/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-outdated-image-bases.yaml
@@ -1,0 +1,70 @@
+{{- if .Values.policies.outdatedImageBases.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkoutdatedimagebases
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkOutdatedImageBases
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            doopImageCheckerURL:
+              type: string
+            createdAtHeader:
+              type: string
+            maxAgeDays:
+              type: integer
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.image_check" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package outdatedimagebases
+
+              import data.lib.add_support_labels
+              import data.lib.image_check
+              import data.lib.traversal
+
+              iro := input.review.object
+              pod := traversal.find_pod(iro)
+              checks := image_check.for_pod_template(pod, input.parameters.doopImageCheckerURL)
+
+              violation contains {"msg": check.error} if {
+                  pod.isFound
+                  check := checks[_]
+                  check.error != ""
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  check := checks[_]
+                  check.error == ""
+                  createdAtAsUnixTime := to_number(trim_space(object.get(check.headers, input.parameters.createdAtHeader, "Unclear")))
+
+                  nowAsUnixTime := time.now_ns() / 1000000000
+                  ageInSeconds := nowAsUnixTime - createdAtAsUnixTime
+                  ageInDays := ageInSeconds / 86400
+                  ageInDays > input.parameters.maxAgeDays
+
+                  msg := sprintf(
+                      "image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
+                      [check.containerImage, check.containerName, ageInDays],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-outdated-image-bases.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-outdated-image-bases.yaml
@@ -55,7 +55,10 @@ spec:
                   pod.isFound
                   check := checks[_]
                   check.error == ""
-                  createdAtAsUnixTime := to_number(trim_space(object.get(check.headers, input.parameters.createdAtHeader, "Unclear")))
+
+                  createdAt := trim_space(object.get(check.headers, input.parameters.createdAtHeader, ""))
+                  regex.match(`^[0-9]+$`, createdAt)
+                  createdAtAsUnixTime := to_number(createdAt)
 
                   nowAsUnixTime := time.now_ns() / 1000000000
                   ageInSeconds := nowAsUnixTime - createdAtAsUnixTime
@@ -65,6 +68,20 @@ spec:
                   msg := sprintf(
                       "image %s for container %q uses a very old base image (oldest layer is %.0f days old)",
                       [check.containerImage, check.containerName, ageInDays],
+                  )
+              }
+
+              violation contains {"msg": add_support_labels.from_k8s_object(iro, msg)} if {
+                  pod.isFound
+                  check := checks[_]
+                  check.error == ""
+
+                  createdAt := trim_space(object.get(check.headers, input.parameters.createdAtHeader, ""))
+                  not regex.match(`^[0-9]+$`, createdAt)
+
+                  msg := sprintf(
+                      "image %s for container %q returned no valid %q header from doop-image-checker (got %q)",
+                      [check.containerImage, check.containerName, input.parameters.createdAtHeader, createdAt],
                   )
               }
 {{- end }}

--- a/gatekeeper-config/charts/templates/constrainttemplate-vulnerable-images.yaml
+++ b/gatekeeper-config/charts/templates/constrainttemplate-vulnerable-images.yaml
@@ -1,0 +1,98 @@
+{{- if .Values.policies.vulnerableImages.enabled }}
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: templates.gatekeeper.sh/v1
+kind: ConstraintTemplate
+metadata:
+  name: gkvulnerableimages
+spec:
+  crd:
+    spec:
+      names:
+        kind: GkVulnerableImages
+      validation:
+        openAPIV3Schema:
+          type: object
+          properties:
+            doopImageCheckerURL:
+              type: string
+            vulnStatusHeader:
+              type: string
+            reportingLevel:
+              type: string
+
+  targets:
+    - target: admission.k8s.gatekeeper.sh
+      code:
+        - engine: Rego
+          source:
+            version: "v1"
+            libs:
+              - |
+{{ include "gatekeeper-config.lib.add_support_labels" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.image_check" . | indent 16 }}
+              - |
+{{ include "gatekeeper-config.lib.traversal" . | indent 16 }}
+            rego: |
+              package vulnerableimages
+
+              import data.lib.add_support_labels
+              import data.lib.image_check
+              import data.lib.traversal
+
+              iro := input.review.object
+              phase := object.get(iro, ["status", "phase"], "Running") # only relevant for iro.kind == "Pod"
+              pod := traversal.find_pod(iro)
+              checks := __run_image_check(phase)
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod"
+                  phase != "Succeeded"
+                  phase != "Failed"
+                  result = image_check.for_pod(iro, input.parameters.doopImageCheckerURL)
+              }
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod"
+
+                  # ignore pods that have already finished running, but still exist
+                  # as a k8s object (e.g. leftovers of completed or failed jobs)
+                  phase in ["Succeeded", "Failed"]
+                  result = []
+              }
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod-owner"
+                  pod.isFound
+                  result = image_check.for_pod_template(pod, input.parameters.doopImageCheckerURL)
+              }
+
+              __run_image_check(phase) := result if {
+                  input.parameters.reportingLevel == "pod-owner"
+                  not pod.isFound
+
+                  # ignore pod owners that are suppressed, e.g. ReplicaSets within Deployments
+                  result = []
+              }
+
+              violation contains {"msg": check.error} if {
+                  check := checks[_]
+                  check.error != ""
+              }
+
+              violation contains {"msg": add_support_labels.extra("status", status, add_support_labels.from_k8s_object(iro, msg))} if {
+                  check := checks[_]
+                  check.error == ""
+                  status := trim_space(object.get(check.headers, input.parameters.vulnStatusHeader, "Unclear"))
+
+                  # report everything with a definite vulnerability
+                  status != "Clean"
+                  status != "Unknown"
+
+                  msg := sprintf(
+                      "image %s for container %q has \"%s: %s\"",
+                      [check.containerImage, check.containerName, input.parameters.vulnStatusHeader, status],
+                  )
+              }
+{{- end }}

--- a/gatekeeper-config/charts/values.yaml
+++ b/gatekeeper-config/charts/values.yaml
@@ -49,5 +49,34 @@ policies:
     enabled: false
     enforcementAction: dryrun
 
+  # requires gatekeeper-doop: helmManifestParserURL must be set
+  deprecatedApiVersion:
+    enabled: false
+    enforcementAction: dryrun
+    helmManifestParserURL: ""
+
+  # requires gatekeeper-doop: helmManifestParserURL must be set
+  oliLabelsRequired:
+    enabled: false
+    enforcementAction: dryrun
+    helmManifestParserURL: ""
+    knownExceptions: []
+    excludedNamespaces: []
+
+  # requires gatekeeper-doop: imageCheckerURL must be set
+  outdatedImageBases:
+    enabled: false
+    enforcementAction: dryrun
+    imageCheckerURL: ""
+    createdAtHeader: ""
+    maxAgeDays: 365
+
+  # requires gatekeeper-doop: imageCheckerURL must be set
+  vulnerableImages:
+    enabled: false
+    enforcementAction: dryrun
+    imageCheckerURL: ""
+    vulnStatusHeader: ""
+
 tests:
   enabled: false

--- a/gatekeeper-config/plugindefinition.yaml
+++ b/gatekeeper-config/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: gatekeeper-config
 spec:
-  version: 0.3.0
+  version: 0.4.0
   displayName: Gatekeeper Config
   description: |
     Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes
@@ -17,7 +17,7 @@ spec:
   helmChart:
     name: gatekeeper-config
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.3.0
+    version: 0.4.0
   options:
     - name: policies.highCpuRequests.enabled
       displayName: High CPU requests policy enabled
@@ -188,5 +188,103 @@ spec:
       displayName: Prometheus scrape annotations enforcement action
       description: Gatekeeper enforcementAction for prometheus-scrape-annotations (dryrun, warn, or deny).
       default: dryrun
+      required: false
+      type: string
+
+    - name: policies.deprecatedApiVersion.enabled
+      displayName: Deprecated API version policy enabled
+      description: Enable the deprecated-api-version policy. Requires gatekeeper-doop (helm-manifest-parser).
+      default: false
+      required: false
+      type: bool
+    - name: policies.deprecatedApiVersion.enforcementAction
+      displayName: Deprecated API version enforcement action
+      description: Gatekeeper enforcementAction for deprecated-api-version (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.deprecatedApiVersion.helmManifestParserURL
+      displayName: Helm manifest parser URL (deprecated-api-version)
+      description: URL of the helm-manifest-parser service. Required when deprecated-api-version is enabled.
+      required: false
+      type: string
+
+    - name: policies.oliLabelsRequired.enabled
+      displayName: OLI labels required policy enabled
+      description: Enable the oli-labels-required policy. Requires gatekeeper-doop (helm-manifest-parser).
+      default: false
+      required: false
+      type: bool
+    - name: policies.oliLabelsRequired.enforcementAction
+      displayName: OLI labels required enforcement action
+      description: Gatekeeper enforcementAction for oli-labels-required (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.oliLabelsRequired.helmManifestParserURL
+      displayName: Helm manifest parser URL (oli-labels-required)
+      description: URL of the helm-manifest-parser service. Required when oli-labels-required is enabled.
+      required: false
+      type: string
+    - name: policies.oliLabelsRequired.knownExceptions
+      displayName: OLI labels known exceptions
+      description: Helm releases temporarily exempt from the policy, in "namespace/release-name" format.
+      required: false
+      type: list
+    - name: policies.oliLabelsRequired.excludedNamespaces
+      displayName: OLI labels excluded namespaces
+      description: Namespaces excluded from the oli-labels-required policy.
+      required: false
+      type: list
+
+    - name: policies.outdatedImageBases.enabled
+      displayName: Outdated image bases policy enabled
+      description: Enable the outdated-image-bases policy. Requires gatekeeper-doop (doop-image-checker).
+      default: false
+      required: false
+      type: bool
+    - name: policies.outdatedImageBases.enforcementAction
+      displayName: Outdated image bases enforcement action
+      description: Gatekeeper enforcementAction for outdated-image-bases (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.outdatedImageBases.imageCheckerURL
+      displayName: Image checker URL (outdated-image-bases)
+      description: URL of the doop-image-checker service. Required when outdated-image-bases is enabled.
+      required: false
+      type: string
+    - name: policies.outdatedImageBases.createdAtHeader
+      displayName: Image creation timestamp header
+      description: Name of the HTTP response header from doop-image-checker that carries the minimum layer creation timestamp (Unix seconds).
+      required: false
+      type: string
+    - name: policies.outdatedImageBases.maxAgeDays
+      displayName: Outdated image bases max age (days)
+      description: Containers whose base image is older than this many days are flagged.
+      default: 365
+      required: false
+      type: int
+
+    - name: policies.vulnerableImages.enabled
+      displayName: Vulnerable images policy enabled
+      description: Enable the vulnerable-images policy. Requires gatekeeper-doop (doop-image-checker).
+      default: false
+      required: false
+      type: bool
+    - name: policies.vulnerableImages.enforcementAction
+      displayName: Vulnerable images enforcement action
+      description: Gatekeeper enforcementAction for vulnerable-images (dryrun, warn, or deny).
+      default: dryrun
+      required: false
+      type: string
+    - name: policies.vulnerableImages.imageCheckerURL
+      displayName: Image checker URL (vulnerable-images)
+      description: URL of the doop-image-checker service. Required when vulnerable-images is enabled.
+      required: false
+      type: string
+    - name: policies.vulnerableImages.vulnStatusHeader
+      displayName: Vulnerability status header
+      description: Name of the HTTP response header from doop-image-checker that carries the vulnerability status. Required when vulnerable-images is enabled.
       required: false
       type: string

--- a/gatekeeper-config/plugindefinition.yaml
+++ b/gatekeeper-config/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: gatekeeper-config
 spec:
-  version: 0.4.0
+  version: 0.4.1
   displayName: Gatekeeper Config
   description: |
     Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes
@@ -17,7 +17,7 @@ spec:
   helmChart:
     name: gatekeeper-config
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.0
+    version: 0.4.1
   options:
     - name: policies.highCpuRequests.enabled
       displayName: High CPU requests policy enabled


### PR DESCRIPTION
## Pull Request Details

Add doop-dependent policies as the final batch of the `gatekeeper-config` migration. All four require services shipped by the `gatekeeper-doop` PluginDefinition (helm-manifest-parser, doop-image-checker) and default to disabled.

**Differences vs upstream:**

| Policy | Upstream | This PR |
|---|---|---|
| `deprecated-api-version` | `apiVersions` and `kubernetesVersion` hardcoded in the chart. | Both are Constraint parameters. `helmManifestParserURL` also parameterized. |
| `oli-labels-required` | `owner-info-on-helm-releases`: enforced legacy owner-info labels via inline Rego. | Renamed; validates the OLI-injected `greenhouse.sap/owned-by` label on Helm release Secrets (matched via `owner: helm`) using helm-manifest-parser. `knownExceptions` list for temporary exemptions. |
| `outdated-image-bases` | Layer age threshold hardcoded. | `doopImageCheckerURL` and `maxAgeDays` are Constraint parameters; complains when the oldest layer is older than `maxAgeDays` (default 365). |
| `vulnerable-images` | Single constraint on Pods. | Two constraints (`vulnerable-images-on-pod` and `vulnerable-images-on-pod-owner`) share one template; reporting level chosen via the `reportingLevel` parameter. |

## Breaking Changes

None.

## Issues Fixed

- Partial progress on [#1420](https://github.com/cloudoperators/greenhouse-extensions/issues/1420)

## Other Relevant Information

Depends on the `gatekeeper-doop` PluginDefinition (separate PR) for the required services. All four policies default to disabled so the chart can be installed safely without doop.