### PR TITLE
feat(gatekeeper-doop): add PluginDefinition for per-cluster DOOP

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,6 +29,7 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /exposed-services/        @cloudoperators/greenhouse-backend
 /external-dns/            @cloudoperators/greenhouse-backend
 /gatekeeper/              @cloudoperators/greenhouse-backend
+/gatekeeper-doop/         @cloudoperators/greenhouse-backend
 /ingress-nginx/           @cloudoperators/greenhouse-backend
 /kafka/                   @cloudoperators/greenhouse-observability
 /kube-monitoring/         @cloudoperators/greenhouse-observability

--- a/.github/workflows/ci-pr-build.yaml
+++ b/.github/workflows/ci-pr-build.yaml
@@ -38,6 +38,8 @@ jobs:
             chartName: exposed-services
           - chartDir: gatekeeper/charts
             chartName: gatekeeper
+          - chartDir: gatekeeper-doop/charts
+            chartName: gatekeeper-doop
           - chartDir: kafka/chart
             chartName: kafka
           - chartDir: kube-monitoring/charts

--- a/.github/workflows/helm-release.yaml
+++ b/.github/workflows/helm-release.yaml
@@ -16,6 +16,7 @@ on:
       - exposed-services/charts/v2.0.0/exposed-service/**
       - gatekeeper/charts/**
       - gatekeeper-config/charts/**
+      - gatekeeper-doop/charts/**
       - kafka/charts/**
       - kube-monitoring/charts/**
       - kubeconfig-generator/chart/**
@@ -67,6 +68,8 @@ jobs:
             chartName: gatekeeper
           - chartDir: gatekeeper-config/charts
             chartName: gatekeeper-config
+          - chartDir: gatekeeper-doop/charts
+            chartName: gatekeeper-doop
           - chartDir: kafka/charts
             chartName: kafka
           - chartDir: kube-monitoring/charts

--- a/docs/catalog.md
+++ b/docs/catalog.md
@@ -14,6 +14,7 @@ This following table provides an overview of the currently available Plugins in 
 | exposed-service|A test plugin for validating service exposure via Greenhouse|1.0.0|
 | external-dns|The kubernetes-sigs/external-dns plugin.|1.0.0|
 | gatekeeper|Policy controller for Kubernetes admission based on the OPA constraint framework|1.0.0|
+| gatekeeper-doop|Per-cluster DOOP components for OPA Gatekeeper (analyzer, image-checker, helm-manifest-parser)|0.1.0|
 | heureka||1.0.0|
 | ingress-nginx|Ingress NGINX controller|1.1.0|
 | kube-monitoring|Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.|1.3.4|

--- a/gatekeeper-doop/README.md
+++ b/gatekeeper-doop/README.md
@@ -1,0 +1,11 @@
+---
+title: Gatekeeper DOOP
+---
+
+Per-cluster components of [DOOP](https://github.com/sapcc/gatekeeper-addons) for OPA Gatekeeper. Runs alongside the `gatekeeper` operator on every managed cluster:
+
+- `doop-analyzer` subscribes to Gatekeeper audit reports, deduplicates violations via merging rules, and uploads the aggregate to an OpenStack Swift container that the central `doop-api` plugin then serves.
+- `doop-image-checker` is an HTTP service called by Rego policies (via `http.send`) to check container image vulnerability and provenance against a container registry that exposes the required metadata.
+- `helm-manifest-parser` is an HTTP service that decodes Helm release Secret blobs into JSON so policies can reason about Helm-managed resources.
+
+Install the `gatekeeper` PluginDefinition first; `gatekeeper-doop` should be installed with `Plugin.spec.waitFor` referencing it. Policies that call `image-check.rego` or `helm-release.rego` require `disabledBuiltins` on the gatekeeper plugin to be set to `[]` so `http.send` is available.

--- a/gatekeeper-doop/charts/Chart.yaml
+++ b/gatekeeper-doop/charts/Chart.yaml
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: gatekeeper-doop
+description: Per-cluster DOOP components - audit analyzer plus image-checker and helm-manifest-parser policy companion services for OPA Gatekeeper.
+type: application
+version: 0.1.0
+appVersion: "0.1.0"
+icon: https://raw.githubusercontent.com/open-policy-agent/opa/main/logo/logo.png
+keywords:
+  - gatekeeper
+  - opa
+  - policy
+  - doop
+maintainers:
+  - name: ivogoman
+  - name: uwe-mayer

--- a/gatekeeper-doop/charts/templates/_helpers.tpl
+++ b/gatekeeper-doop/charts/templates/_helpers.tpl
@@ -1,0 +1,16 @@
+{{/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+*/}}
+
+{{- define "gatekeeper-doop.labels" -}}
+app.kubernetes.io/name: gatekeeper-doop
+app.kubernetes.io/instance: {{ .Release.Name }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "gatekeeper-doop.image" -}}
+{{- $repo := .Values.image.repository | required ".Values.image.repository is required" -}}
+{{- $tag := .Values.image.tag | default .Chart.AppVersion -}}
+{{- printf "%s:%s" $repo $tag -}}
+{{- end -}}

