### PR TITLE
feat(logs): collect kernel crash dumps via systemd journal (systemd-pstore.service)

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.12
+version: 0.4.13
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_kvm-config.tpl
+++ b/logs/charts/templates/_kvm-config.tpl
@@ -47,6 +47,18 @@ file_log/ch_logs:
       id: file-label
       type: add
       value: files-ch
+journald/pstore:
+  storage: file_storage/journald
+  units:
+    - systemd-pstore.service
+  start_at: beginning
+  all: true
+  merge: true
+  operators:
+    - id: pstore-label
+      type: add
+      field: attributes["log.type"]
+      value: "journald-pstore"
 {{- end }}
 {{- define "kvm.transform" }}
 transform/kvm_openvswitch:
@@ -121,6 +133,23 @@ transform/ch_logs:
       - set(log.attributes["config.parsed"], "libvirt-ch")
       - set(log.observed_time, Now())
       - set(log.time, log.observed_time)
+
+transform/pstore:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      conditions:
+        - attributes["log.type"] == "pstore"
+      statements:
+        - merge_maps(log.cache, log.body, "upsert")
+        - set(log.attributes["message"], log.cache["MESSAGE"])
+        - set(log.attributes["pstore.file"], log.cache["FILE"])
+        - set(log.attributes["boot_id"], log.cache["_BOOT_ID"])
+        - set(resource.attributes["host.name"], log.cache["_HOSTNAME"])
+        - set(resource.attributes["syslog.unit"], log.cache["_SYSTEMD_UNIT"])
+        - set(log.attributes["config.parsed"], "pstore")
+        - set(log.observed_time, Now())
+        - set(log.time, log.observed_time)
 {{- end }}
 {{- define "kvm.pipeline" }}
 logs/kvm_containerd:
@@ -130,6 +159,10 @@ logs/kvm_containerd:
 logs/kvm_file_log:
   receivers: [file_log/qemu_logs,file_log/openvswitch_logs,file_log/kvm_monitoring,file_log/ch_logs]
   processors: [k8s_attributes, attributes/cluster, transform/kvm_logs, transform/kvm_monitoring, transform/qemu_logs, transform/ch_logs]
+  exporters: [routing]
+logs/kvm_pstore:
+  receivers: [journald/pstore]
+  processors: [attributes/cluster, transform/pstore]
   exporters: [routing]
 {{- end }}
 

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.12
+  version: 0.15.13
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.12
+    version: 0.4.13
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

Collect kernel crash dumps (panics, MCEs) from the systemd journal instead of reading files under `/var/lib/systemd/pstore/`. This removes a hostPath volume mount and works regardless of `Storage=` mode in `/etc/systemd/pstore.conf`.

Gated by `kvmConfig.enabled`.

- Adds `journald/pstore` receiver filtered on `_SYSTEMD_UNIT=systemd-pstore.service` (`units:`), with `merge: true` (required — the collector container has `/var/log/journal` mounted but not `/run/log/journal`), `start_at: beginning`, `all: true`.
- Adds `transform/pstore` extracting `MESSAGE`, `FILE`, `_BOOT_ID`, `_HOSTNAME`, `_SYSTEMD_UNIT` from `log.body` into attributes / resource attributes, and tagging `config.parsed: pstore`.
- Adds dedicated `logs/kvm_pstore` pipeline (no `k8s_attributes` — host-level source).
- Chart / plugindefinition version bump `0.4.12 -> 0.4.13` / `0.15.12 -> 0.15.13`.

## Why journald and not the file directory

`systemd-pstore.service` always logs pstore contents to the journal via `sd_journal_sendv()`, independent of `Storage=` — the `FILE=` field contains the raw dmesg payload, `MESSAGE=` is the summary. See [`src/pstore/pstore.c` (`move_file()`)](https://github.com/systemd/systemd/blob/main/src/pstore/pstore.c). Works with both `Storage=external` (default; files + journal) and `Storage=journal` (journal only).

## Verification


