### PR TITLE
faet(opensearch): update image tag after upgrading custom plugins

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -39,7 +39,7 @@ jobs:
           - Context: https://github.com/SAP-cloud-infrastructure/opensearch-fortlogs.git#main
             Dockerfiles: Dockerfile
             Imagename: opensearch-fortlogs
-            Imagetag: 3.7.0-dev
+            Imagetag: 3.7.0-dev01
             Platform: linux/amd64
 
     permissions:


### PR DESCRIPTION
feat(opensearch): bump image tag to include updated alerting plugin

The opensearch-fortlogs image tag is updated to 3.7.0-dev01 to pick up the upgrade of the alerting custom plugin to 3.7.0.0-sci-v5 in the upstream build.