--- a/gatekeeper-doop/charts/templates/configmap-analyzer-rules.yaml
+++ b/gatekeeper-doop/charts/templates/configmap-analyzer-rules.yaml
@@ -1,6 +1,6 @@
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
-{{- $cname     := .Values.cluster.name           | required ".Values.cluster.name is required" -}}
+{{ $cname     := .Values.cluster.name           | required ".Values.cluster.name is required" -}}
 {{- $clayer    := .Values.cluster.layer          | required ".Values.cluster.layer is required" -}}
 {{- $ctype     := .Values.cluster.type           | required ".Values.cluster.type is required" -}}
 {{- $region    := .Values.swift.region           | required ".Values.swift.region is required" -}}
@@ -20,7 +20,7 @@ data:
         "type": {{ quote $ctype }}
       },
       "swift": {
-        "container_name": "doop-analyzer{{ if $cname | regexMatch "^[akv]-" }}-kubernikus{{ end }}",
+        "container_name": "doop-analyzer",
         "object_name": {{ quote $cname }}
       },
       "processing_rules": [
@@ -92,27 +92,7 @@ data:
               "message": "$1<region>$2"
             }
           }
-        }{{- if contains "qa" $region }},
-        {
-          "description": "M213: Merge across usages of eu-de-1 as a primary image source (if eu-de-1 mentioned in name)",
-          "replace": {
-            "source": "name",
-            "pattern": "(.*)keppel.eu-de-1(.*)",
-            "target": {
-              "name": "$1keppel.<region>$2"
-            }
-          }
-        },
-        {
-          "description": "M214: Merge across usages of eu-de-1 as a primary image source (if eu-de-1 mentioned in message)",
-          "replace": {
-            "source": "message",
-            "pattern": "(.*)keppel.eu-de-1(.*)",
-            "target": {
-              "message": "$1keppel.<region>$2"
-            }
-          }
-        }{{- end }}{{- if ne $altregion $region }},
+        }{{- if ne $altregion $region }},
         {
           "description": "M221: Merge across alternate regions (if alternate region mentioned in name)",
           "replace": {
@@ -133,22 +113,6 @@ data:
             }
           }
         }{{- end }},
-        {{- if eq $ctype "cloudshell" "test" }}
-        {
-          "description": "M301: Merge across pods managed by cloud-shell",
-          "match": {
-            "namespace": "cloud-shell",
-            "kind": "Pod"
-          },
-          "replace": {
-            "source": "name",
-            "pattern": "shell-(?:c[0-9]{7}|[di][0-9]{6})",
-            "target": {
-              "name": "shell-<uid>"
-            }
-          }
-        },
-        {{- end }}
         {
           "description": "M401: Merge across pods in the same DaemonSet, Job or ReplicaSet",
           "match": {
@@ -214,22 +178,9 @@ data:
               "name": "$1-<index>"
             }
           }
