### PR TITLE
fix(audit-logs): decouple prometheus labels from rules.create

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.1.4
+version: 0.1.5
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/_helpers.tpl
+++ b/audit-logs/charts/templates/_helpers.tpl
@@ -15,10 +15,10 @@ plugindefinition: audit-logs
 
 {{/* Generate prometheus specific labels */}}
 {{- define "plugin.prometheusLabels" }}
-{{- if and .Values.auditLogs.prometheus.rules.create .Values.auditLogs.prometheus.additionalLabels }}
+{{- if .Values.auditLogs.prometheus.additionalLabels }}
 {{- tpl (toYaml .Values.auditLogs.prometheus.additionalLabels) . }}
 {{- end }}
-{{- if and .Values.auditLogs.prometheus.rules.create .Values.auditLogs.prometheus.rules.labels }}
+{{- if .Values.auditLogs.prometheus.rules.labels }}
 {{ tpl (toYaml .Values.auditLogs.prometheus.rules.labels) . }}
 {{- end }}
 {{- end }}

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.1.4
+    version: 0.1.5
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.4
+        version: 0.1.5
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
## Summary

The `plugin.prometheusLabels` helper in the audit-logs chart gates `auditLogs.prometheus.additionalLabels` (and `auditLogs.prometheus.rules.labels`) on `auditLogs.prometheus.rules.create`:

```gotemplate
{{- if and .Values.auditLogs.prometheus.rules.create .Values.auditLogs.prometheus.additionalLabels }}
{{- tpl (toYaml .Values.auditLogs.prometheus.additionalLabels) . }}
{{- end }}
```

Because this helper is also invoked from `pmon-filelog.yaml`, `pmon-ingester.yaml`, and `smon.yaml`, disabling PrometheusRule creation silently strips the `additionalLabels` from the `PodMonitor` / `ServiceMonitor` too — even though these labels have nothing to do with rules.
