### PR TITLE
fix(logs): correct tcp_log/syslog_tls receiver name in syslog TLS pipeline

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.13
+version: 0.4.14
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -44,7 +44,7 @@ syslog/udp:
 {{- end }}
 
 {{- define "syslog_tls.receiver" }}
-tcplog/syslog_tls:
+tcp_log/syslog_tls:
   listen_address: 0.0.0.0:{{ .Values.openTelemetry.externalCollector.syslogTLSConfig.tcp_port }}
   add_attributes: true
   tls:

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.13
+  version: 0.15.14
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -13,7 +13,7 @@ spec:
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.13
+    version: 0.4.14
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

Fix a name mismatch in the external OTEL collector config that causes the `external-collector` pod to crashloop in every cluster where syslog TLS is enabled.

- Rename the receiver defined in `syslog_tls.receiver` from `tcplog/syslog_tls` → `tcp_log/syslog_tls` to match the pipeline reference in `syslog_tls.pipeline` and stay consistent with the sibling `tcp_log/syslog` receiver naming.
- Bump chart version `0.4.13` → `0.4.14`.
- Bump plugin definition version `0.15.13` → `0.15.14`.