-        }{{- if eq $ctype "kubernikus" "test" }},
+        },
         {
-          "description": "M501: Merge across Kubernikus clusters of the same name in different projects",
-          "match": {
-            "namespace": "kubernikus"
-          },
-          "replace": {
-            "source": "name",
-            "pattern": "(.+)-[0-9a-f]{32}(-.+)?",
-            "target": {
-              "name": "$1-<variable>$2"
-            }
-          }
-        }{{- end }}{{- if eq $ctype "scaleout" "test" }},
-        {
-          "description": "M502: Merge across Grafana deployments managed by the grafana-operator",
+          "description": "M501: Merge across Grafana deployments managed by the grafana-operator",
           "match": {
             "name": "grafana-.*"
           },
@@ -240,6 +191,9 @@ data:
               "namespace": "<variable>"
             }
           }
-        }{{- end }}
+        }
+        {{- range .Values.analyzer.extraMergingRules }},
+        {{ . | toJson }}
+        {{- end }}
       ]
     }

--- a/gatekeeper-doop/charts/templates/configmap-analyzer-rules.yaml
+++ b/gatekeeper-doop/charts/templates/configmap-analyzer-rules.yaml
@@ -1,0 +1,245 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+{{- $cname     := .Values.cluster.name           | required ".Values.cluster.name is required" -}}
+{{- $clayer    := .Values.cluster.layer          | required ".Values.cluster.layer is required" -}}
+{{- $ctype     := .Values.cluster.type           | required ".Values.cluster.type is required" -}}
+{{- $region    := .Values.swift.region           | required ".Values.swift.region is required" -}}
+{{- $altregion := .Values.swift.alternateRegion  | default $region -}}
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-analyzer
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+data:
+  config.json: |
+    {
+      "cluster_identity": {
+        "layer": {{ quote $clayer }},
+        "type": {{ quote $ctype }}
+      },
+      "swift": {
+        "container_name": "doop-analyzer{{ if $cname | regexMatch "^[akv]-" }}-kubernikus{{ end }}",
+        "object_name": {{ quote $cname }}
+      },
+      "processing_rules": [
+        {
+          "description": "R101: Rewrite Helm releases into a more readable pseudo-Kind",
+          "match": {
+            "kind": "Secret"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "sh\\.helm\\.release\\.v1\\.(.*)(\\.v\\d+)",
+            "target": {
+              "kind": "Helm 3 release",
+              "name": "$1$2"
+            }
+          }
+        }
+      ],
+      "merging_rules": [
+        {
+          "description": "M101: Merge across versions of the same Helm release",
+          "match": {
+            "kind": "Helm 3 release"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.*)\\.v\\d+",
+            "target": {
+              "name": "$1"
+            }
+          }
+        }{{- if ne $cname $region }},
+        {
+          "description": "M201: Merge across clusters (if cluster mentioned in name)",
+          "replace": {
+            "source": "name",
+            "pattern": "(.*){{ $cname }}(.*)",
+            "target": {
+              "name": "$1<cluster>$2"
+            }
+          }
+        },
+        {
+          "description": "M202: Merge across clusters (if cluster mentioned in message)",
+          "replace": {
+            "source": "message",
+            "pattern": "(.*){{ $cname }}(.*)",
+            "target": {
+              "message": "$1<cluster>$2"
+            }
+          }
+        }{{- end }},
+        {
+          "description": "M211: Merge across regions (if region mentioned in name)",
+          "replace": {
+            "source": "name",
+            "pattern": "(.*){{ $region }}(.*)",
+            "target": {
+              "name": "$1<region>$2"
+            }
+          }
+        },
+        {
+          "description": "M212: Merge across regions (if region mentioned in message)",
+          "replace": {
+            "source": "message",
+            "pattern": "(.*){{ $region }}(.*)",
+            "target": {
+              "message": "$1<region>$2"
+            }
+          }
+        }{{- if contains "qa" $region }},
+        {
+          "description": "M213: Merge across usages of eu-de-1 as a primary image source (if eu-de-1 mentioned in name)",
+          "replace": {
+            "source": "name",
+            "pattern": "(.*)keppel.eu-de-1(.*)",
+            "target": {
+              "name": "$1keppel.<region>$2"
+            }
+          }
+        },
+        {
+          "description": "M214: Merge across usages of eu-de-1 as a primary image source (if eu-de-1 mentioned in message)",
+          "replace": {
+            "source": "message",
+            "pattern": "(.*)keppel.eu-de-1(.*)",
+            "target": {
+              "message": "$1keppel.<region>$2"
+            }
+          }
+        }{{- end }}{{- if ne $altregion $region }},
+        {
+          "description": "M221: Merge across alternate regions (if alternate region mentioned in name)",
+          "replace": {
+            "source": "name",
+            "pattern": "(.*){{ $altregion }}(.*)",
+            "target": {
+              "name": "$1<altregion>$2"
+            }
+          }
+        },
+        {
+          "description": "M222: Merge across alternate regions (if alternate region mentioned in message)",
+          "replace": {
+            "source": "message",
+            "pattern": "(.*){{ $altregion }}(.*)",
+            "target": {
+              "message": "$1<altregion>$2"
+            }
+          }
+        }{{- end }},
+        {{- if eq $ctype "cloudshell" "test" }}
+        {
+          "description": "M301: Merge across pods managed by cloud-shell",
+          "match": {
+            "namespace": "cloud-shell",
+            "kind": "Pod"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "shell-(?:c[0-9]{7}|[di][0-9]{6})",
+            "target": {
+              "name": "shell-<uid>"
+            }
+          }
+        },
+        {{- end }}
+        {
+          "description": "M401: Merge across pods in the same DaemonSet, Job or ReplicaSet",
+          "match": {
+            "kind": "Pod"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.+)-[0-9a-z]{5}",
+            "target": {
+              "name": "$1-<variable>"
+            }
+          }
+        },
+        {
+          "description": "M402: Merge across ReplicaSets in the same Deployment",
+          "match": {
+            "kind": "Pod|ReplicaSet"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.+)-[0-9a-f]{8,10}(?:-<variable>)?",
+            "target": {
+              "name": "$1-<variable>"
+            }
+          }
+        },
+        {
+          "description": "M403: Merge across pods in ReplicaSets in the same Deployment even if the child suffixes are fused",
+          "match": {
+            "kind": "Pod",
+            "name": ".{63}"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.+)-[0-9a-f]{1,10}[0-9a-z]{5}",
+            "target": {
+              "name": "$1-<variable>"
+            }
+          }
+        },
+        {
+          "description": "M404: Merge across jobs in the same CronJob",
+          "match": {
+            "kind": "Pod|Job"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.+)-[0-9]{8}(?:-<variable>)?",
+            "target": {
+              "name": "$1-<variable>"
+            }
+          }
+        },
+        {
+          "description": "M405: Merge across pods in the same StatefulSet",
+          "match": {
+            "kind": "Pod"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.+)-[0-9]{1,2}",
+            "target": {
+              "name": "$1-<index>"
+            }
+          }
+        }{{- if eq $ctype "kubernikus" "test" }},
+        {
+          "description": "M501: Merge across Kubernikus clusters of the same name in different projects",
+          "match": {
+            "namespace": "kubernikus"
+          },
+          "replace": {
+            "source": "name",
+            "pattern": "(.+)-[0-9a-f]{32}(-.+)?",
+            "target": {
+              "name": "$1-<variable>$2"
+            }
+          }
+        }{{- end }}{{- if eq $ctype "scaleout" "test" }},
+        {
+          "description": "M502: Merge across Grafana deployments managed by the grafana-operator",
+          "match": {
+            "name": "grafana-.*"
+          },
+          "replace": {
+            "source": "namespace",
+            "pattern": "[0-9a-f]{32}",
+            "target": {
+              "namespace": "<variable>"
+            }
+          }
+        }{{- end }}
+      ]
+    }

