### PR TITLE
feat(logs): add syslog format detection, ISO timestamp parser, and observedTimestamp fallback

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.12
+version: 0.4.13
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -213,6 +213,16 @@ transform/syslog_audit_classification:
         - 'set(log.attributes["audit_relevant"], "false")'
         # Mark as audit if process IS in the audit-relevant whitelist
         - 'set(log.attributes["audit_relevant"], "true") where log.attributes["appname"] != nil and IsMatch(log.attributes["appname"], "(?i)^(Hostd|NSX|procstate|shell|sshd|ssoAudit|vpxd|ssoadminserver|sudo):?$")'
+# Uses observedTimestamp as fallback when no timestamp could be parsed from the log body
+# (e.g. unknown format logs that end up with @timestamp = 1970-01-01T00:00:00Z)
+transform/syslog_observed_timestamp_fallback:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      conditions:
+        - 'time_unix_nano == 0'
+      statements:
+        - 'set(time_unix_nano, observed_time_unix_nano)'
 {{- end }}
 
 {{- define "syslog_audit_filter.connectors" }}

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -7,6 +7,12 @@ tcp_log/syslog:
   listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogConfig.tcp_port }}
   add_attributes: true
   operators:
+  # Routes incoming syslog messages based on their header format:
+  #   RFC 5424: "<priority>VERSION timestamp ..." e.g. "<134>1 2026-07-10T09:32:35..."
+  #   RFC 3164: "<priority>Mmm dd HH:MM:SS ..."  e.g. "<13>Jan 15 10:30:00..."
+  #   RFC 3164 with ISO 8601 timestamp (non-standard, used by VMware ESXi/vSAN):
+  #             "<priority>ISO-timestamp ..."     e.g. "<12>2026-07-10T09:34:11.260Z..."
+  #   Unknown:  anything else (no syslog header, continuation lines, garbage)
   - type: router
     id: syslog_format_router
     routes:
@@ -14,16 +20,51 @@ tcp_log/syslog:
       output: syslog_5424_parser
     - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
       output: syslog_3164_parser
-    default: add_log_type
+    - expr: 'body matches "^<\\d+>\\d{4}-\\d{2}-\\d{2}T"'
+      output: syslog_iso_parser
+    default: add_format_unknown
   - type: syslog_parser
     id: syslog_5424_parser
     protocol: rfc5424
     on_error: send
-    output: add_log_type
+    output: add_format_rfc5424
   - type: syslog_parser
     id: syslog_3164_parser
     protocol: rfc3164
     on_error: send
+    output: add_format_rfc3164
+  - type: regex_parser
+    id: syslog_iso_parser
+    regex: '^<(?P<priority>\d+)>(?P<timestamp>\d{4}-\d{2}-\d{2}T\S+)\s+(?P<hostname>\S+)\s+(?P<message>.*)'
+    on_error: send
+    timestamp:
+      parse_from: attributes.timestamp
+      layout: '2006-01-02T15:04:05.999999999Z'
+      layout_type: gotime
+    output: syslog_iso_cleanup
+  - type: remove
+    id: syslog_iso_cleanup
+    field: attributes.timestamp
+    output: add_format_iso
+  - type: add
+    id: add_format_rfc5424
+    field: attributes.log.syslog.format
+    value: rfc5424
+    output: add_log_type
+  - type: add
+    id: add_format_rfc3164
+    field: attributes.log.syslog.format
+    value: rfc3164
+    output: add_log_type
+  - type: add
+    id: add_format_iso
+    field: attributes.log.syslog.format
+    value: rfc3164_iso8601
+    output: add_log_type
+  - type: add
+    id: add_format_unknown
+    field: attributes.log.syslog.format
+    value: unknown
     output: add_log_type
   - type: add
     id: add_log_type
@@ -44,7 +85,7 @@ syslog/udp:
 {{- end }}
 
 {{- define "syslog_tls.receiver" }}
-tcplog/syslog_tls:
+tcp_log/syslog_tls:
   listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogTLSConfig.tcp_port }}
   add_attributes: true
   tls:
@@ -54,6 +95,12 @@ tcplog/syslog_tls:
     ca_file: /etc/ssl/syslog-tls/ca.crt
     {{- end }}
   operators:
+  # Routes incoming syslog messages based on their header format:
+  #   RFC 5424: "<priority>VERSION timestamp ..." e.g. "<134>1 2026-07-10T09:32:35..."
+  #   RFC 3164: "<priority>Mmm dd HH:MM:SS ..."  e.g. "<13>Jan 15 10:30:00..."
+  #   RFC 3164 with ISO 8601 timestamp (non-standard, used by VMware ESXi/vSAN):
+  #             "<priority>ISO-timestamp ..."     e.g. "<12>2026-07-10T09:34:11.260Z..."
+  #   Unknown:  anything else (no syslog header, continuation lines, garbage)
   - type: router
     id: syslog_tls_format_router
     routes:
@@ -61,16 +108,51 @@ tcplog/syslog_tls:
       output: syslog_tls_5424_parser
     - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
       output: syslog_tls_3164_parser
