### PR TITLE
[logs] remove duplicate pipeline

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.18
+version: 0.4.19
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_ceph-config.tpl
+++ b/logs/charts/templates/_ceph-config.tpl
@@ -134,6 +134,6 @@ transform/ceph_prysm_sidecar:
 {{- define "ceph.pipeline" }}
 logs/ceph:
   receivers: [file_log/containerd]
-  processors: [k8s_attributes, attributes/cluster, transform/ingress, transform/ceph_rgw, transform/ceph_osd, transform/ceph_prysm_sidecar]
+  processors: [k8s_attributes, attributes/cluster, filter/rgw, transform/ingress, transform/ceph_rgw, transform/ceph_osd, transform/ceph_prysm_sidecar]
   exporters: [routing]
 {{- end }}

--- a/logs/charts/templates/_containerd-config.tpl
+++ b/logs/charts/templates/_containerd-config.tpl
@@ -64,6 +64,6 @@ transform/perses:
 {{- define "containerd.pipeline" }}
 logs/containerd:
   receivers: [file_log/containerd]
-  processors: [k8s_attributes, attributes/cluster{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}, filter/rgw{{- end }}, transform/ingress, transform/protocol, transform/perses]
+  processors: [k8s_attributes, attributes/cluster, transform/ingress, transform/protocol, transform/perses]
   exporters: [routing]
 {{- end }}

--- a/logs/charts/templates/_openstack-config.tpl
+++ b/logs/charts/templates/_openstack-config.tpl
@@ -166,13 +166,6 @@ filter/hermes_logstash:
     log_record:
       - 'IsMatch(body, ".*Authorization: Basic.*")'
 
-{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}
-filter/rgw:
-  error_mode: ignore
-  logs:
-    log_record:
-      - 'resource.attributes["k8s.container.name"] == "rgw"'
-{{- end }}
 
 transform/swift_proxy:
   error_mode: ignore

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -466,7 +466,7 @@ spec:
 {{- if .Values.openTelemetry.logsCollector.k8seventsConfig.enabled }}
     {{- include "k8sevents.pipeline" . | nindent 8 -}}
 {{- end }}
-{{- if and .Values.openTelemetry.logsCollector.containerdConfig.enabled .Values.openTelemetry.logsCollector.openstackConfig.enabled }}
+{{- if and .Values.openTelemetry.logsCollector.containerdConfig.enabled .Values.openTelemetry.logsCollector.openstackConfig.enabled (not .Values.openTelemetry.logsCollector.cephConfig.enabled) }}
     {{- include "openstack.pipeline" . | nindent 8 -}}
 {{- else if and .Values.openTelemetry.logsCollector.containerdConfig.enabled (not .Values.openTelemetry.logsCollector.cephConfig.enabled) }}
     {{- include "containerd.pipeline" . | nindent 8 -}}
@@ -474,7 +474,7 @@ spec:
 {{- if .Values.openTelemetry.logsCollector.kvmConfig.enabled }}
     {{- include "kvm.pipeline" . | nindent 8 -}}
 {{- end }}
-{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
     {{- include "ceph.pipeline" . | nindent 8 -}}
 {{- end }}
 {{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled }}

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -468,7 +468,7 @@ spec:
 {{- end }}
 {{- if and .Values.openTelemetry.logsCollector.containerdConfig.enabled .Values.openTelemetry.logsCollector.openstackConfig.enabled }}
     {{- include "openstack.pipeline" . | nindent 8 -}}
-{{- else if .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
+{{- else if and .Values.openTelemetry.logsCollector.containerdConfig.enabled (not .Values.openTelemetry.logsCollector.cephConfig.enabled) }}
     {{- include "containerd.pipeline" . | nindent 8 -}}
 {{- end }}
 {{- if .Values.openTelemetry.logsCollector.kvmConfig.enabled }}

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -137,7 +137,7 @@ spec:
 {{- if .Values.openTelemetry.logsCollector.k8seventsConfig.enabled }}
     {{- include "k8sevents.transform" . | nindent 6 -}}
 {{- end }}
-{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
     {{- include "ceph.transform" . | nindent 6 -}}
 {{- end }}
 {{- if .Values.openTelemetry.logsCollector.kvmConfig.enabled }}
@@ -206,7 +206,7 @@ spec:
             - tag_name: app.label.release
               key: release
               from: pod
-{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
     {{- include "ceph.labels" . | nindent 12 -}}
 {{- end }}
         pod_association:
@@ -319,7 +319,7 @@ spec:
           max_interval: 5s
           max_elapsed_time: 30s
         timeout: 30s
-{{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled (and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled) }}
     {{- include "openstack.exporter" . | nindent 6 -}}
 {{- end }}
 {{- end }}
@@ -341,9 +341,9 @@ spec:
     connectors:
       routing:
         default_pipelines:
-{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
           - logs/route_storage
-{{- else }}
+{{- else if .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
           - logs/route_default
 {{- end }}
         error_mode: ignore
@@ -379,7 +379,7 @@ spec:
           num_consumers: 2
           queue_size: 1000
           sizer: requests
-{{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled (and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled) }}
       failover/opensearch_storage:
         priority_levels:
           - [logs/failover_a_storage]
@@ -477,7 +477,7 @@ spec:
 {{- if and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled }}
     {{- include "ceph.pipeline" . | nindent 8 -}}
 {{- end }}
-{{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled .Values.openTelemetry.logsCollector.cephConfig.enabled }}
+{{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled (and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled) }}
         logs/route_storage:
           receivers: [routing]
           processors: [transform/fix_log_attribute, batch]

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.18
+  version: 0.15.19
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.18
+    version: 0.4.19
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
 PR #1828 — [logs] remove duplicate pipeline

  Overview

  Fixes a configuration bug where enabling both cephConfig and containerdConfig would produce two pipelines (logs/ceph and logs/containerd) both consuming file_log/containerd, causing duplicate log
  ingestion. Also resolves a duplicate filter/rgw processor definition that could render an invalid collector config when both openstack and ceph were enabled.

  What the PR does

  - logs/containerd suppressed when cephConfig.enabled — ceph.pipeline takes over as the sole container log pipeline
  - logs/openstack suppressed when cephConfig.enabled — prevents a third possible duplicate
  - All ceph-related sections gated on containerdConfig.enabled — prevents dangling routing config when containerd receiver is absent
  - filter/rgw consolidated — removed from openstack.transform, now lives only in ceph.transform; added to ceph.pipeline processors
  - containerd.pipeline cleaned up — removed the now-unnecessary conditional filter/rgw reference

  Code quality

  - Logic is correct and consistent — all 9 occurrences of cephConfig.enabled in logs-collector.yaml are now properly paired with containerdConfig.enabled
  - The (not ...) construct in Helm and/or conditions is idiomatic and works correctly
  - Blank line left after removing filter/rgw block in _openstack-config.tpl (minor nit)