--- a/gatekeeper-doop/charts/templates/deployment-analyzer.yaml
+++ b/gatekeeper-doop/charts/templates/deployment-analyzer.yaml
@@ -1,0 +1,81 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-analyzer
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: analyzer
+spec:
+  replicas: {{ .Values.analyzer.replicas }}
+  strategy:
+    type: Recreate
+  minReadySeconds: 15
+  selector:
+    matchLabels:
+      {{- include "gatekeeper-doop.labels" . | nindent 6 }}
+      app.kubernetes.io/component: analyzer
+  template:
+    metadata:
+      labels:
+        {{- include "gatekeeper-doop.labels" . | nindent 8 }}
+        app.kubernetes.io/component: analyzer
+      annotations:
+        checksum/configmap: {{ include (print $.Template.BasePath "/configmap-analyzer-rules.yaml") . | sha256sum }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
+    spec:
+      serviceAccountName: {{ .Release.Name }}-doop-agent
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: analyzer
+          image: {{ include "gatekeeper-doop.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["doop-analyzer"]
+          args: ["run", "/etc/doop-analyzer/config.json"]
+          env:
+            - name: OS_AUTH_URL
+              value: {{ .Values.swift.authURL | required ".Values.swift.authURL is required" | quote }}
+            - name: OS_AUTH_VERSION
+              value: "3"
+            - name: OS_IDENTITY_API_VERSION
+              value: "3"
+            - name: OS_USER_DOMAIN_NAME
+              value: {{ .Values.swift.userDomain | quote }}
+            - name: OS_USERNAME
+              value: {{ .Values.swift.username | required ".Values.swift.username is required" | quote }}
+            - name: OS_PROJECT_DOMAIN_NAME
+              value: {{ .Values.swift.projectDomain | quote }}
+            - name: OS_PROJECT_NAME
+              value: {{ .Values.swift.projectName | required ".Values.swift.projectName is required" | quote }}
+            - name: OS_REGION_NAME
+              value: {{ .Values.swift.region | required ".Values.swift.region is required" | quote }}
+            - name: OS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-doop-agent
+                  key: swift_password
+          ports:
+            - name: metrics
+              containerPort: 8080
+          resources:
+            {{- toYaml .Values.analyzer.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: config
+              mountPath: /etc/doop-analyzer
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: {{ .Release.Name }}-analyzer

--- a/gatekeeper-doop/charts/templates/deployment-helm-manifest-parser.yaml
+++ b/gatekeeper-doop/charts/templates/deployment-helm-manifest-parser.yaml
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-helm-manifest-parser
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: helm-manifest-parser
+spec:
+  replicas: {{ .Values.helmManifestParser.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
+  selector:
+    matchLabels:
+      {{- include "gatekeeper-doop.labels" . | nindent 6 }}
+      app.kubernetes.io/component: helm-manifest-parser
+  template:
+    metadata:
+      labels:
+        {{- include "gatekeeper-doop.labels" . | nindent 8 }}
+        app.kubernetes.io/component: helm-manifest-parser
+      annotations:
+        kubectl.kubernetes.io/default-container: helm-manifest-parser
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: helm-manifest-parser
+          image: {{ include "gatekeeper-doop.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["helm-manifest-parser"]
+          args: [":8080"]
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.helmManifestParser.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/gatekeeper-doop/charts/templates/deployment-image-checker.yaml
+++ b/gatekeeper-doop/charts/templates/deployment-image-checker.yaml
@@ -1,0 +1,76 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Release.Name }}-image-checker
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-checker
+spec:
+  replicas: {{ .Values.imageChecker.replicas }}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 2
+  selector:
+    matchLabels:
+      {{- include "gatekeeper-doop.labels" . | nindent 6 }}
+      app.kubernetes.io/component: image-checker
+  template:
+    metadata:
+      labels:
+        {{- include "gatekeeper-doop.labels" . | nindent 8 }}
+        app.kubernetes.io/component: image-checker
+      annotations:
+        kubectl.kubernetes.io/default-container: image-checker
+    spec:
+      automountServiceAccountToken: false
+      enableServiceLinks: false
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+        - name: image-checker
+          image: {{ include "gatekeeper-doop.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["doop-image-checker"]
+          args: [":8080"]
+          env:
+            - name: LOG_ALL_REQUESTS
+              value: "false"
+            - name: REGISTRY_URL
+              value: {{ .Values.imageChecker.registryURL | required ".Values.imageChecker.registryURL is required" | quote }}
+          ports:
+            - name: http
+              containerPort: 8080
+          livenessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            timeoutSeconds: 10
+            periodSeconds: 60
+            initialDelaySeconds: 60
+          readinessProbe:
+            httpGet:
+              path: /healthcheck
+              port: http
+            timeoutSeconds: 5
+            periodSeconds: 5
+          resources:
+            {{- toYaml .Values.imageChecker.resources | nindent 12 }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/gatekeeper-doop/charts/templates/rbac.yaml
+++ b/gatekeeper-doop/charts/templates/rbac.yaml
@@ -1,0 +1,40 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Release.Name }}-doop-agent
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Release.Name }}-doop-agent
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - constraints.gatekeeper.sh
+      - templates.gatekeeper.sh
+    resources:
+      - "*"
+    verbs:
+      - get
+      - list
+      - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Release.Name }}-doop-agent
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Release.Name }}-doop-agent
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Release.Name }}-doop-agent
+    namespace: {{ .Release.Namespace }}

