### PR TITLE
chore(repo-guard): bump to 5.2.0

### DIFF
--- a/repo-guard/plugindefinition.yaml
+++ b/repo-guard/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: ClusterPluginDefinition
 metadata:
   name: repo-guard
 spec:
-  version: "5.1.1"
+  version: "5.2.0"
   displayName: Repo Guard
   description: Repo Guard automates GitHub organization management using Kubernetes Custom Resources (CRDs)
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/repo-guard/refs/heads/main/README.md
   helmChart:
     name: repo-guard
     repository: oci://ghcr.io/cloudoperators/charts
-    version: 5.1.1
+    version: 5.2.0
   options:
     - name: manager
       description: Manager configuration


### PR DESCRIPTION
## Summary
- Bumps repo-guard version from `5.1.1` to `5.2.0` in `plugindefinition.yaml`

## Test plan
- [ ] Verify `spec.version` and `helmChart.version` are both set to `5.2.0`
- [ ] Confirm OCI chart `ghcr.io/cloudoperators/charts/repo-guard:5.2.0` exists and is accessible