### PR TITLE
chore(repo-guard): bump to 5.1.1

### DIFF
--- a/repo-guard/plugindefinition.yaml
+++ b/repo-guard/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: ClusterPluginDefinition
 metadata:
   name: repo-guard
 spec:
-  version: "5.0.0"
+  version: "5.1.1"
   displayName: Repo Guard
   description: Repo Guard automates GitHub organization management using Kubernetes Custom Resources (CRDs)
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/repo-guard/refs/heads/main/README.md
   helmChart:
     name: repo-guard
     repository: oci://ghcr.io/cloudoperators/charts
-    version: 5.0.0
+    version: 5.1.1
   options:
     - name: manager
       description: Manager configuration


### PR DESCRIPTION
## Summary
- Bumps `spec.version` and `helmChart.version` to `5.1.1` in `repo-guard/plugindefinition.yaml`