### PR TITLE
feat(opensearch): enable opensearch operator metrics

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -241,6 +241,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | operator.manager.livenessProbe.successThreshold | int | `1` |  |
 | operator.manager.livenessProbe.timeoutSeconds | int | `3` |  |
 | operator.manager.loglevel | string | `"debug"` |  |
+| operator.manager.metricsBindAddress | string | `"127.0.0.1:8080"` |  |
 | operator.manager.parallelRecoveryEnabled | bool | `true` |  |
 | operator.manager.pprofEndpointsEnabled | bool | `false` |  |
 | operator.manager.readinessProbe.failureThreshold | int | `3` |  |
@@ -256,7 +257,6 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | operator.manager.resources.requests.memory | string | `"350Mi"` |  |
 | operator.manager.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | operator.manager.watchNamespace | string | `nil` |  |
-| operator.manager.metricsBindAddress | string | `"127.0.0.1:8080"` | Address on which operator metrics should be exposed. The only acceptable value other then default is `:8443`. |
 | operator.nameOverride | string | `""` |  |
 | operator.namespace | string | `""` |  |
 | operator.nodeSelector | object | `{}` |  |

--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -256,6 +256,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | operator.manager.resources.requests.memory | string | `"350Mi"` |  |
 | operator.manager.securityContext.allowPrivilegeEscalation | bool | `false` |  |
 | operator.manager.watchNamespace | string | `nil` |  |
+| operator.manager.metricsBindAddress | string | `"127.0.0.1:8080"` | Address on which operator metrics should be exposed. The only acceptable value other then default is `:8443`. |
 | operator.nameOverride | string | `""` |  |
 | operator.namespace | string | `""` |  |
 | operator.nodeSelector | object | `{}` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.11
+version: 0.2.12
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -5,9 +5,9 @@ groups:
     rules:
       - alert: OpenSearchClusterRed
         expr: |
