### PR TITLE
fix(audit-logs): parameterize auditd init container image

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -84,6 +84,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
 | auditLogs.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
 | auditLogs.logsCollector.auditd.enabled | bool | `true` | Activates the ingestion of auditd logs. |
+| auditLogs.logsCollector.auditd.initImage | object | `{"repository":"alpine","tag":"latest"}` | Init container image used to stop the host auditd service. |
 | auditLogs.logsCollector.containerd.enabled | bool | `false` | Activates ingestion of container stdout/stderr logs from /var/log/pods |
 | auditLogs.logsCollector.enabled | bool | `true` | Activates the standard configuration for Logs. |
 | auditLogs.logsCollector.journald.enabled | bool | `false` | Activates ingestion of systemd journal logs |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.1.3
+version: 0.1.4
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/_auditd-config.tpl
+++ b/audit-logs/charts/templates/_auditd-config.tpl
@@ -1,7 +1,7 @@
 {{- define "auditd.initContainer" }}
 initContainers:
 - name: init
-  image: alpine:latest
+  image: "{{ .Values.auditLogs.logsCollector.auditd.initImage.repository }}:{{ .Values.auditLogs.logsCollector.auditd.initImage.tag }}"
   securityContext:
     privileged: true
   command:

--- a/audit-logs/charts/templates/secret.yaml
+++ b/audit-logs/charts/templates/secret.yaml
@@ -12,10 +12,10 @@ metadata:
   {{ toYaml .Values.auditLogs.customLabels | nindent 4 }}
   {{- end }}
 data:
-   failover_username_a: {{ .Values.auditLogs.openSearchLogs.failover_username_a | b64enc }}
-   failover_password_a: {{ .Values.auditLogs.openSearchLogs.failover_password_a | b64enc }}
+   failover_username_a: {{ .Values.auditLogs.openSearchLogs.failover_username_a | default "" | b64enc }}
+   failover_password_a: {{ .Values.auditLogs.openSearchLogs.failover_password_a | default "" | b64enc }}
 {{- if .Values.auditLogs.openSearchLogs.failover.enabled }}
-   failover_username_b: {{ .Values.auditLogs.openSearchLogs.failover_username_b | b64enc }}
-   failover_password_b: {{ .Values.auditLogs.openSearchLogs.failover_password_b | b64enc }}
+   failover_username_b: {{ .Values.auditLogs.openSearchLogs.failover_username_b | default "" | b64enc }}
+   failover_password_b: {{ .Values.auditLogs.openSearchLogs.failover_password_b | default "" | b64enc }}
 {{ end }}
 {{- end }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -29,6 +29,10 @@ auditLogs:
     auditd:
       # -- Activates the ingestion of auditd logs.
       enabled: true
+      # -- Init container image used to stop the host auditd service.
+      initImage:
+        repository: alpine
+        tag: latest
     kubeApiAudit:
       # -- Activates export for kube-apiserver audit logs
       enabled: false

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.1.3
+    version: 0.1.4
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.3
+        version: 0.1.4
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
The auditd init container hardcodes `alpine:latest`, which is denied on clusters that restrict images to an internal registry mirror.

- `_auditd-config.tpl`: init image driven by `auditLogs.logsCollector.auditd.initImage.{repository,tag}` (defaults to `alpine:latest`).
- `secret.yaml`: `b64enc` now guards against nil failover creds so `helm template` works on defaults.

Chart 0.1.3 → 0.1.4.