### PR TITLE
fix(logs): rename bare 'log' attribute to prevent OpenSearch mapping conflict

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.6
+version: 0.4.7
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -96,6 +96,13 @@ spec:
         send_batch_max_size: 5000
         timeout: 30s
         send_batch_size: 100
+      transform/fix_log_attribute:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(attributes["log_message"], attributes["log"]) where attributes["log"] != nil
+              - delete_key(attributes, "log") where attributes["log"] != nil
       attributes/cluster:
         actions:
           - action: insert
@@ -419,7 +426,7 @@ spec:
       pipelines:
         logs/route_default:
           receivers: [routing]
-          processors: [batch]
+          processors: [transform/fix_log_attribute, batch]
 {{- if .Values.openTelemetry.kafka.enabled }}
           exporters: [kafka]
 {{- else }}
@@ -435,7 +442,7 @@ spec:
 {{- end }}
         logs/route_cronus:
           receivers: [routing]
-          processors: [batch]
+          processors: [transform/fix_log_attribute, batch]
 {{- if .Values.openTelemetry.kafka.enabled }}
           exporters: [kafka]
 {{- else }}
@@ -469,7 +476,7 @@ spec:
 {{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled }}
         logs/route_storage:
           receivers: [routing]
-          processors: [batch]
+          processors: [transform/fix_log_attribute, batch]
 {{- if .Values.openTelemetry.kafka.enabled }}
           exporters: [kafka/storage]
 {{- else }}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.6
+  version: 0.15.7
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.6
+    version: 0.4.7
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

- Adds `transform/fix_log_attribute` processor to the daemonset logs-collector to rename any bare `log` attribute to `log_message`
- Prevents `mapper_parsing_exception` errors in OpenSearch caused by a field type conflict between `attributes.log` (object with sub-fields like `log.file.name`, `log.iostream`) and a bare `log` string value from some log sources

## Problem

Some log records arrive with a flat `attributes.log = "some string"` which conflicts with the existing `attributes.log` object mapping in OpenSearch (containing `log.file.name`, `log.file.path`, `log.iostream`, `log.type`). This causes:

```
mapper_parsing_exception: object mapping for [attributes.log] tried to parse field [log] as object, but found a concrete value
```

The error rejects entire batches (~143 records per batch), causing data loss across all ingestion pipelines.

## Fix

A `transform/fix_log_attribute` processor is added to all route pipelines (`route_default`, `route_cronus`, `route_storage`) in the daemonset collector. This renames the bare `log` attribute to `log_message` at the source before it enters Kafka, ensuring all downstream consumers receive clean data.