--- a/gatekeeper-doop/charts/templates/secret.yaml
+++ b/gatekeeper-doop/charts/templates/secret.yaml
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ .Release.Name }}-doop-agent
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+type: Opaque
+data:
+  swift_password: {{ .Values.swift.password | required ".Values.swift.password is required" | b64enc | quote }}

--- a/gatekeeper-doop/charts/templates/service-helm-manifest-parser.yaml
+++ b/gatekeeper-doop/charts/templates/service-helm-manifest-parser.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-helm-manifest-parser
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: helm-manifest-parser
+spec:
+  selector:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: helm-manifest-parser
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/gatekeeper-doop/charts/templates/service-image-checker.yaml
+++ b/gatekeeper-doop/charts/templates/service-image-checker.yaml
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Release.Name }}-image-checker
+  labels:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-checker
+spec:
+  selector:
+    {{- include "gatekeeper-doop.labels" . | nindent 4 }}
+    app.kubernetes.io/component: image-checker
+  ports:
+    - name: http
+      port: 80
+      targetPort: http

--- a/gatekeeper-doop/charts/values.yaml
+++ b/gatekeeper-doop/charts/values.yaml
@@ -23,6 +23,7 @@ swift:
 
 analyzer:
   replicas: 1
+  extraMergingRules: []        # appended to the built-in generic merging rules; supply fleet-specific dedup rules here
   resources:
     requests:
       cpu: 50m

