### PR TITLE
feat(fortlogs): configurable sending_queue num_consumers on ingester

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.11
+version: 0.4.12
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.10
+version: 0.4.11
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -118,6 +118,10 @@ spec:
             insecure: {{ $cfg.opensearch.tls.insecure }}
           endpoint: {{ $cfg.opensearch.endpoint | quote }}
         logs_index: {{ $name | quote }}
+        sending_queue:
+          enabled: {{ dig "sendingQueue" "enabled" false $cfg.opensearch }}
+          num_consumers: {{ dig "sendingQueue" "numConsumers" 1 $cfg.opensearch }}
+          queue_size: {{ dig "sendingQueue" "queueSize" 10 $cfg.opensearch }}
         retry_on_failure:
           enabled: true
           initial_interval: 1s
@@ -133,6 +137,10 @@ spec:
             insecure: {{ $cfg.opensearch.tls.insecure }}
           endpoint: {{ $cfg.opensearch.endpoint | quote }}
         logs_index: {{ $name | quote }}
+        sending_queue:
+          enabled: {{ dig "sendingQueue" "enabled" false $cfg.opensearch }}
+          num_consumers: {{ dig "sendingQueue" "numConsumers" 1 $cfg.opensearch }}
+          queue_size: {{ dig "sendingQueue" "queueSize" 10 $cfg.opensearch }}
         retry_on_failure:
           enabled: true
           initial_interval: 1s

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -120,6 +120,7 @@ spec:
         logs_index: {{ $name | quote }}
         sending_queue:
           enabled: {{ dig "sendingQueue" "enabled" false $cfg.opensearch }}
+          block_on_overflow: true
           num_consumers: {{ dig "sendingQueue" "numConsumers" 1 $cfg.opensearch }}
           queue_size: {{ dig "sendingQueue" "queueSize" 10 $cfg.opensearch }}
         retry_on_failure:
@@ -139,6 +140,7 @@ spec:
         logs_index: {{ $name | quote }}
         sending_queue:
           enabled: {{ dig "sendingQueue" "enabled" false $cfg.opensearch }}
+          block_on_overflow: true
           num_consumers: {{ dig "sendingQueue" "numConsumers" 1 $cfg.opensearch }}
           queue_size: {{ dig "sendingQueue" "queueSize" 10 $cfg.opensearch }}
         retry_on_failure:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -214,6 +214,8 @@ openTelemetry:
     #       endpoint: <url>
     #       tls: { caSecret, caSecretKey, insecure }
     #       failover_username_a / failover_password_a / failover_username_b / failover_password_b
+    #       sendingQueue: { enabled, numConsumers, queueSize }  # optional; default enabled=false (synchronous)
+    #         (set enabled=true + numConsumers>1 to raise export concurrency; keep queueSize small to preserve backpressure)
     # Each entry renders one OpenTelemetryCollector named "logs-ingester-<name>" with
     # group_id "logs-ingester-<name>" and indexes documents into OpenSearch index "<name>".
     # -- Map of ingest collectors keyed by name. Configured via PluginPreset.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.10
+  version: 0.15.11
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.10
+    version: 0.4.11
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.11
+  version: 0.15.12
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.11
+    version: 0.4.12
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Add optional per-collector `sendingQueue` config to the ingester OpenSearch exporters. Ingester exporters send to OpenSearch one request at a time (synchronous), which caps per-consumer throughput. High-volume clusters can't keep up. This lets a collector opt into concurrent export. 