-          (sum by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
           /
-          (count by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
           == 2
         for: 5m
         labels:
@@ -15,14 +15,14 @@ groups:
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterRed.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          summary: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is RED"
-          description: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is in RED status for more than 5 minutes"
+          summary: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is RED"
+          description: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is in RED status for more than 5 minutes"
 
       - alert: OpenSearchClusterYellow
         expr: |
-          (sum by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
           /
-          (count by (opster_io_opensearch_cluster) (opensearch_cluster_status))
+          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
           == 1
         for: 120m
         labels:
@@ -30,8 +30,8 @@ groups:
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterYellow.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          summary: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is YELLOW"
-          description: "OpenSearch cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
+          summary: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is YELLOW"
+          description: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
 
       - alert: OpenSearchDiskSpaceRunningLow
         expr: predict_linear(opensearch_fs_total_free_bytes[24h], 24*3600) < 0
@@ -42,10 +42,10 @@ groups:
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
           summary: "OpenSearch disk space predicted to run out"
-          description: "OpenSearch node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} is predicted to run out of disk space within 24 hours"
+          description: "OpenSearch node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is predicted to run out of disk space within 24 hours"
 
       - alert: OpenSearchIndexSizeTooLarge
-        expr: (max by (opster_io_opensearch_cluster, index) (opensearch_index_store_size_bytes{context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opster_io_opensearch_cluster, index) (rate(opensearch_index_doc_number{context="primaries", index=~".ds.*"}[15m]) > 1)
+        expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{context="primaries", index=~".ds.*"}[15m]) > 1)
         for: 30m
         labels:
           severity: info # warning
@@ -53,4 +53,4 @@ groups:
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
           summary: "Index size of {{`{{ $labels.index }}`}} has exceeded the threshold."
-          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opster_io_opensearch_cluster }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."
+          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."

--- a/opensearch/chart/alerts/opensearch-guardian.yaml
+++ b/opensearch/chart/alerts/opensearch-guardian.yaml
@@ -2,47 +2,47 @@ groups:
   - name: opensearch-guardian
     interval: 30s
     rules:
-    - alert: OpenSearchGuardianNoncompliant
-      expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="noncompliant"} > 0
-      for: 10m
-      labels:
-        severity: info # critical
-        component: opensearch-guardian
-        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianNoncompliant.md
-        {{- include "opensearch-alert-labels" . | nindent 10 }}
-      annotations:
-        summary: "OpenSearch is NONCOMPLIANT"
-        description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has been NONCOMPLIANT for more than 10 minutes"
-    - alert: OpenSearchGuardianEmpty
-      expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="empty"} > 0
-      for: 10m
-      labels:
-        severity: info # critical
-        component: opensearch-guardian
-        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianEmpty.md
-        {{- include "opensearch-alert-labels" . | nindent 10 }}
-      annotations:
-        summary: "OpenSearch has empty Guardian status"
-        description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has empty Guardian status for more than 10 minutes"
-    - alert: OpenSearchGuardianErrors                                                                                                                                            
-      expr: increase(opensearch_guardian_errors_total{cluster="{{ .Values.cluster.cluster.name }}"}[10m]) > 0                                                                    
-      for: 0m                                                                                                                                                                    
-      labels:                                                                                                                                                                    
-        severity: info # critical                                                                                                                                                           
-        component: opensearch-guardian                                                                                                                                           
-        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianErrors.md                                                                                                                                                         
-        {{- include "opensearch-alert-labels" . | nindent 10 }}                                                                                                                  
-      annotations:                                                                                                                                                               
-        summary: "OpenSearch Guardian errors detected"                                                                                                                           
-        description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} reported Guardian errors in the last 10 minutes"
-    - alert: OpenSearchGuardianStatusStale                                                                                                                                            
-      expr: (time() - opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
-      for: 0m                                                                                                                                                                    
-      labels:                                                                                                                                                                    
-        severity: info # critical                                                                                                                                                           
-        component: opensearch-guardian                                                                                                                                           
-        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianStatusStale.md                                                                                                                                                         
-        {{- include "opensearch-alert-labels" . | nindent 10 }}                                                                                                                  
-      annotations:                                                                                                                                                               
-        summary: "OpenSearch Guardian status is stale"                                                                                                                           
-        description: "OpenSearch Guardian in namespace {{`{{ $labels.namespace }}`}} has not refreshed status for more than 7 minutes" 
+      - alert: OpenSearchGuardianNoncompliant
+        expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="noncompliant"} > 0
+        for: 10m
+        labels:
+          severity: info # critical
+          component: opensearch-guardian
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianNoncompliant.md
+          {{- include "opensearch-alert-labels" . | nindent 10 }}
+        annotations:
+          summary: "OpenSearch is NONCOMPLIANT"
+          description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has been NONCOMPLIANT for more than 10 minutes"
+      - alert: OpenSearchGuardianEmpty
+        expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="empty"} > 0
+        for: 10m
+        labels:
+          severity: info # critical
+          component: opensearch-guardian
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianEmpty.md
+          {{- include "opensearch-alert-labels" . | nindent 10 }}
+        annotations:
+          summary: "OpenSearch has empty Guardian status"
+          description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has empty Guardian status for more than 10 minutes"
+      - alert: OpenSearchGuardianErrors                                                                                                                                            
+        expr: increase(opensearch_guardian_errors_total{cluster="{{ .Values.cluster.cluster.name }}"}[10m]) > 0                                                                    
+        for: 0m                                                                                                                                                                    
+        labels:                                                                                                                                                                    
+          severity: info # critical                                                                                                                                                           
+          component: opensearch-guardian                                                                                                                                           
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianErrors.md                                                                                                                                                         
+          {{- include "opensearch-alert-labels" . | nindent 10 }}                                                                                                                  
+        annotations:                                                                                                                                                               
+          summary: "OpenSearch Guardian errors detected"                                                                                                                           
+          description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} reported Guardian errors in the last 10 minutes"
+      - alert: OpenSearchGuardianStatusStale                                                                                                                                            
+        expr: (time() - opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
+        for: 0m                                                                                                                                                                    
+        labels:                                                                                                                                                                    
+          severity: info # critical                                                                                                                                                           
+          component: opensearch-guardian                                                                                                                                           
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianStatusStale.md                                                                                                                                                         
+          {{- include "opensearch-alert-labels" . | nindent 10 }}                                                                                                                  
+        annotations:                                                                                                                                                               
+          summary: "OpenSearch Guardian status is stale"                                                                                                                           
+          description: "OpenSearch Guardian in namespace {{`{{ $labels.namespace }}`}} has not refreshed status for more than 7 minutes" 

--- a/opensearch/chart/alerts/opensearch-guardian.yaml
+++ b/opensearch/chart/alerts/opensearch-guardian.yaml
@@ -1,0 +1,48 @@
+groups:
+  - name: opensearch-guardian
+    interval: 30s
+    rules:
+    - alert: OpenSearchGuardianNoncompliant
+      expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="noncompliant"} > 0
+      for: 10m
+      labels:
+        severity: info # critical
+        component: opensearch-guardian
+        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianNoncompliant.md
+        {{- include "opensearch-alert-labels" . | nindent 10 }}
+      annotations:
+        summary: "OpenSearch is NONCOMPLIANT"
+        description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has been NONCOMPLIANT for more than 10 minutes"
+    - alert: OpenSearchGuardianEmpty
+      expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="empty"} > 0
+      for: 10m
+      labels:
+        severity: info # critical
+        component: opensearch-guardian
+        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianEmpty.md
+        {{- include "opensearch-alert-labels" . | nindent 10 }}
+      annotations:
+        summary: "OpenSearch has empty Guardian status"
+        description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has empty Guardian status for more than 10 minutes"
+    - alert: OpenSearchGuardianErrors                                                                                                                                            
+      expr: increase(opensearch_guardian_errors_total{cluster="{{ .Values.cluster.cluster.name }}"}[10m]) > 0                                                                    
+      for: 0m                                                                                                                                                                    
+      labels:                                                                                                                                                                    
+        severity: info # critical                                                                                                                                                           
+        component: opensearch-guardian                                                                                                                                           
+        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianErrors.md                                                                                                                                                         
+        {{- include "opensearch-alert-labels" . | nindent 10 }}                                                                                                                  
+      annotations:                                                                                                                                                               
+        summary: "OpenSearch Guardian errors detected"                                                                                                                           
+        description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} reported Guardian errors in the last 10 minutes"
+    - alert: OpenSearchGuardianStatusStale                                                                                                                                            
+      expr: (time() - opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
+      for: 0m                                                                                                                                                                    
+      labels:                                                                                                                                                                    
+        severity: info # critical                                                                                                                                                           
+        component: opensearch-guardian                                                                                                                                           
+        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianStatusStale.md                                                                                                                                                         
+        {{- include "opensearch-alert-labels" . | nindent 10 }}                                                                                                                  
+      annotations:                                                                                                                                                               
+        summary: "OpenSearch Guardian status is stale"                                                                                                                           
+        description: "OpenSearch Guardian in namespace {{`{{ $labels.namespace }}`}} has not refreshed status for more than 7 minutes" 

--- a/opensearch/chart/alerts/opensearch-operator.yaml
+++ b/opensearch/chart/alerts/opensearch-operator.yaml
@@ -1,4 +1,15 @@
 groups:
   - name: opensearch-operator
     interval: 30s
-    rules: []
+    rules:
+    - alert: OpenSearchOperatorDown
+      expr: up{job=~".*opensearch-operator.*"} == 0
+      for: 10m
+      labels:
+        severity: info # critical
+        component: opensearch-operator
+        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorDown.md
+        {{- include "opensearch-alert-labels" . | nindent 10 }}
+      annotations:
+        summary: "OpenSearch operator is down"
+        description: "OpenSearch operator in namespace {{`{{ $labels.namespace }}`}} has been down for more than 10 minutes"

--- a/opensearch/chart/alerts/opensearch-operator.yaml
+++ b/opensearch/chart/alerts/opensearch-operator.yaml
@@ -2,14 +2,14 @@ groups:
   - name: opensearch-operator
     interval: 30s
     rules:
-    - alert: OpenSearchOperatorDown
-      expr: up{job=~".*opensearch-operator.*"} == 0
-      for: 10m
-      labels:
-        severity: info # critical
-        component: opensearch-operator
-        playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorDown.md
-        {{- include "opensearch-alert-labels" . | nindent 10 }}
-      annotations:
-        summary: "OpenSearch operator is down"
-        description: "OpenSearch operator in namespace {{`{{ $labels.namespace }}`}} has been down for more than 10 minutes"
+      - alert: OpenSearchOperatorDown
+        expr: up{job=~".*opensearch-operator.*"} == 0
+        for: 10m
+        labels:
+          severity: info # critical
+          component: opensearch-operator
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchOperatorDown.md
+          {{- include "opensearch-alert-labels" . | nindent 10 }}
+        annotations:
+          summary: "OpenSearch operator is down"
+          description: "OpenSearch operator in namespace {{`{{ $labels.namespace }}`}} has been down for more than 10 minutes"

--- a/opensearch/chart/templates/_helpers.tpl
+++ b/opensearch/chart/templates/_helpers.tpl
@@ -17,3 +17,11 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{ . | toYaml }}
 {{- end -}}
 {{- end -}}
