### PR TITLE
kube-monitoring(feat): amo fallback rulename

### DIFF
--- a/kube-monitoring/charts/Chart.yaml
+++ b/kube-monitoring/charts/Chart.yaml
@@ -9,7 +9,7 @@ maintainers:
 name: kube-monitoring
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 13.4.3
+version: 13.4.4
 keywords:
   - operator
   - prometheus

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -499,7 +499,7 @@ absentMetricsOperator:
   # @section -- absent-metrics-operator options
   enabled: false
   # @ignored
-  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else if index .metadata.labels "thanos-ruler" }}{{ index .metadata.labels "thanos-ruler" }}{{ else }}{{ index .metadata.labels "prometheus" }}{{ end }}'
+  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else if index .metadata.labels "thanos-ruler" }}{{ index .metadata.labels "thanos-ruler" }}{{ else if index .metadata.labels "prometheus" }}{{ index .metadata.labels "prometheus" }}{{ else }}no-label{{ end }}'
   # @ignored
   extraArgs: []
     # - --keep-labels=support_group,tier,service

--- a/kube-monitoring/charts/values.yaml
+++ b/kube-monitoring/charts/values.yaml
@@ -499,7 +499,7 @@ absentMetricsOperator:
   # @section -- absent-metrics-operator options
   enabled: false
   # @ignored
-  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else if index .metadata.labels "thanos-ruler" }}{{ index .metadata.labels "thanos-ruler" }}{{ else if index .metadata.labels "prometheus" }}{{ index .metadata.labels "prometheus" }}{{ else }}no-label{{ end }}'
+  promRuleName: '{{ if index .metadata.labels "plugin" }}{{ index .metadata.labels "plugin" }}{{ else if index .metadata.labels "thanos-ruler" }}{{ index .metadata.labels "thanos-ruler" }}{{ else if index .metadata.labels "prometheus" }}{{ index .metadata.labels "prometheus" }}{{ else }}no-selector{{ end }}'
   # @ignored
   extraArgs: []
     # - --keep-labels=support_group,tier,service

--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 14.4.3
+  version: 14.4.4
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -15,7 +15,7 @@ spec:
     # renovate depName=ghcr.io/cloudoperators/greenhouse-extensions/charts/kube-monitoring
     name: kube-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 13.4.3
+    version: 13.4.4
   options:
     - name: global.commonLabels
       description: Labels to add to all resources. This can be used to add a support group or service to all alerts.


### PR DESCRIPTION
current config will fail promrule creating if any of those labels is not present `prometheus`, `plugin` or `thanos-ruler` 

adding a fallback to `no-label` will create `no-label-absent-metric-alert-rules` PrometheusRule in respective namespaces


`{"level":"error","ts":"2026-07-13T08:18:34Z","msg":"Reconciler error","controller":"prometheusrule","controllerGroup":"monitoring.coreos.com","controllerKind":"PrometheusRule","PrometheusRule":{"name":"secrets-injector-alerts","namespace":"secrets-injector"},"namespace":"secrets-injector","name":"secrets-injector-alerts","reconcileID":"8d9eea89-cd11-4b5e-98cb-809fb680b8da","error":"PrometheusRule.monitoring.coreos.com \"-absent-metric-alert-rules\" is invalid: metadata.name: Invalid value: \"-absent-metric-alert-rules\": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:494\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/src/vendor/sigs.k8s.io/controller-runtime/pkg/internal/controller/controller.go:312"}`