### PR TITLE
feat(thanos): enable gRPC server TLS on ThanosRuler

### DIFF
--- a/thanos/charts/Chart.lock
+++ b/thanos/charts/Chart.lock
@@ -3,4 +3,4 @@ dependencies:
   repository: https://thanos-community.github.io/helm-charts/
   version: 0.23.1
 digest: sha256:44f062d84fcc7c22abbaf351c47e340c92c2b694bac7b9b42780f414b8952f62
-generated: "2026-07-02T09:44:27.819644+02:00"
+generated: "2026-07-15T11:05:23.376+02:00"

--- a/thanos/charts/Chart.yaml
+++ b/thanos/charts/Chart.yaml
@@ -11,7 +11,7 @@ maintainers:
 name: thanos
 sources:
   - https://github.com/cloudoperators/greenhouse-extensions
-version: 0.11.0
+version: 0.12.0
 dependencies:
   - name: thanos
     repository: https://thanos-community.github.io/helm-charts/

--- a/thanos/charts/templates/query/deployment.yaml
+++ b/thanos/charts/templates/query/deployment.yaml
@@ -60,6 +60,9 @@ spec:
         - --grpc-client-tls-cert=/etc/tls/client/tls.crt
         - --grpc-client-tls-key=/etc/tls/client/tls.key
         - --grpc-client-tls-secure
+        {{- if .Values.thanos.ruler.grpcTlsSecretName }}
+        - --grpc-client-tls-skip-verify
+        {{- end }}
         {{- end }}
         image: "{{ .Values.thanos.image.repository }}:{{ .Values.thanos.image.tag }}"
         imagePullPolicy: {{ default "IfNotPresent" .Values.thanos.image.pullPolicy }}

--- a/thanos/charts/templates/ruler/ruler.yaml
+++ b/thanos/charts/templates/ruler/ruler.yaml
@@ -91,7 +91,6 @@ spec:
     key: alertManagerConfig.yaml # Key name for Alertmanager config YAML
     name: thanos-ruler-{{ include "release.name" . }}-alertmanager-config # Secret name containing Alertmanager config
   {{- end }}
-  {{- /* containers and volumes must be a single block — merge all mounts here */}}
   {{- if or (and .Values.thanos.ruler.alertmanagers.authentication.enabled .Values.thanos.ruler.alertmanagers.enabled) .Values.thanos.ruler.grpcTlsSecretName }}
   containers:
     - name: thanos-ruler

--- a/thanos/charts/templates/ruler/ruler.yaml
+++ b/thanos/charts/templates/ruler/ruler.yaml
@@ -91,16 +91,36 @@ spec:
     key: alertManagerConfig.yaml # Key name for Alertmanager config YAML
     name: thanos-ruler-{{ include "release.name" . }}-alertmanager-config # Secret name containing Alertmanager config
   {{- end }}
-  {{- if and .Values.thanos.ruler.alertmanagers.authentication.enabled .Values.thanos.ruler.alertmanagers.enabled }}
+  {{- /* containers and volumes must be a single block — merge all mounts here */}}
+  {{- if or (and .Values.thanos.ruler.alertmanagers.authentication.enabled .Values.thanos.ruler.alertmanagers.enabled) .Values.thanos.ruler.grpcTlsSecretName }}
   containers:
     - name: thanos-ruler
       volumeMounts:
+        {{- if and .Values.thanos.ruler.alertmanagers.authentication.enabled .Values.thanos.ruler.alertmanagers.enabled }}
         - mountPath: /etc/thanos/secrets/thanos-ruler-{{ include "release.name" . }}-alertmanager-sso-cert
           name: thanos-ruler-{{ include "release.name" . }}-alertmanager-sso-cert
           readOnly: true
+        {{- end }}
+        {{- if .Values.thanos.ruler.grpcTlsSecretName }}
+        - mountPath: /etc/thanos/grpc-server-tls
+          name: grpc-server-tls
+          readOnly: true
+        {{- end }}
   volumes:
+    {{- if and .Values.thanos.ruler.alertmanagers.authentication.enabled .Values.thanos.ruler.alertmanagers.enabled }}
     - name: thanos-ruler-{{ include "release.name" . }}-alertmanager-sso-cert
       secret:
         secretName: thanos-ruler-{{ include "release.name" . }}-alertmanager-sso-cert
+    {{- end }}
+    {{- if .Values.thanos.ruler.grpcTlsSecretName }}
+    - name: grpc-server-tls
+      secret:
+        secretName: {{ .Values.thanos.ruler.grpcTlsSecretName }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.thanos.ruler.grpcTlsSecretName }}
+  grpcServerTlsConfig:
+    certFile: /etc/thanos/grpc-server-tls/tls.crt
+    keyFile: /etc/thanos/grpc-server-tls/tls.key
   {{- end }}
 {{- end }}

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -409,7 +409,6 @@ thanos:
         # key: object-storage-configs.yaml
 
     # -- Name of the Secret containing tls.crt and tls.key to enable TLS on the ruler gRPC port (10901).
-    # When set, also adds --grpc-client-tls-skip-verify to the query so it can connect to the ruler.
     grpcTlsSecretName: ""
 
     # -- Resource requests and limits for the Thanos Ruler container.

--- a/thanos/charts/values.yaml
+++ b/thanos/charts/values.yaml
@@ -408,6 +408,10 @@ thanos:
         # name: kube-monitoring-prometheus
         # key: object-storage-configs.yaml
 
+    # -- Name of the Secret containing tls.crt and tls.key to enable TLS on the ruler gRPC port (10901).
+    # When set, also adds --grpc-client-tls-skip-verify to the query so it can connect to the ruler.
+    grpcTlsSecretName: ""
+
     # -- Resource requests and limits for the Thanos Ruler container.
     resources: {}
 

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -219,3 +219,7 @@ spec:
       default: {}
       required: false
       type: map
+    - name: thanos.ruler.grpcTlsSecretName
+      description: Name of the Secret containing tls.crt and tls.key to enable TLS on the ruler gRPC port (10901). When set, also adds --grpc-client-tls-skip-verify to the query.
+      required: false
+      type: string

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -220,6 +220,5 @@ spec:
       required: false
       type: map
     - name: thanos.ruler.grpcTlsSecretName
-      description: Name of the Secret containing tls.crt and tls.key to enable TLS on the ruler gRPC port (10901). When set, also adds --grpc-client-tls-skip-verify to the query.
       required: false
       type: string

--- a/thanos/plugindefinition.yaml
+++ b/thanos/plugindefinition.yaml
@@ -6,12 +6,12 @@ kind: PluginDefinition
 metadata:
   name: thanos
 spec:
-  version: 0.11.0
+  version: 0.12.0
   description: thanos
   helmChart:
     name: thanos
     repository: "oci://ghcr.io/cloudoperators/greenhouse-extensions/charts"
-    version: 0.11.0
+    version: 0.12.0
   options:
     - default: null
       description: CLI param for Thanos Query


### PR DESCRIPTION


## Problem

`thanos-regional-query` uses `--grpc-client-tls-secure` globally. The `ThanosRuler` serves plain gRPC on port 10901 by default, causing a TLS handshake failure and the ruler never appearing as a store endpoint in the Thanos Query UI.

## Solution

Mount an existing TLS Secret (e.g. `thanos-regional-tls`) onto the ruler pod and configure `grpcServerTlsConfig` to use it. The query's `--grpc-client-tls-skip-verify` flag is added conditionally to bypass SAN verification for in-cluster connections.