+
+{{- define "opensearch.guardianEnabled" -}}
+{{- range .Values.cluster.cluster.general.pluginList -}}
+  {{- if contains "guardian" . -}}
+    true
+  {{- end -}}
+{{- end -}}
+{{- end -}}

--- a/opensearch/chart/templates/_helpers.tpl
+++ b/opensearch/chart/templates/_helpers.tpl
@@ -19,7 +19,7 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
 
 {{- define "opensearch.guardianEnabled" -}}
-{{- range .Values.cluster.cluster.general.pluginList -}}
+{{- range .Values.cluster.cluster.general.pluginsList -}}
   {{- if contains "guardian" . -}}
     true
   {{- end -}}

--- a/opensearch/chart/templates/alerts.yaml
+++ b/opensearch/chart/templates/alerts.yaml
@@ -30,3 +30,18 @@ spec:
 {{ tpl (printf "%s" $bytes) $root | indent 2 }}
 {{- end }}
 {{- end }}
+{{- $guardianEnabled := include "opensearch.guardianEnabled" . -}}
+{{- if and .Values.cluster.cluster.general.monitoring.enable $guardianEnabled }}
+{{- range $path, $bytes := .Files.Glob "alerts/opensearch-guardian.yaml" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name ($path | trimSuffix ".yaml") | replace "/" "-" | trunc 63 }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" $ | nindent 4 }}
+spec:
+{{ tpl (printf "%s" $bytes) $root | indent 2 }}
+{{- end }}
+{{- end }}

--- a/opensearch/chart/templates/service-monitor-guardian.yaml
+++ b/opensearch/chart/templates/service-monitor-guardian.yaml
@@ -37,12 +37,6 @@ spec:
       {{- else }}
       insecureSkipVerify: true
       {{- end }}
-    metricRelabelings:
-      - sourceLabels: [__name__]
-        regex: "(.*)"
-        targetLabel: __name__
-        replacement: "opensearch_guardian_$1"
-        action: replace
   namespaceSelector:
     matchNames:
     - {{ .Release.Namespace }}

--- a/opensearch/chart/templates/service-monitor-guardian.yaml
+++ b/opensearch/chart/templates/service-monitor-guardian.yaml
@@ -1,10 +1,11 @@
-{{- if .Values.cluster.cluster.general.monitoring.enable }}
+{{- $guardianEnabled := include "opensearch.guardianEnabled" . -}}
+{{- if and .Values.cluster.cluster.general.monitoring.enable $guardianEnabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: {{ .Values.cluster.cluster.name | default .Release.Name }}-operator-metrics
+  name: {{ .Values.cluster.cluster.name | default .Release.Name }}-guardian-metrics
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "opensearch.labels" . | nindent 4 }}
@@ -13,14 +14,23 @@ metadata:
     {{- end }}
 spec:
   selector:
+    matchExpressions:
+    - key: opensearch.org/opensearch-nodepool
+      operator: Exists
     matchLabels:
-      app.kubernetes.io/name: operator
+      opensearch.org/opensearch-cluster: {{ .Values.cluster.cluster.name }}
   endpoints:
-  - port: https
-    path: /metrics
+  - basicAuth:
+      password:
+        key: password
+        name: {{ .Values.cluster.cluster.general.monitoring.monitoringUserSecret }}
+      username:
+        key: username
+        name: {{ .Values.cluster.cluster.general.monitoring.monitoringUserSecret }}
+    port: http
+    path: /_plugins/_guardian/metrics
     scheme: https
     interval: {{ .Values.cluster.cluster.general.monitoring.scrapeInterval | default "30s" }}
-    bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
     tlsConfig:
       {{- if .Values.cluster.cluster.general.monitoring.tlsConfig }}
       {{- toYaml .Values.cluster.cluster.general.monitoring.tlsConfig | nindent 6 }}
@@ -31,7 +41,7 @@ spec:
       - sourceLabels: [__name__]
         regex: "(.*)"
         targetLabel: __name__
-        replacement: "opensearch_operator_$1"
+        replacement: "opensearch_guardian_$1"
         action: replace
   namespaceSelector:
     matchNames:

--- a/opensearch/chart/templates/service-monitor-operator.yaml
+++ b/opensearch/chart/templates/service-monitor-operator.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.cluster.cluster.general.monitoring.enable }}
+{{- if and .Values.operator.enabled .Values.cluster.cluster.general.monitoring.enable (ne (.Values.operator.manager.metricsBindAddress | default "127.0.0.1:8080") "127.0.0.1:8080") }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 apiVersion: monitoring.coreos.com/v1
@@ -15,6 +15,7 @@ spec:
   selector:
     matchLabels:
       app.kubernetes.io/name: operator
+      app.kubernetes.io/instance: {{ .Release.Name }}
   endpoints:
   - port: https
     path: /metrics

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -120,9 +120,9 @@ operator:
     runAsNonRoot: true
   priorityClassName: ""
   manager:
-    # By default operator binds it's metrics to loopback IP
-    # To configure it on expose port use ":8443" - in order to make it work ClusterRole and ClusterRoleBinding
-    # needs to be created to allow prometheus scrape the /metrics endpoint
+    # By default the operator binds its metrics endpoint to the loopback interface.
+    # To expose metrics, set this to ":8443". When exposing metrics, Prometheus may need ClusterRole/ClusterRoleBinding
+    # to authenticate/authorize against the /metrics endpoint
     metricsBindAddress: "127.0.0.1:8080"
     securityContext:
       allowPrivilegeEscalation: false

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -122,7 +122,7 @@ operator:
   manager:
     # By default operator binds it's metrics to loopback IP
     # To configure it on expose port use ":8443" - in order to make it work ClusterRole and ClusterRoleBinding
-    # needs to be created to allow prometheus scrape the /metrics endpoint 
+    # needs to be created to allow prometheus scrape the /metrics endpoint
     metricsBindAddress: "127.0.0.1:8080"
     securityContext:
       allowPrivilegeEscalation: false

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -120,6 +120,10 @@ operator:
     runAsNonRoot: true
   priorityClassName: ""
   manager:
+    # By default operator binds it's metrics to loopback IP
+    # To configure it on expose port use ":8443" - in order to make it work ClusterRole and ClusterRoleBinding
+    # needs to be created to allow prometheus scrape the /metrics endpoint 
+    metricsBindAddress: "127.0.0.1:8080"
     securityContext:
       allowPrivilegeEscalation: false
     extraEnv: []

--- a/opensearch/playbooks/OpenSearchGuardianEmpty.md
+++ b/opensearch/playbooks/OpenSearchGuardianEmpty.md
@@ -1,0 +1,79 @@
+---
+title: OpenSearchGuardianEmpty
+weight: 20
+---
+
+# OpenSearchGuardianEmpty
+
+## Problem
+
+The OpenSearch Guardian plugin could not determine the compliance status — the status is empty/unknown.
+
+## Impact
+
+- Cluster compliance state is unknown.
+
+## Diagnosis
+
+**Step 1 — Check Guardian in OpenSearch Dashboards:**
+
+1. In the Greenhouse UI, go to **Organization** in the left menu, then **Plugins** > **opensearch \<cluster\>**.
+2. Under **External Links**, click on **opensearch-dashboards-external**. Log in if prompted.
+3. In the left side menu, find and click **Guardian**.
+4. On the **Status** tab, click **Refresh**. Note whether status is empty or shows an error.
+5. Check the **History** tab to see when the status last changed and if Guardian was previously working.
+6. Check the **Configuration** tab to confirm Guardian is configured correctly.
+
+**Step 2 — Check OpenSearch pod logs:**
+
+Log in to the target k8s cluster and inspect logs for Guardian-related errors:
+
+```bash
+kubectl -n fortlogs-audit logs -l ccloud/service=opensearch | grep -i guardian
+```
+
+Look for errors related to index mapping, status initialization, or datastream rollover failures.
+
+## Resolution Steps
+
+### 1. Cluster in RED state
+
+If logs or the dashboard show cluster health is RED, Guardian cannot write its status. Fix the cluster first.
+
+See playbook: [OpenSearchClusterRed](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterRed.md)
+
+### 2. Guardian index mapping conflict
+
+Guardian fails to update `.guardian-status` index due to mapping incompatibility. Symptoms in logs: mapping update errors or document rejection errors for `.guardian-status`.
+
+1. Delete the `.guardian-status` index via Dev Tools:
+
+   ```http
+   DELETE /.guardian-status
+   ```
+
+2. Restart one of the OpenSearch pods to trigger Guardian re-initialization:
+
+   ```bash
+   kubectl -n fortlogs-audit delete pod <opensearch-pod-name>
+   ```
+
+3. After pod restarts, go to Guardian in the dashboard and click **Refresh** — status should populate.
+
+### 3. Guardian status history datastream needs rollover
+
+If the `guardian-status-history` datastream is stale or causing write failures, trigger a rollover via Dev Tools:
+
+```http
+POST /guardian-status-history/_rollover
+```
+
+## Verify Resolution
+
+1. In Guardian, click **Refresh** on the **Status** tab.
+2. Confirm status is no longer empty — it should show either **compliant** or **noncompliant**.
+3. If **noncompliant**, follow the [OpenSearchGuardianNoncompliant](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianNoncompliant.md) playbook.
+
+## Contact Support
+
+If status remains empty after these steps, seek assistance from your operations team.

--- a/opensearch/playbooks/OpenSearchGuardianErrors.md
+++ b/opensearch/playbooks/OpenSearchGuardianErrors.md
@@ -1,0 +1,53 @@
+---
+title: OpenSearchGuardianErrors
+weight: 20
+---
+
+# OpenSearchGuardianErrors
+
+## Problem
+
+The OpenSearch Guardian plugin reported errors. The real compliance state of the cluster is unknown.
+
+## Impact
+
+- Ingestion to guarded datastreams may be blocked.
+- Compliance status cannot be trusted until errors are resolved.
+
+## Diagnosis
+
+**Step 1 — Check Guardian in OpenSearch Dashboards:**
+
+1. In the Greenhouse UI, go to **Organization** in the left menu, then **Plugins** > **opensearch \<cluster\>**.
+2. Under **External Links**, click on **opensearch-dashboards-external**. Log in if prompted.
+3. In the left side menu, find and click **Guardian**.
+4. On the **Status** tab, click **Refresh**. Note any errors shown.
+5. Check the **History** tab — if status recently changed to compliant, Guardian may have self-healed. Verify the timeline matches the alert.
+6. Check the **Configuration** tab to confirm Guardian configuration looks correct.
+
+**Step 2 — Check OpenSearch pod logs:**
+
+Log in to the target k8s cluster and look for Guardian errors:
+
+```bash
+kubectl -n fortlogs-audit logs -l ccloud/service=opensearch | grep -i guardian
+```
+
+## Resolution Steps
+
+The **Status** tab should indicate what error is present. Follow the relevant playbook based on what you find:
+
+- **Status is noncompliant** → follow [OpenSearchGuardianNoncompliant](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianNoncompliant.md)
+- **Status is empty** → follow [OpenSearchGuardianEmpty](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianEmpty.md)
+- **Status shows errors** → Verify Cluster is not in RED status. Verify if history checks are being triggered. Look in the pods logs for errors. Delete `.guardian-status` index if there is a problem with saving the current status. Rollover `guardian-status-history` if history docs cannot be saved. 
+- **Status is compliant and History shows recent self-heal** → no action needed, monitor for recurrence
+
+## Verify Resolution
+
+1. In Guardian, click **Refresh** on the **Status** tab.
+2. Confirm status is **compliant** and no errors are shown.
+3. Check the **History** tab to confirm the error is no longer recurring.
+
+## Contact Support
+
+If errors persist or the root cause is unclear, seek assistance from your operations team.

--- a/opensearch/playbooks/OpenSearchGuardianNoncompliant.md
+++ b/opensearch/playbooks/OpenSearchGuardianNoncompliant.md
@@ -1,0 +1,158 @@
+---
+title: OpenSearchGuardianNoncompliant
+weight: 20
+---
+
+# OpenSearchGuardianNoncompliant
+
+## Problem
+
+The OpenSearch Guardian plugin detected that the cluster is in a noncompliant state. Guardian enforces compliance criteria including audit log configuration, guarded datastream existence, index template settings, and forbidden permissions/role mappings.
+
+Compliance criteria — all must be satisfied:
+
+- Audit logs are enabled
+- All guarded datastreams exist
+- Each guarded datastream has an index template with at least 1 `replica` and `index.append_only.enabled: true`
+- No forbidden permissions exist
+- No forbidden role mappings exist
+
+## Impact
+
+**Ingestion to guarded datastreams is stopped while status is noncompliant.** Logs accumulate inside Kafka. Act quickly — if Kafka buffer fills up, messages will be dropped and lost.
+
+## Diagnosis
+
+1. Open OpenSearch Dashboards:
+   1. In the Greenhouse UI, go to **Organization** in the left menu, then **Plugins** > **opensearch \<cluster\>**.
+   2. Under **External Links**, click on **opensearch-dashboards-external**.
+   3. Log in if prompted.
+
+2. In the left side menu, find and click **Guardian**.
+
+3. On the **Status** tab, click **Refresh** to ensure the status is current. Review all listed violations.
+
+4. Check the **Configuration** tab to see:
+   - Which datastreams are guarded
+   - Which permissions and role mappings are forbidden
+
+5. Check the **History** tab to see when the status changed — this helps estimate how much log data is buffered in Kafka.
+
+## Resolution Steps
+
+Work through violations shown on the **Status** tab one by one.
+
+### 1. Audit logs not enabled
+
+Enable audit logging via Dev Tools:
+
+```json
+PUT _plugins/_security/api/audit/config
+{
+  "enabled": true
+}
+```
+- Or via UI: on the left side menu: Security > Audit logs (Enable audit logging: Enable)
+
+### 2. Index template missing or misconfigured
+
+Index templates are created from k8s CR (opensearchindextemplates.opensearch.org). If they are missing or are misconfigured most probably the k8s reconciliation is broken. Any changes to live cluster made via UI should be in quick manner overwritten by k8s OpenSearch Operator to match k8s state. To investigate follow below steps:
+
+1. Check configuration on the OpenSearch cluster. On OpenSearch Dashboard go to left side menu and go to IndexManagement > Templates. Look for: `audit-kafka-index-template`, `hermes-kafka-index-template`, `syslog-audit-kafka-index-template`. Confirm their configuration: look at `replicas` and `append_only` setting. If all is correct then look at the priority of the template. See if there is any index template with higher priority that matches index pattern.
+2. Check configuration on a k8s cluster. Log in to k8s cluster and run:
+    ```bash
+    kubectl -n fortlogs-audit get opensearchindextemplates.opensearch.org
+    ```
+    Inspect a specific template (look for `replicas` and `append_only`):
+    ```bash
+    kubectl -n fortlogs-audit get opensearchindextemplates.opensearch.org audit-kafka-index-template -o yaml
+    kubectl -n fortlogs-audit get opensearchindextemplates.opensearch.org hermes-kafka-index-template -o yaml
+    kubectl -n fortlogs-audit get opensearchindextemplates.opensearch.org syslog-audit-kafka-index-template -o yaml
+    ```
+3. Log in into greenhouse cluster to verify plugin and pluginpreset.
+    ```bash
+    kubectl get plugins | grep opensearch
+    kubectl get pluginpreset | grep opensearch
+    kubectl get plugin <plugin-name> -o yaml
+    kubectl get pluginpreset <pluginpreset-name> -o yaml
+    ```
+    If the plugin/pluginpreset status is not Ready - and the status of a CR is not helpful need to reach out to the Greenhouse Operation Team.
+
+**WORKAROUND**: Via OpenSearch Dashboard create a new index template as a duplicate of the wrong one - fix the issues and give higher priority. Guardian should pick up the new index template and not complain.
+
+### 3. Guarded datastream does not exist
+
+Create the missing datastream via Dev Tools:
+
+```http
+PUT _data_stream/<datastream-name>
+```
+
+Replace `<datastream-name>` with the name shown in the Guardian violation.
+
+### 4. Forbidden permissions exist
+
+On OpenSearch Dashboard go to left side menu and go to Security > Permissions. Find the problematic permission and delete. 
+
+### 5. Forbidden role mappings exist
+
+On OpenSearch Dashboard go to left side menu and go to Security > Roles. Find the problematic Role and see to which users it's mapped. Delete problematic mapping.
+
+### 6. Index in guarded datastream is not append_only
+
+This requires index deletion. **Before deleting, assess whether data loss is acceptable:**
+
+- **If data can be lost:** Delete the index directly:
+
+  ```http
+  DELETE /<index-name>
+  ```
+
+- **If data must be preserved — reindex first:**
+
+  1. Create a temporary index:
+
+     ```json
+     PUT <temp-index-name>
+     {
+       "settings": {
+         "number_of_replicas": 1
+       }
+     }
+     ```
+
+  2. Reindex data into the temporary index:
+
+     ```json
+     POST _reindex
+     {
+       "source": { "index": "<index-name>" },
+       "dest": { "index": "<temp-index-name>" }
+     }
+     ```
+
+  3. Verify document count matches:
+
+     ```http
+     GET <temp-index-name>/_count
+     GET <index-name>/_count
+     ```
+
+  4. Delete the original index:
+
+     ```http
+     DELETE /<index-name>
+     ```
+
+  5. If needed, reindex back into the datastream after compliance is restored.
+
+## Verify Resolution
+
+1. In Guardian, click **Refresh** on the **Status** tab.
+2. Confirm status changed to **compliant**.
+3. Verify ingestion resumes — check that logs are no longer accumulating in Kafka.
+4. Check the **History** tab to confirm the compliance state transition was recorded.
+
+## Contact Support
+
+If violations persist after following these steps, or if you are unsure whether it is safe to delete an index, seek assistance from your operations team before proceeding.

--- a/opensearch/playbooks/OpenSearchGuardianStatusStale.md
+++ b/opensearch/playbooks/OpenSearchGuardianStatusStale.md
@@ -1,0 +1,37 @@
+---
+title: OpenSearchGuardianStatusStale
+weight: 20
+---
+
+# OpenSearchGuardianStatusStale
+
+## Problem
+
+The OpenSearch Guardian plugin could not refresh the status. Status should be refreshed every 5 min.
+
+## Impact
+
+- Current cluster compliance state is unknown.
+- Cluster might not fulfill all compliance requirements.
+
+## Diagnosis
+
+Validate Guardian Configuration of `plugins.guardian.job_interval`. Log into k8s cluster and run:
+```bash
+kubectl exec -it opensearch-audit-manager-2 -c opensearch -- cat config/opensearch.yml | grep guardian
+```
+If you will see  `plugins.guardian.job_interval` that shows value which is greater than 5 then it looks like the alert is not configured properly for the guardian interval. If no setting at all - then the default of 5 should be enforced.
+
+For more follow playbooks:
+[OpenSearchGuardianEmpty](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianEmpty.md)
+[OpenSearchGuardianErrors](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianErrors.md)
+
+## Verify Resolution
+
+1. In Guardian, click **Refresh** on the **Status** tab.
+2. Confirm status is **compliant** and no errors are shown.
+3. Check the **History** tab to confirm the error is no longer recurring.
+
+## Contact Support
+
+If errors persist or the root cause is unclear, seek assistance from your operations team.

--- a/opensearch/playbooks/OpenSearchGuardianStatusStale.md
+++ b/opensearch/playbooks/OpenSearchGuardianStatusStale.md
@@ -16,11 +16,11 @@ The OpenSearch Guardian plugin could not refresh the status. Status should be re
 
 ## Diagnosis
 
-Validate Guardian Configuration of `plugins.guardian.job_interval`. Log into k8s cluster and run:
+Validate Guardian configuration for `plugins.guardian.job_interval`. Log into the Kubernetes cluster and run:
 ```bash
-kubectl exec -it opensearch-audit-manager-2 -c opensearch -- cat config/opensearch.yml | grep guardian
+kubectl -n <namespace> exec -i <opensearch-pod-name> -c opensearch -- cat config/opensearch.yml | grep guardian
 ```
-If you will see  `plugins.guardian.job_interval` that shows value which is greater than 5 then it looks like the alert is not configured properly for the guardian interval. If no setting at all - then the default of 5 should be enforced.
+If you see `plugins.guardian.job_interval` set to a value greater than 5, the alert threshold likely needs to be adjusted to match the configured interval. If the setting is absent, the default interval of 5 minutes should apply.
 
 For more follow playbooks:
 [OpenSearchGuardianEmpty](https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchGuardianEmpty.md)

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.11
+  version: 0.2.12
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.11
+    version: 0.2.12
   options:
     - name: queryExporter.enabled
       description: "Enable the OpenSearch query exporter for custom Prometheus metrics from OpenSearch queries"


### PR DESCRIPTION
## Pull Request Details                                                                                                                                                              
                                                                                                                                                                               
  - Guardian metrics scraping: Add ServiceMonitor for Guardian plugin metrics endpoint (/_plugins/_guardian/metrics), enabled conditionally when monitoring is on.                                                                                             
  - Operator metrics scraping: Enable ServiceMonitor for OpenSearch operator metrics (previously stubbed out). Add metricsBindAddress value (127.0.0.1:8080; use :8443 to expose externally).                                                                                                                                                          
  - Guardian alert rules: Add 4 new PrometheusRule alerts — OpenSearchGuardianNoncompliant, OpenSearchGuardianEmpty, OpenSearchGuardianErrors, OpenSearchGuardianStatusStale.  Guardian alerts deploy only when monitoring is enabled and pluginList contains guardian (via opensearch.guardianEnabled helper).                                             
  - Operator alert rules: Add OpenSearchOperatorDown alert (previously rules: []).
  - Cluster alert label fix: Rename label references from opster_io_opensearch_cluster → opensearch_org_opensearch_cluster across all cluster alert expressions and            
  annotations.                                                                                                                                                                 
  - Playbooks: Add 4 new runbooks — OpenSearchGuardianNoncompliant, OpenSearchGuardianEmpty, OpenSearchGuardianErrors, OpenSearchGuardianStatusStale.                          
  - Chart bump: 0.2.11 → 0.2.12.                                                                                                                                               
                                                                                                                                                                               
  Test plan                                                                                                                                                                    
                                                                                                                                                                               
  - Helm template renders correctly with monitoring enabled + guardian in pluginList                                                                                           
  - Helm template renders correctly with monitoring enabled + guardian absent from pluginList (no guardian PrometheusRule or ServiceMonitor)
  - Helm template renders correctly with monitoring disabled (no guardian resources)                                                                                           
  - Operator ServiceMonitor scrapes metrics when metricsBindAddress set to :8443                                                                                               
  - Guardian alerts fire on noncompliant/empty/error/stale conditions in Prometheus
