### PR TITLE
feat(kafka): export log-dir size and broker throughput metrics

### DIFF
--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.10
+version: 0.1.11
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/metrics-configmap.yaml
+++ b/kafka/charts/templates/metrics-configmap.yaml
@@ -50,6 +50,26 @@ data:
     - pattern: kafka.server<type=(.+), name=(.+)><>Value
       name: kafka_server_$1_$2
       type: GAUGE
+    - pattern: kafka.log<type=Log, name=(.+), topic=(.+), partition=(.+)><>Value
+      name: kafka_log_log_$1
+      type: GAUGE
+      labels:
+        topic: "$2"
+        partition: "$3"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+      labels:
+        "$4": "$5"
+        "$6": "$7"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
+      labels:
+        "$4": "$5"
+    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
+      name: kafka_$1_$2_$3_total
+      type: COUNTER
     - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
       name: kafka_$1_$2_$3_percent_rate
       type: GAUGE

--- a/kafka/charts/templates/metrics-configmap.yaml
+++ b/kafka/charts/templates/metrics-configmap.yaml
@@ -19,12 +19,6 @@ data:
         clientId: "$3"
         topic: "$4"
         partition: "$5"
-    - pattern: kafka.server<type=(.+), name=(.+), clientId=(.+), brokerHost=(.+), brokerPort=(.+)><>Value
-      name: kafka_server_$1_$2
-      type: GAUGE
-      labels:
-        clientId: "$3"
-        broker: "$4:$5"
     - pattern: kafka.server<type=(.+), cipher=(.+), protocol=(.+), listener=(.+), networkProcessor=(.+)><>connections
       name: kafka_server_$1_connections_tls_info
       type: GAUGE

--- a/kafka/charts/templates/metrics-configmap.yaml
+++ b/kafka/charts/templates/metrics-configmap.yaml
@@ -50,19 +50,13 @@ data:
       labels:
         topic: "$2"
         partition: "$3"
-    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+), (.+)=(.+)><>Count
-      name: kafka_$1_$2_$3_total
+    - pattern: kafka.server<type=BrokerTopicMetrics, name=(.+)PerSec\w*, topic=(.+)><>Count
+      name: kafka_server_brokertopicmetrics_$1_total
       type: COUNTER
       labels:
-        "$4": "$5"
-        "$6": "$7"
-    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*, (.+)=(.+)><>Count
-      name: kafka_$1_$2_$3_total
-      type: COUNTER
-      labels:
-        "$4": "$5"
-    - pattern: kafka.(\w+)<type=(.+), name=(.+)PerSec\w*><>Count
-      name: kafka_$1_$2_$3_total
+        topic: "$2"
+    - pattern: kafka.server<type=BrokerTopicMetrics, name=(.+)PerSec\w*><>Count
+      name: kafka_server_brokertopicmetrics_$1_total
       type: COUNTER
     - pattern: kafka.(\w+)<type=(.+), name=(.+)Percent\w*><>MeanRate
       name: kafka_$1_$2_$3_percent_rate

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.10
+  version: 0.1.11
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.10
+    version: 0.1.11
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

Add JMX exporter rules so the broker exposes two new groups of metrics:

- **Per-topic log size** (`kafka_log_log_size` and related offset/segment metrics), shows how much disk each topic partition uses and how many messages it holds.

- **Broker throughput** (`kafka_server_brokertopicmetrics_*_total`), messages in, bytes in/out and produce/fetch request rates per broker.

Also removes an old `FetcherStats` rule that no longer matches anything on Kafka 4.x (KRaft), so it just produced empty output.