### PR TITLE
chore: bump shoot-grafter to v0.4.1

### DIFF
--- a/shoot-grafter/charts/Chart.yaml
+++ b/shoot-grafter/charts/Chart.yaml
@@ -5,8 +5,8 @@ apiVersion: v2
 description: Automatic onboarding of Gardener Shoots to Greenhouse
 type: application
 name: shoot-grafter
-version: 0.4.0
-appVersion: "v0.4.0"
+version: 0.4.1
+appVersion: "v0.4.1"
 keywords:
 - operator
 - gardener

--- a/shoot-grafter/charts/crds/shoot-grafter.cloudoperators.dev_careinstructions.yaml
+++ b/shoot-grafter/charts/crds/shoot-grafter.cloudoperators.dev_careinstructions.yaml
@@ -55,6 +55,13 @@ spec:
             description: CareInstructionSpec holds the configuration for how to onboard
               Gardener shoots to Greenhouse.
             properties:
+              additionalAnnotations:
+                additionalProperties:
+                  type: string
+                description: |-
+                  AdditionalAnnotations are annotations to be added to the Greenhouse cluster Secret
+                  created for each matched Shoot.
+                type: object
               additionalLabels:
                 additionalProperties:
                   type: string

--- a/shoot-grafter/plugindefinition.yaml
+++ b/shoot-grafter/plugindefinition.yaml
@@ -7,9 +7,9 @@ metadata:
   name: shoot-grafter
 spec:
   description: Automatic onboarding of Gardener Shoots to Greenhouse
-  version: 0.4.0
+  version: 0.4.1
   helmChart:
     name: shoot-grafter
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.0
+    version: 0.4.1
   


### PR DESCRIPTION
This PR updates the shoot-grafter to v0.4.1 and updates the CRD.