### PR TITLE
fix(logs): rename coredns time attribute to avoid OpenSearch date mapping conflict

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.7
+version: 0.4.8
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_openstack-config.tpl
+++ b/logs/charts/templates/_openstack-config.tpl
@@ -112,7 +112,7 @@ transform/coredns_api:
       statements:
         - merge_maps(log.cache, ParseJSON(log.body), "upsert") where IsMatch(log.body, "^\\{")
         - set(log.attributes["log.level"], log.cache["level"])
-        - set(log.attributes["time"], log.cache["time"])
+        - set(log.attributes["coredns.time"], log.cache["time"])
         - set(log.attributes["request.id"], log.cache["request-id"])
         - set(log.attributes["duration"], log.cache["duration"])
         - set(log.attributes["component"], log.cache["component"])

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.7
+  version: 0.15.8
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.7
+    version: 0.4.8
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

- Renames `attributes.time` to `attributes.coredns.time` in the `transform/coredns_api` processor to avoid OpenSearch `mapper_parsing_exception` errors.

## Problem

The coreDNS API transform sets `log.attributes["time"]` to a relative duration value (e.g. `5.839760296Z`) from coreDNS JSON logs. OpenSearch maps the `attributes.time` field as type `date` with format `strict_date_optional_time||epoch_millis`. This value is not a valid date, causing permanent bulk rejection errors in the ingester:

```
mapper_parsing_exception: failed to parse field [attributes.time] of type [date].
Preview of field's value: '5.839760296Z'
```

Since the failover connector treats this as a non-retryable error, it blocks **all** logs in the same batch from being ingested, effectively stopping the entire logging pipeline.

## Fix

Rename the attribute from `time` to `coredns.time` to avoid conflicting with OpenSearch's date mapping.