### PR TITLE
fix: add missing configmaps patch and events.k8s.io verbs to shoot-grafter ClusterRole

### DIFF
--- a/shoot-grafter/charts/Chart.yaml
+++ b/shoot-grafter/charts/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 description: Automatic onboarding of Gardener Shoots to Greenhouse
 type: application
 name: shoot-grafter
-version: 0.4.1
+version: 0.4.2
 appVersion: "v0.4.1"
 keywords:
 - operator

--- a/shoot-grafter/charts/templates/rbac.yaml
+++ b/shoot-grafter/charts/templates/rbac.yaml
@@ -31,10 +31,12 @@ rules:
   verbs:
   - get
   - list
+  - patch
   - update
   - watch
 - apiGroups:
   - ""
+  - events.k8s.io
   resources:
   - events
   verbs:

--- a/shoot-grafter/plugindefinition.yaml
+++ b/shoot-grafter/plugindefinition.yaml
@@ -7,9 +7,9 @@ metadata:
   name: shoot-grafter
 spec:
   description: Automatic onboarding of Gardener Shoots to Greenhouse
-  version: 0.4.1
+  version: 0.4.2
   helmChart:
     name: shoot-grafter
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.1
+    version: 0.4.2
   


### PR DESCRIPTION
The deployed ClusterRole was missing patch on configmaps (needed by ensureAuthConfigMapLabeled to label auth CMs) and events.k8s.io on events (needed by controller-runtime's event recorder). Both caused forbidden errors in prod. Bumps chart version to 0.4.2.

Related issue: https://github.com/cloudoperators/shoot-grafter/issues/71