### PR TITLE
feat(logs): add TLS support for Kafka exporters

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -140,12 +140,14 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.ingesterCollector.prometheus.podMonitor.enabled | bool | `true` | Render a PodMonitor per enabled ingest collector. |
 | openTelemetry.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
 | openTelemetry.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
-| openTelemetry.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","protocol_version":""}` | Kafka exporter configuration shared by all collectors |
+| openTelemetry.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","protocol_version":"","tls":{"enabled":false}}` | Kafka exporter configuration shared by all collectors |
 | openTelemetry.kafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
 | openTelemetry.kafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
 | openTelemetry.kafka.enabled | bool | `false` | Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering) |
 | openTelemetry.kafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw) |
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
+| openTelemetry.kafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
+| openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.cephConfig | object | `{"enabled":false}` | Activates the configuration for Ceph logs (requires logsCollector to be enabled). |
 | openTelemetry.logsCollector.containerdConfig | object | `{"enabled":true}` | Activates the containerd file log receiver (requires logsCollector to be enabled). |
 | openTelemetry.logsCollector.enabled | bool | `true` | Activates the standard configuration for Logs. |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.5
+version: 0.4.6
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -309,6 +309,10 @@ kafka/syslog_audit:
     encoding: {{ .Values.openTelemetry.kafka.encoding }}
   producer:
     compression: {{ .Values.openTelemetry.kafka.compression }}
+{{- if .Values.openTelemetry.kafka.tls.enabled }}
+  tls:
+    insecure: false
+{{- end }}
 kafka/syslog_non_audit:
   brokers:
 {{- range .Values.openTelemetry.kafka.brokers }}
@@ -320,6 +324,10 @@ kafka/syslog_non_audit:
     encoding: {{ .Values.openTelemetry.kafka.encoding }}
   producer:
     compression: {{ .Values.openTelemetry.kafka.compression }}
+{{- if .Values.openTelemetry.kafka.tls.enabled }}
+  tls:
+    insecure: false
+{{- end }}
 {{- end }}
 {{- end }}
 

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -153,6 +153,10 @@ spec:
           encoding: {{ .Values.openTelemetry.kafka.encoding }}
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
+{{- if .Values.openTelemetry.kafka.tls.enabled }}
+        tls:
+          insecure: false
+{{- end }}
 {{- if .Values.openTelemetry.externalCollector.tracesConfig.enabled }}
       kafka/traces:
         brokers:
@@ -165,6 +169,10 @@ spec:
           encoding: {{ .Values.openTelemetry.kafka.encoding }}
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
+{{- if .Values.openTelemetry.kafka.tls.enabled }}
+        tls:
+          insecure: false
+{{- end }}
 {{- end }}
 {{- end }}
 {{- if .Values.openTelemetry.externalCollector.externalConfig.enabled }}

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -62,7 +62,7 @@ spec:
           - {{ . }}
 {{- end }}
         protocol_version: {{ $kafka.protocol_version }}
-{{- if (default false (dig "tls" "enabled" false $kafka)) }}
+{{- if or (default false (dig "tls" "enabled" false $kafka)) $root.Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
 {{- end }}

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -62,6 +62,10 @@ spec:
           - {{ . }}
 {{- end }}
         protocol_version: {{ $kafka.protocol_version }}
+{{- if (default false (dig "tls" "enabled" false $kafka)) }}
+        tls:
+          insecure: false
+{{- end }}
         logs:
           topics:
             - {{ $cfg.topic | quote }}

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -244,6 +244,10 @@ spec:
           encoding: {{ .Values.openTelemetry.kafka.encoding }}
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
+{{- if .Values.openTelemetry.kafka.tls.enabled }}
+        tls:
+          insecure: false
+{{- end }}
       kafka/storage:
         brokers:
 {{- range .Values.openTelemetry.kafka.brokers }}
@@ -255,6 +259,10 @@ spec:
           encoding: {{ .Values.openTelemetry.kafka.encoding }}
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
+{{- if .Values.openTelemetry.kafka.tls.enabled }}
+        tls:
+          insecure: false
+{{- end }}
 {{- else }}
       opensearch/failover_a:
         http:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -83,6 +83,10 @@ openTelemetry:
     encoding: ""
     # -- Compression type (none, gzip, snappy, lz4, zstd)
     compression: ""
+    # -- TLS configuration for Kafka connections
+    tls:
+      # -- Enable TLS for Kafka connections
+      enabled: false
   logsCollector:
     # -- Activates the standard configuration for Logs.
     enabled: true

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.5
+  version: 0.15.6
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.5
+    version: 0.4.6
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

- Add `tls: { insecure: false }` rendering to all Kafka exporter/receiver sections when `openTelemetry.kafka.tls.enabled` is true
- Add `openTelemetry.kafka.tls.enabled` (default: `false`) to `values.yaml` for backward compatibility
- Bump chart version `0.4.5` → `0.4.6` and plugindefinition version `0.15.5` → `0.15.6`

## Context

The logs chart accepts `openTelemetry.kafka.tls.enabled` as a plugin option value but never rendered it into the OTel collector's Kafka exporter config. Existing clusters worked because the Kafka external LoadBalancer terminates TLS at the LB level, so clients could speak plaintext. From cluster networks, TLS is not terminated at the LB, causing the Kafka client to fail with:

```
invalid large response size; the first three bytes received appear to be a tls alert record for TLS v1.2; is this a plaintext connection speaking to a tls endpoint?
```

## Changes

Templates updated:
- `logs-collector.yaml` — `kafka` and `kafka/storage` exporters
- `external-collector.yaml` — `kafka` and `kafka/traces` exporters
- `_syslog-audit-filter-config.tpl` — `kafka/syslog_audit` and `kafka/syslog_non_audit` exporters
- `ingester-collector.yaml` — `kafka` receiver