-    default: add_tls_log_type
+    - expr: 'body matches "^<\\d+>\\d{4}-\\d{2}-\\d{2}T"'
+      output: syslog_tls_iso_parser
+    default: add_tls_format_unknown
   - type: syslog_parser
     id: syslog_tls_5424_parser
     protocol: rfc5424
     on_error: send
-    output: add_tls_log_type
+    output: add_tls_format_rfc5424
   - type: syslog_parser
     id: syslog_tls_3164_parser
     protocol: rfc3164
     on_error: send
+    output: add_tls_format_rfc3164
+  - type: regex_parser
+    id: syslog_tls_iso_parser
+    regex: '^<(?P<priority>\d+)>(?P<timestamp>\d{4}-\d{2}-\d{2}T\S+)\s+(?P<hostname>\S+)\s+(?P<message>.*)'
+    on_error: send
+    timestamp:
+      parse_from: attributes.timestamp
+      layout: '2006-01-02T15:04:05.999999999Z'
+      layout_type: gotime
+    output: syslog_tls_iso_cleanup
+  - type: remove
+    id: syslog_tls_iso_cleanup
+    field: attributes.timestamp
+    output: add_tls_format_iso
+  - type: add
+    id: add_tls_format_rfc5424
+    field: attributes.log.syslog.format
+    value: rfc5424
+    output: add_tls_log_type
+  - type: add
+    id: add_tls_format_rfc3164
+    field: attributes.log.syslog.format
+    value: rfc3164
+    output: add_tls_log_type
+  - type: add
+    id: add_tls_format_iso
+    field: attributes.log.syslog.format
+    value: rfc3164_iso8601
+    output: add_tls_log_type
+  - type: add
+    id: add_tls_format_unknown
+    field: attributes.log.syslog.format
+    value: unknown
     output: add_tls_log_type
   - type: add
     id: add_tls_log_type
@@ -84,6 +166,7 @@ logs/syslog_tcp:
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
+    - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
@@ -99,6 +182,7 @@ logs/syslog_udp:
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
+    - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
@@ -116,6 +200,7 @@ logs/syslog_tcp_tls:
   processors:
     - filter/syslog_early_drop
     - filter/syslog_drop_verbose
+    - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -39,7 +39,7 @@ tcp_log/syslog:
     on_error: send
     timestamp:
       parse_from: attributes.timestamp
-      layout: '2006-01-02T15:04:05.999999999Z'
+      layout: '2006-01-02T15:04:05.999999999Z07:00'
       layout_type: gotime
     output: syslog_iso_cleanup
   - type: remove
@@ -77,6 +77,10 @@ syslog/udp:
     id: syslogudp
     type: add
     value: syslogudp
+  - field: attributes.log.syslog.format
+    id: syslogudp_format
+    type: add
+    value: rfc3164
   protocol: rfc3164
   udp:
     listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogConfig.udp_port }}
@@ -127,7 +131,7 @@ tcp_log/syslog_tls:
     on_error: send
     timestamp:
       parse_from: attributes.timestamp
-      layout: '2006-01-02T15:04:05.999999999Z'
+      layout: '2006-01-02T15:04:05.999999999Z07:00'
       layout_type: gotime
     output: syslog_tls_iso_cleanup
   - type: remove

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.12
+  version: 0.15.13
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.12
+    version: 0.4.13
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

- Add a third router route to detect non-standard syslog messages that use RFC 3164 structure with ISO 8601 timestamps (commonly emitted by VMware ESXi/vSAN appliances)
- Add a regex parser to extract `priority`, `timestamp`, `hostname`, and `message` from these ISO-format messages, fixing logs that previously ended up with `@timestamp = 1970-01-01T00:00:00Z`
- Add `attributes.log.syslog.format` label to all syslog logs with values: `rfc5424`, `rfc3164`, `rfc3164_iso8601`, or `unknown`
- Add `transform/syslog_observed_timestamp_fallback` processor that uses `observedTimestamp` as fallback when no timestamp could be parsed from the log body (unknown format / garbage messages)
- Add comments to the router explaining the different syslog format patterns

## Problem

Some syslog senders emit messages in a non-standard format:
```
<12>2026-01-15T09:34:11.260Z hostname PROCESS: message...
```

This doesn't match RFC 5424 (missing version number) or RFC 3164 (ISO timestamp instead of BSD `Mmm dd HH:MM:SS`), so these messages fell through to the default route with no timestamp parsing, resulting in `@timestamp = 1970-01-01T00:00:00Z`.

Additionally, some messages arrive with no syslog header at all (e.g. continuation lines from multi-line messages), which also end up at epoch time.

## Changes

| File | Change |
|------|--------|
| `_syslog-config.tpl` | New ISO route + regex parser + format labels + comments (both TCP and TLS receivers) |
| `_syslog-audit-filter-config.tpl` | New `transform/syslog_observed_timestamp_fallback` processor |
| `Chart.yaml` | Version bump `0.4.12` → `0.4.13` |
| `plugindefinition.yaml` | Version bump `0.15.12` → `0.15.13` / chart ref `0.4.12` → `0.4.13` |

## Testing

Deployed and validated on a QA cluster. Both external-collector pods started cleanly with 0 errors and 0 restarts. Confirmed:
- New ISO-format messages get correct timestamps
- `log.syslog.format` attribute is populated on all syslog logs
- Unknown format logs use `observedTimestamp` instead of epoch