### PR TITLE
feat(logs): extract forwarded_by attribute from syslog message body

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.8
+version: 0.4.9
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -48,6 +48,24 @@ attributes/syslog_audit_failover_username_b:
 {{- end }}
 {{/*
   ============================================================================
+  Extract forwarded_by attribute from message body
+  Logs forwarded via Logstash have "forwarded_by=octobus_logstash" appended
+  to the message. This extracts it into a proper attribute and removes it
+  from the message body.
+  ============================================================================
+*/}}
+transform/syslog_forwarded_by:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - 'set(attributes["forwarded_by"], "octobus_logstash") where attributes["message"] != nil and IsMatch(attributes["message"], ".*forwarded_by=octobus_logstash.*")'
+        - 'set(attributes["forwarded_by"], "octobus_logstash") where attributes["message"] == nil and body != nil and IsMatch(body, ".*forwarded_by=octobus_logstash.*")'
+        - 'replace_pattern(attributes["message"], " forwarded_by=octobus_logstash", "") where attributes["forwarded_by"] == "octobus_logstash" and attributes["message"] != nil'
+        - 'replace_pattern(body, " forwarded_by=octobus_logstash", "") where attributes["forwarded_by"] == "octobus_logstash" and body != nil'
+
+{{/*
+  ============================================================================
   Early drop of non-audit-relevant messages
   ============================================================================
 */}}

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -84,6 +84,7 @@ logs/syslog_tcp:
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
+    - transform/syslog_forwarded_by
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events
@@ -98,6 +99,7 @@ logs/syslog_udp:
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
+    - transform/syslog_forwarded_by
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events
@@ -114,6 +116,7 @@ logs/syslog_tcp_tls:
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
+    - transform/syslog_forwarded_by
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.8
+  version: 0.15.9
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.8
+    version: 0.4.9
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

- Adds a `transform/syslog_forwarded_by` processor to the external-collector syslog pipelines that extracts `forwarded_by=octobus_logstash` from the message body into a proper structured attribute
- Strips the marker text from both `attributes["message"]` and `body` to keep log messages clean

## Context

Logs forwarded via the octobus Logstash relay have `forwarded_by=octobus_logstash` appended to the syslog message body (the only way to pass metadata with a `line` codec over TCP). This makes it impossible to filter/query on this field without full-text search.

This processor:
1. Detects the marker in `attributes["message"]` (primary) or `body` (fallback for unparsed logs)
2. Sets `attributes["forwarded_by"] = "octobus_logstash"` as a structured attribute
3. Removes the marker from the message and body fields

## Pipeline placement

Runs after the early drop filters (to avoid processing logs that will be discarded) and before user extraction/hostname parsing (so the marker doesn't interfere with other parsers):

```
filter/syslog_early_drop → filter/syslog_drop_verbose → transform/syslog_forwarded_by → transform/syslog_user_extraction → ...
```

Applied to all three syslog pipelines: TCP, UDP, and TCP+TLS.