### PR TITLE
Fix/fortlogs alert labels

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.13
+version: 0.2.14
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -5,13 +5,14 @@ groups:
     rules:
       - alert: OpenSearchClusterRed
         expr: |
-          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
+          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
           /
-          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
+          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
           == 2
         for: 5m
         labels:
           severity: info # critical
+          component: opensearch
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterRed.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
@@ -20,13 +21,14 @@ groups:
 
       - alert: OpenSearchClusterYellow
         expr: |
-          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
+          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
           /
-          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status))
+          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
           == 1
         for: 120m
         labels:
           severity: info # warning
+          component: opensearch
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchClusterYellow.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
@@ -34,10 +36,11 @@ groups:
           description: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
 
       - alert: OpenSearchDiskSpaceRunningLow
-        expr: predict_linear(opensearch_fs_total_free_bytes[24h], 24*3600) < 0
+        expr: predict_linear(opensearch_fs_total_free_bytes{namespace="{{ .Release.Namespace }}"}[24h], 24*3600) < 0
         for: 1h
         labels:
           severity: info # critical
+          component: opensearch
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighDiskUsage.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
@@ -45,10 +48,11 @@ groups:
           description: "OpenSearch node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is predicted to run out of disk space within 24 hours"
 
       - alert: OpenSearchIndexSizeTooLarge
-        expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{context="primaries", index=~".ds.*"}[15m]) > 1)
+        expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"}[15m]) > 1)
         for: 30m
         labels:
           severity: info # warning
+          component: opensearch
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchIndexTooLarge.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:

--- a/opensearch/chart/alerts/opensearch-guardian.yaml
+++ b/opensearch/chart/alerts/opensearch-guardian.yaml
@@ -3,7 +3,7 @@ groups:
     interval: 30s
     rules:
       - alert: OpenSearchGuardianNoncompliant
-        expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="noncompliant"} > 0
+        expr: opensearch_guardian_status{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}", status="noncompliant"} > 0
         for: 10m
         labels:
           severity: info # critical
@@ -14,7 +14,7 @@ groups:
           summary: "OpenSearch is NONCOMPLIANT"
           description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has been NONCOMPLIANT for more than 10 minutes"
       - alert: OpenSearchGuardianEmpty
-        expr: opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="empty"} > 0
+        expr: opensearch_guardian_status{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}", status="empty"} > 0
         for: 10m
         labels:
           severity: info # critical
@@ -25,7 +25,7 @@ groups:
           summary: "OpenSearch has empty Guardian status"
           description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} has empty Guardian status for more than 10 minutes"
       - alert: OpenSearchGuardianErrors                                                                                                                                            
-        expr: increase(opensearch_guardian_errors_total{cluster="{{ .Values.cluster.cluster.name }}"}[10m]) > 0                                                                    
+        expr: increase(opensearch_guardian_errors_total{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}"}[10m]) > 0                                                                    
         for: 0m                                                                                                                                                                    
         labels:                                                                                                                                                                    
           severity: info # critical                                                                                                                                                           
@@ -36,7 +36,7 @@ groups:
           summary: "OpenSearch Guardian errors detected"                                                                                                                           
           description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} reported Guardian errors in the last 10 minutes"
       - alert: OpenSearchGuardianStatusStale                                                                                                                                            
-        expr: (time() - opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
+        expr: (time() - opensearch_guardian_status{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
         for: 0m                                                                                                                                                                    
         labels:                                                                                                                                                                    
           severity: info # critical                                                                                                                                                           

--- a/opensearch/chart/alerts/opensearch-guardian.yaml
+++ b/opensearch/chart/alerts/opensearch-guardian.yaml
@@ -36,7 +36,7 @@ groups:
           summary: "OpenSearch Guardian errors detected"                                                                                                                           
           description: "OpenSearch in namespace {{`{{ $labels.namespace }}`}} reported Guardian errors in the last 10 minutes"
       - alert: OpenSearchGuardianStatusStale                                                                                                                                            
-        expr: (time() - opensearch_guardian_status{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
+        expr: (time() - opensearch_guardian_status{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} / 1000) > 420 and opensearch_guardian_status{namespace="{{ .Release.Namespace }}", cluster="{{ .Values.cluster.cluster.name }}", status="compliant"} > 0
         for: 0m                                                                                                                                                                    
         labels:                                                                                                                                                                    
           severity: info # critical                                                                                                                                                           

--- a/opensearch/chart/alerts/opensearch-operator.yaml
+++ b/opensearch/chart/alerts/opensearch-operator.yaml
@@ -3,7 +3,7 @@ groups:
     interval: 30s
     rules:
       - alert: OpenSearchOperatorDown
-        expr: up{job=~".*opensearch-operator.*"} == 0
+        expr: up{job=~".*opensearch-operator.*", namespace="{{ .Release.Namespace }}"} == 0
         for: 10m
         labels:
           severity: info # critical

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.13
+  version: 0.2.14
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.13
+    version: 0.2.14
   options:
     - name: queryExporter.enabled
       description: "Enable the OpenSearch query exporter for custom Prometheus metrics from OpenSearch queries"


### PR DESCRIPTION
## Pull Request Details                                                                                                                                                              
                                                                                                                                                                               
  - Scope all Prometheus alert rule expressions to `namespace="{{ .Release.Namespace }}"` to prevent cross-namespace metric pollution                                          
  - Add `component: opensearch` label to cluster alert rules for consistent label taxonomy                                                                                     
  - Bump chart version `0.2.13` → `0.2.14`                                                                                                                                     
                                                                                                                                                                               
  ## Changes                                                                                                                                                                   
                                                                                                                                                                               
  | File | What changed |                                                                                                                                                      
  |------|-------------|
  | `opensearch-cluster.yaml` | Namespace filter on 4 alert exprs + `component: opensearch` label |                                                                            
  | `opensearch-guardian.yaml` | Namespace filter on 4 alert exprs |                                                                                                           
  | `opensearch-operator.yaml` | Namespace filter on 1 alert expr |                                                                                                            
  | `Chart.yaml`, `plugindefinition.yaml` | Version bump |                                                                                                                     
                                                                                                                                                                               
  ## Test plan                                                                                                                                                                 
                                                                                                                                                                               
  - [ ] Deploy chart to test namespace; verify alerts fire only for metrics in that namespace                                                                                  
  - [ ] Confirm `component: opensearch` label appears on cluster alerts
  - [ ] Verify no regression on existing alert routing rules
