### PR TITLE
fix(logs): handle mixed syslog formats and prevent oversized message ingestion failures

### DIFF
--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -3,16 +3,32 @@ SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse c
 SPDX-License-Identifier: Apache-2.0
 */}}
 {{- define "syslog.receiver" }}
-syslog/tcp:
+tcplog/syslog:
+  listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogConfig.tcp_port }}
+  add_attributes: true
   operators:
-  - field: attributes.log.type
-    id: syslogtcp
-    type: add
+  - type: router
+    id: syslog_format_router
+    routes:
+    - expr: 'body matches "^<\\d+>\\d+ "'
+      output: syslog_5424_parser
+    - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
+      output: syslog_3164_parser
+    default: add_log_type
+  - type: syslog_parser
+    id: syslog_5424_parser
+    protocol: rfc5424
+    on_error: send
+    output: add_log_type
+  - type: syslog_parser
+    id: syslog_3164_parser
+    protocol: rfc3164
+    on_error: send
+    output: add_log_type
+  - type: add
+    id: add_log_type
+    field: attributes.log.type
     value: syslogtcp
-  protocol: rfc5424
-  tcp:
-    listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogConfig.tcp_port }}
-    add_attributes: true
 syslog/udp:
   location: UTC
   operators:
@@ -48,7 +64,7 @@ syslog/tcp-tls:
 
 {{- define "syslog.pipeline" }}
 logs/syslog_tcp:
-  receivers: [syslog/tcp]
+  receivers: [tcplog/syslog]
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -89,6 +89,13 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 30
+      transform/truncate_message:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - "truncate_all(attributes, 32000)"
+              - "truncate_all(resource.attributes, 32000)"
       attributes/cluster:
         actions:
           - action: insert
@@ -173,7 +180,7 @@ spec:
       pipelines:
         logs/{{ $name }}:
           receivers: [kafka/{{ $name }}]
-          processors: [memory_limiter, attributes/cluster]
+          processors: [memory_limiter, transform/truncate_message, attributes/cluster]
           exporters: [failover/opensearch_{{ $name }}]
         logs/{{ $name }}_failover_a:
           receivers: [failover/opensearch_{{ $name }}]


### PR DESCRIPTION
## Summary

- Replace the `syslog/tcp` receiver (rfc5424-only) with a `tcplog/syslog` receiver that uses a router operator to auto-detect and parse both RFC 5424 and RFC 3164 syslog messages over TCP
- Add a `transform/truncate_message` processor to all ingester collectors to truncate attributes to 32000 chars, preventing OpenSearch keyword field limit (32766 bytes) rejections

## Problem

1. **External collector parse errors**: Upstream senders (Logstash) forward a mix of RFC 5424 and RFC 3164 syslog messages over TCP port 514. The `syslog/tcp` receiver was configured with `protocol: rfc5424` only, causing continuous parse errors for BSD-format messages.

2. **Ingester poison-pill loop**: Some syslog messages have `attributes.message` exceeding 32KB. OpenSearch rejects these as permanent errors (`max_bytes_length_exceeded_exception`). The ingester's Kafka consumer rewinds and retries the same batch endlessly, blocking all syslog ingestion.

## Solution

### Change 1: `_syslog-config.tpl`

Replace the `syslog/tcp` receiver with a `tcplog/syslog` receiver that:
- Uses a `router` operator to detect message format via regex
- Routes RFC 5424 messages (`<PRI>VERSION ...`) to an rfc5424 syslog parser
- Routes RFC 3164 messages (`<PRI>MONTH ...`) to an rfc3164 syslog parser
- Passes unrecognized formats through without parsing (still ingested)

### Change 2: `ingester-collector.yaml`

Add a `transform/truncate_message` processor with `truncate_all(attributes, 32000)` to the ingester pipeline, ensuring no attribute exceeds OpenSearch's keyword field limit.

## Testing

- External collector: zero syslog parse errors after change
- Ingester: successfully processed 2.5M backlogged records after fix was applied