--- a/gatekeeper-doop/charts/values.yaml
+++ b/gatekeeper-doop/charts/values.yaml
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+image:
+  repository: ghcr.io/cloudoperators/gatekeeper-addons
+  tag: ""
+  pullPolicy: IfNotPresent
+
+cluster:
+  name: ""
+  layer: ""
+  type: ""
+
+swift:
+  authURL: ""
+  username: ""
+  password: ""
+  userDomain: Default
+  projectName: ""
+  projectDomain: Default
+  region: ""
+  alternateRegion: ""
+
+analyzer:
+  replicas: 1
+  resources:
+    requests:
+      cpu: 50m
+      memory: 64Mi
+    limits:
+      cpu: 50m
+      memory: 64Mi
+
+imageChecker:
+  replicas: 2
+  registryURL: ""
+  resources:
+    requests:
+      cpu: 25m
+      memory: 64Mi
+    limits:
+      cpu: 25m
+      memory: 64Mi
+
+helmManifestParser:
+  replicas: 2
+  resources:
+    requests:
+      cpu: 100m
+      memory: 192Mi
+    limits:
+      cpu: 1000m
+      memory: 192Mi

--- a/gatekeeper-doop/plugindefinition.yaml
+++ b/gatekeeper-doop/plugindefinition.yaml
@@ -35,11 +35,11 @@ spec:
       required: true
       type: string
     - name: cluster.layer
