### PR TITLE
fix(logs): handle mixed syslog formats and prevent oversized message ingestion failures

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.7
+version: 0.4.8
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -3,16 +3,32 @@ SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse c
 SPDX-License-Identifier: Apache-2.0
 */}}
 {{- define "syslog.receiver" }}
-syslog/tcp:
+tcplog/syslog:
+  listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogConfig.tcp_port }}
+  add_attributes: true
   operators:
-  - field: attributes.log.type
-    id: syslogtcp
-    type: add
+  - type: router
+    id: syslog_format_router
+    routes:
+    - expr: 'body matches "^<\\d+>\\d+ "'
+      output: syslog_5424_parser
+    - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
+      output: syslog_3164_parser
+    default: add_log_type
+  - type: syslog_parser
+    id: syslog_5424_parser
+    protocol: rfc5424
+    on_error: send
+    output: add_log_type
+  - type: syslog_parser
+    id: syslog_3164_parser
+    protocol: rfc3164
+    on_error: send
+    output: add_log_type
+  - type: add
+    id: add_log_type
+    field: attributes.log.type
     value: syslogtcp
-  protocol: rfc5424
-  tcp:
-    listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogConfig.tcp_port }}
-    add_attributes: true
 syslog/udp:
   location: UTC
   operators:
@@ -28,27 +44,43 @@ syslog/udp:
 {{- end }}
 
 {{- define "syslog_tls.receiver" }}
-syslog/tcp-tls:
+tcplog/syslog_tls:
+  listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogTLSConfig.tcp_port }}
+  add_attributes: true
+  tls:
+    cert_file: /etc/ssl/syslog-tls/tls.crt
+    key_file: /etc/ssl/syslog-tls/tls.key
+    {{- if .Values.openTelemetry.externalCollector.syslogTLSConfig.clientCAEnabled }}
+    ca_file: /etc/ssl/syslog-tls/ca.crt
+    {{- end }}
   operators:
-  - field: attributes.log.type
-    id: syslogtcptls
-    type: add
+  - type: router
+    id: syslog_tls_format_router
+    routes:
+    - expr: 'body matches "^<\\d+>\\d+ "'
+      output: syslog_tls_5424_parser
+    - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
+      output: syslog_tls_3164_parser
+    default: add_tls_log_type
+  - type: syslog_parser
+    id: syslog_tls_5424_parser
+    protocol: rfc5424
+    on_error: send
+    output: add_tls_log_type
+  - type: syslog_parser
+    id: syslog_tls_3164_parser
+    protocol: rfc3164
+    on_error: send
+    output: add_tls_log_type
+  - type: add
+    id: add_tls_log_type
+    field: attributes.log.type
     value: syslogtcptls
-  protocol: rfc5424
-  tcp:
-    listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogTLSConfig.tcp_port }}
-    add_attributes: true
-    tls:
-      cert_file: /etc/ssl/syslog-tls/tls.crt
-      key_file: /etc/ssl/syslog-tls/tls.key
-      {{- if .Values.openTelemetry.externalCollector.syslogTLSConfig.clientCAEnabled }}
-      ca_file: /etc/ssl/syslog-tls/ca.crt
-      {{- end }}
 {{- end }}
 
 {{- define "syslog.pipeline" }}
 logs/syslog_tcp:
-  receivers: [syslog/tcp]
+  receivers: [tcplog/syslog]
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
@@ -57,6 +89,7 @@ logs/syslog_tcp:
     - transform/syslog_esxi_vm_events
     - transform/syslog_esxi_sshd
     - transform/syslog_audit_classification
+    - transform/truncate_message
     - attributes/cluster
   exporters: [routing/syslog_audit]
 
@@ -70,13 +103,14 @@ logs/syslog_udp:
     - transform/syslog_esxi_vm_events
     - transform/syslog_esxi_sshd
     - transform/syslog_audit_classification
+    - transform/truncate_message
     - attributes/cluster
   exporters: [routing/syslog_audit]
 {{- end }}
 
 {{- define "syslog_tls.pipeline" }}
 logs/syslog_tcp_tls:
-  receivers: [syslog/tcp-tls]
+  receivers: [tcplog/syslog_tls]
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
@@ -85,6 +119,7 @@ logs/syslog_tcp_tls:
     - transform/syslog_esxi_vm_events
     - transform/syslog_esxi_sshd
     - transform/syslog_audit_classification
+    - transform/truncate_message
     - attributes/cluster
   exporters: [routing/syslog_audit]
 {{- end }}

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -130,6 +130,15 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 30
+{{- if or .Values.openTelemetry.externalCollector.syslogConfig.enabled .Values.openTelemetry.externalCollector.syslogTLSConfig.enabled }}
+      transform/truncate_message:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - "truncate_all(attributes, 32000)"
+              - "truncate_all(resource.attributes, 32000)"
+{{- end }}
       resource:
         attributes:
         - action: insert

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.7
+  version: 0.15.8
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.7
+    version: 0.4.8
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

- Replace the `syslog/tcp` and `syslog/tcp-tls` receivers (rfc5424-only) with `tcplog/syslog` and `tcplog/syslog_tls` receivers that use a router operator to auto-detect and parse both RFC 5424 and RFC 3164 syslog messages over TCP
- Add a `transform/truncate_message` processor to all syslog pipelines in the external collector to truncate attributes to 32000 chars, preventing OpenSearch keyword field limit (32766 bytes) rejections

## Problem

1. **External collector parse errors**: Upstream senders (e.g. Logstash) forward a mix of RFC 5424 and RFC 3164 syslog messages over TCP port 514. The `syslog/tcp` receiver was configured with `protocol: rfc5424` only, causing continuous parse errors for BSD-format messages.

2. **Ingester poison-pill loop**: Some syslog messages have `attributes.message` exceeding 32KB. OpenSearch rejects these as permanent errors (`max_bytes_length_exceeded_exception`). The ingester's Kafka consumer rewinds and retries the same batch endlessly, blocking all syslog ingestion.

## Solution

### Change 1: `_syslog-config.tpl` — Mixed format support

Replace the `syslog/tcp` and `syslog/tcp-tls` receivers with `tcplog/syslog` and `tcplog/syslog_tls` receivers that:
- Use a `router` operator to detect message format via regex
- Route RFC 5424 messages (`<PRI>VERSION ...`) to an rfc5424 syslog parser
- Route RFC 3164 messages (`<PRI>MONTH ...`) to an rfc3164 syslog parser
- Pass unrecognized formats through without parsing (still ingested)

The `syslog/udp` receiver remains unchanged (rfc3164-only, appropriate for UDP syslog).

### Change 2: `external-collector.yaml` + `_syslog-config.tpl` — Truncation at source

Add a `transform/truncate_message` processor with `truncate_all(attributes, 32000)` to all syslog pipelines in the external collector. This truncates oversized attributes before they reach Kafka, preventing the downstream ingester from encountering OpenSearch's keyword field limit.

## Testing

Both changes were validated live:
- External collector: zero syslog parse errors after deploying the router-based receiver
- Ingester: successfully processed millions of backlogged records after the truncation fix unblocked the pipeline