### PR TITLE
feat(logs): make syslog TLS certificate issuer kind and group configurable

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -97,7 +97,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | Image repository for OpenTelemetry Collector |
 | openTelemetry.collectorImage.tag | string | `"a8981ba"` | Image tag for OpenTelemetry Collector |
 | openTelemetry.customLabels | object | `{}` | custom Labels applied to servicemonitor, secrets and collectors |
-| openTelemetry.externalCollector | object | `{"calicoLoadBalancerIP":false,"enabled":false,"externalConfig":{"alertmanager_port":1515,"deployments_port":1516,"enabled":false},"externalIP":null,"externalTrafficPolicy":"Local","kafkaTopic":"","kafkaTracesTopic":"","replicas":2,"serviceAnnotations":{},"serviceType":"LoadBalancer","syslogConfig":{"enabled":false,"tcp_port":514,"udp_port":514},"syslogTLSConfig":{"dnsName":null,"enabled":false,"issuerName":null,"tcp_port":6514},"tracesConfig":{"enabled":false,"otlp_grpc_port":4317,"otlp_http_port":4318}}` | Standalone external OTel Collector as StatefulSet. |
+| openTelemetry.externalCollector | object | `{"calicoLoadBalancerIP":false,"enabled":false,"externalConfig":{"alertmanager_port":1515,"deployments_port":1516,"enabled":false},"externalIP":null,"externalTrafficPolicy":"Local","kafkaTopic":"","kafkaTracesTopic":"","replicas":2,"serviceAnnotations":{},"serviceType":"LoadBalancer","syslogConfig":{"enabled":false,"tcp_port":514,"udp_port":514},"syslogTLSConfig":{"dnsName":null,"enabled":false,"issuerGroup":"cert-manager.io","issuerKind":"ClusterIssuer","issuerName":null,"tcp_port":6514},"tracesConfig":{"enabled":false,"otlp_grpc_port":4317,"otlp_http_port":4318}}` | Standalone external OTel Collector as StatefulSet. |
 | openTelemetry.externalCollector.calicoLoadBalancerIP | bool | `false` | Enable Calico projectcalico.org/loadBalancerIPs annotation for the external IP |
 | openTelemetry.externalCollector.enabled | bool | `false` | Enables the standalone external OTel Collector StatefulSet and its PodMonitor. |
 | openTelemetry.externalCollector.externalConfig | object | `{"alertmanager_port":1515,"deployments_port":1516,"enabled":false}` | Activates the external alertmanager webhook and deployment event receivers. |
@@ -113,9 +113,11 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.externalCollector.syslogConfig | object | `{"enabled":false,"tcp_port":514,"udp_port":514}` | Activates syslog TCP/UDP ingestion (rfc5424/rfc3164). |
 | openTelemetry.externalCollector.syslogConfig.tcp_port | int | `514` | TCP port for syslog (rfc5424) |
 | openTelemetry.externalCollector.syslogConfig.udp_port | int | `514` | UDP port for syslog (rfc3164) |
-| openTelemetry.externalCollector.syslogTLSConfig | object | `{"dnsName":null,"enabled":false,"issuerName":null,"tcp_port":6514}` | Activates syslog TCP with TLS ingestion (rfc5424). |
+| openTelemetry.externalCollector.syslogTLSConfig | object | `{"dnsName":null,"enabled":false,"issuerGroup":"cert-manager.io","issuerKind":"ClusterIssuer","issuerName":null,"tcp_port":6514}` | Activates syslog TCP with TLS ingestion (rfc5424). |
 | openTelemetry.externalCollector.syslogTLSConfig.dnsName | string | `nil` | DNS name for the TLS certificate |
-| openTelemetry.externalCollector.syslogTLSConfig.issuerName | string | `nil` | cert-manager ClusterIssuer name for DigiCert |
+| openTelemetry.externalCollector.syslogTLSConfig.issuerGroup | string | `"cert-manager.io"` | cert-manager issuer group (e.g. cert-manager.io or certmanager.cloud.sap) |
+| openTelemetry.externalCollector.syslogTLSConfig.issuerKind | string | `"ClusterIssuer"` | cert-manager issuer kind (Issuer or ClusterIssuer) |
+| openTelemetry.externalCollector.syslogTLSConfig.issuerName | string | `nil` | cert-manager Issuer or ClusterIssuer name for TLS certificate |
 | openTelemetry.externalCollector.syslogTLSConfig.tcp_port | int | `6514` | TCP port for TLS syslog (rfc5424) |
 | openTelemetry.externalCollector.tracesConfig | object | `{"enabled":false,"otlp_grpc_port":4317,"otlp_http_port":4318}` | Activates OTLP traces ingestion (gRPC and HTTP). |
 | openTelemetry.externalCollector.tracesConfig.otlp_grpc_port | int | `4317` | gRPC port for OTLP traces |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.2
+version: 0.4.3
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/syslog-tls-certificate.yaml
+++ b/logs/charts/templates/syslog-tls-certificate.yaml
@@ -15,6 +15,6 @@ spec:
     - {{ required "openTelemetry.externalCollector.syslogTLSConfig.dnsName is required when syslogTLSConfig.enabled=true" .Values.openTelemetry.externalCollector.syslogTLSConfig.dnsName }}
   issuerRef:
     name: {{ required "openTelemetry.externalCollector.syslogTLSConfig.issuerName is required when syslogTLSConfig.enabled=true" .Values.openTelemetry.externalCollector.syslogTLSConfig.issuerName }}
-    kind: ClusterIssuer
-    group: cert-manager.io
+    kind: {{ .Values.openTelemetry.externalCollector.syslogTLSConfig.issuerKind | default "ClusterIssuer" }}
+    group: {{ .Values.openTelemetry.externalCollector.syslogTLSConfig.issuerGroup | default "cert-manager.io" }}
 {{- end }}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -140,8 +140,12 @@ openTelemetry:
       enabled: false
       # -- TCP port for TLS syslog (rfc5424)
       tcp_port: 6514
-      # -- cert-manager ClusterIssuer name for DigiCert
+      # -- cert-manager Issuer or ClusterIssuer name for TLS certificate
       issuerName:
+      # -- cert-manager issuer kind (Issuer or ClusterIssuer)
+      issuerKind: ClusterIssuer
+      # -- cert-manager issuer group (e.g. cert-manager.io or certmanager.cloud.sap)
+      issuerGroup: cert-manager.io
       # -- DNS name for the TLS certificate
       dnsName:
     # -- Activates the external alertmanager webhook and deployment event receivers.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.2
+  version: 0.15.3
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.2
+    version: 0.4.3
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary
- Make the cert-manager `issuerKind` and `issuerGroup` fields configurable in the syslog TLS certificate template, instead of hardcoding `ClusterIssuer` and `cert-manager.io`
- Adds support for alternative issuer types (e.g., `Issuer`) and groups (e.g., `certmanager.cloud.sap`)
- Bumps plugin version to `0.15.3` and helm chart version to `0.4.3`