-      description: Cluster layer label (e.g. prod, qa, labs). Reported alongside each violation.
+      description: Cluster layer label (e.g. prod, qa). Reported alongside each violation.
       required: true
       type: string
     - name: cluster.type
-      description: Cluster type label (e.g. baremetal, scaleout, kubernikus). Drives which merging rules apply.
+      description: Cluster type label. Reported alongside each violation.
       required: true
       type: string
     - name: swift.authURL
@@ -92,13 +92,17 @@ spec:
           memory: 64Mi
       required: false
       type: map
+    - name: analyzer.extraMergingRules
+      description: Additional analyzer merging rules appended to the built-in generic set. Each item is a merging-rule object. Use to add fleet-specific deduplication without forking the chart.
+      required: false
+      type: list
     - name: imageChecker.replicas
       description: Number of doop-image-checker replicas.
       default: 2
       required: false
       type: int
     - name: imageChecker.registryURL
-      description: Container registry endpoint that the image-checker queries for image vulnerability and provenance metadata (e.g. a Keppel-compatible URL). Required for the vulnerable-images and outdated-image-bases policies to function.
+      description: Container registry endpoint that the image-checker queries for image vulnerability and provenance metadata. Required for the vulnerable-images and outdated-image-bases policies to function.
       required: true
       type: string
     - name: imageChecker.resources

--- a/gatekeeper-doop/plugindefinition.yaml
+++ b/gatekeeper-doop/plugindefinition.yaml
@@ -1,0 +1,130 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: gatekeeper-doop
+spec:
+  version: 0.1.0
+  displayName: Gatekeeper DOOP
+  description: Per-cluster DOOP components for OPA Gatekeeper. Deploys doop-analyzer (audit aggregation to Swift), doop-image-checker (image vulnerability HTTP service called by Rego policies), and helm-manifest-parser (decodes Helm release Secret blobs for Rego policies). Requires the gatekeeper PluginDefinition to be installed first.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/gatekeeper-doop/README.md
+  icon: https://raw.githubusercontent.com/open-policy-agent/opa/main/logo/logo.png
+  helmChart:
+    name: gatekeeper-doop
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    version: 0.1.0
+  options:
+    - name: image.repository
+      description: Container image repository for the gatekeeper-addons bundle. All three deployments share the same image.
+      default: ghcr.io/cloudoperators/gatekeeper-addons
+      required: false
+      type: string
+    - name: image.tag
+      description: Container image tag. If empty, the chart's appVersion is used.
+      required: false
+      type: string
+    - name: image.pullPolicy
+      description: Image pull policy.
+      default: IfNotPresent
+      required: false
+      type: string
+    - name: cluster.name
+      description: Identifier of the cluster this analyzer instance reports for. Used as the Swift object name and to deduplicate violations that mention the cluster name.
+      required: true
+      type: string
+    - name: cluster.layer
+      description: Cluster layer label (e.g. prod, qa, labs). Reported alongside each violation.
+      required: true
+      type: string
+    - name: cluster.type
+      description: Cluster type label (e.g. baremetal, scaleout, kubernikus). Drives which merging rules apply.
+      required: true
+      type: string
+    - name: swift.authURL
+      description: OpenStack Keystone v3 auth URL.
+      required: true
+      type: string
+    - name: swift.username
+      description: OpenStack username with write access to the Swift container.
+      required: true
+      type: string
+    - name: swift.password
+      description: OpenStack password for the username above. Stored as a Kubernetes Secret.
+      required: true
+      type: secret
+    - name: swift.userDomain
+      description: OpenStack user domain name.
+      default: Default
+      required: false
+      type: string
+    - name: swift.projectName
+      description: OpenStack project that owns the Swift container.
+      required: true
+      type: string
+    - name: swift.projectDomain
+      description: OpenStack project domain name.
+      default: Default
+      required: false
+      type: string
+    - name: swift.region
+      description: OpenStack region for the Swift endpoint. Also used by analyzer merging rules to deduplicate region mentions.
+      required: true
+      type: string
+    - name: swift.alternateRegion
+      description: Optional alternate region used by analyzer merging rules. Defaults to swift.region.
+      required: false
+      type: string
+    - name: analyzer.replicas
+      description: Number of doop-analyzer replicas.
+      default: 1
+      required: false
+      type: int
+    - name: analyzer.resources
+      description: Resource requests and limits for the doop-analyzer container.
+      default:
+        requests:
+          cpu: 50m
+          memory: 64Mi
+        limits:
+          cpu: 50m
+          memory: 64Mi
+      required: false
+      type: map
+    - name: imageChecker.replicas
+      description: Number of doop-image-checker replicas.
+      default: 2
+      required: false
+      type: int
+    - name: imageChecker.registryURL
+      description: Container registry endpoint that the image-checker queries for image vulnerability and provenance metadata (e.g. a Keppel-compatible URL). Required for the vulnerable-images and outdated-image-bases policies to function.
+      required: true
+      type: string
+    - name: imageChecker.resources
+      description: Resource requests and limits for the doop-image-checker container.
+      default:
+        requests:
+          cpu: 25m
+          memory: 64Mi
+        limits:
+          cpu: 25m
+          memory: 64Mi
+      required: false
+      type: map
+    - name: helmManifestParser.replicas
+      description: Number of helm-manifest-parser replicas.
+      default: 2
+      required: false
+      type: int
+    - name: helmManifestParser.resources
+      description: Resource requests and limits for the helm-manifest-parser container.
+      default:
+        requests:
+          cpu: 100m
+          memory: 192Mi
+        limits:
+          cpu: 1000m
+          memory: 192Mi
+      required: false
+      type: map

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -10,6 +10,7 @@ resources:
   - external-dns/plugindefinition.yaml
   - gatekeeper/plugindefinition.yaml
   - gatekeeper-config/plugindefinition.yaml
+  - gatekeeper-doop/plugindefinition.yaml
   - repo-guard/plugindefinition.yaml
   - ingress-nginx/plugindefinition.yaml
   - kafka/plugindefinition.yaml


### PR DESCRIPTION
## Pull Request Details

Add a `gatekeeper-doop` PluginDefinition shipping the per-cluster DOOP components that back the doop-dependent Gatekeeper policies:

- **doop-analyzer** - aggregates Gatekeeper audit results and uploads them to Swift for the central `doop-api` to serve.
- **doop-image-checker** - HTTP service called by Rego policies to fetch image vulnerability / base-image headers
- **helm-manifest-parser** - decodes the `data.release` blob in Helm release Secrets into a JSON manifest for Rego policies.

## Breaking Changes

None.

## Issues Fixed

- Partial progress on [#1420](https://github.com/cloudoperators/greenhouse-extensions/issues/1420)

## Other Relevant Information

Requires the `gatekeeper` PluginDefinition installed first (via `Plugin.spec.waitFor`). This is the service side of the doop-dependent policies added in #1774 (`gatekeeper-config`); those policies stay disabled until these services are available.