### PR TITLE
fix(logs): correct filter/rgw placement across all ingest pipelines

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.18
+version: 0.4.19
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_ceph-config.tpl
+++ b/logs/charts/templates/_ceph-config.tpl
@@ -134,6 +134,6 @@ transform/ceph_prysm_sidecar:
 {{- define "ceph.pipeline" }}
 logs/ceph:
   receivers: [file_log/containerd]
-  processors: [k8s_attributes, attributes/cluster, transform/ingress, transform/ceph_rgw, transform/ceph_osd, transform/ceph_prysm_sidecar]
+  processors: [k8s_attributes, attributes/cluster, filter/rgw, transform/ingress, transform/ceph_rgw, transform/ceph_osd, transform/ceph_prysm_sidecar]
   exporters: [routing]
 {{- end }}

--- a/logs/charts/templates/_openstack-config.tpl
+++ b/logs/charts/templates/_openstack-config.tpl
@@ -166,14 +166,6 @@ filter/hermes_logstash:
     log_record:
       - 'IsMatch(body, ".*Authorization: Basic.*")'
 
-{{- if .Values.openTelemetry.logsCollector.cephConfig.enabled }}
-filter/rgw:
-  error_mode: ignore
-  logs:
-    log_record:
-      - 'resource.attributes["k8s.container.name"] == "rgw"'
-{{- end }}
-
 transform/swift_proxy:
   error_mode: ignore
   log_statements:

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.18
+  version: 0.15.19
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.18
+    version: 0.4.19
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

Two related corrections to how `filter/rgw` is defined and applied. Both stem from #1824 having moved the filter without fully aligning the state across the ingest pipelines.

### 1. Remove duplicate `filter/rgw` definition (CI unblock)

`filter/rgw` was defined in two template partials, so when both `cephConfig.enabled` and `openstackConfig.enabled` are `true` — which is exactly what [`logs/charts/ci/test-values.yaml`](../blob/main/logs/charts/ci/test-values.yaml) sets — both blocks render into the same `logs-collector` OTEL config and Helm's post-render bails out:

```
Helm install failed for release default/logs with chart logs@0.4.18:
error while running post render on files:
yaml: unmarshal errors:
  line 361: mapping key "filter/rgw" already defined at line 314
```

This has been blocking `e2e-flux-helm` on every subsequent `logs/` chart PR (e.g. #1820).

**Root cause**: #1818 originally introduced `filter/rgw` in [`_openstack-config.tpl`](../blob/main/logs/charts/templates/_openstack-config.tpl). #1824 moved the ceph-rgw filtering into the containerd pipeline and added a second `filter/rgw` block to [`_ceph-config.tpl`](../blob/main/logs/charts/templates/_ceph-config.tpl) inside `{{- define "ceph.transform" }}`, but the copy in `_openstack-config.tpl` was not removed. #1824 was merged despite its own `e2e-flux-helm` already failing with the exact same duplicate-key error.

**Fix**: drop the duplicate block from `_openstack-config.tpl`. The definition in `ceph.transform` is the canonical one (rendered whenever `cephConfig.enabled`, matching the guard the openstack copy already used), and the openstack pipeline continues to reference `filter/rgw` from the single remaining definition.

### 2. Apply `filter/rgw` to `logs/ceph` too

#1824 moved `filter/rgw` from `logs/ceph` to `logs/containerd` but did not re-add it to `logs/ceph`, so the RGW daemon log stream still flows through the dedicated ceph pipeline unfiltered.

On a live storage cluster (`st1-eu-de-1`) a single `rgw` container emits **~860 lines/second** of ceph-internal debug noise (`====== req done ======`, `osd_op_reply(...)`, `-- N.N.N.N/... <== osd.X ...`), and `rook-ceph-rgw` runs many replicas per cluster — ingesting that stream into OpenSearch is not viable.

`filter/rgw` was already applied to `logs/containerd` (#1824) and `logs/openstack` (#1818) with the same intent. This PR adds it to `logs/ceph` so the drop is consistent across every pipeline whose receiver is `file_log/containerd`.

Placement matches the existing pattern in both other pipelines: after `attributes/cluster` (which depends on `k8s_attributes` having populated the resource attributes) and before any transform.

**Side effect**: `transform/ceph_rgw` becomes unreachable, since its only input (rgw container logs) is now dropped upstream. Left in place in this PR; a follow-up can remove it once the drop is confirmed intentional in review.

## Verification

Rendered locally against the CI test values:

```
$ helm template logs ./logs/charts -f logs/charts/ci/test-values.yaml
# exit 0
```

- Strict YAML load of the rendered output: **no duplicate keys anywhere** (38 docs parsed cleanly).
- `filter/rgw:` now appears **exactly once** in the rendered output (was twice on \`main\`).
- All three pipelines that share the `file_log/containerd` receiver now reference `filter/rgw`:
  - `logs/containerd`: `[k8s_attributes, attributes/cluster, ..., filter/rgw, ...]` (from #1824, unchanged)
  - `logs/openstack`: `[..., filter/hermes_logstash, filter/rgw, transform/swift_proxy, ...]` (from #1818, unchanged)
  - `logs/ceph`: `[k8s_attributes, attributes/cluster, filter/rgw, transform/ingress, transform/ceph_rgw, ...]` (new in this PR)

## Impact on running clusters

None expected today. Live storage clusters (e.g. `st1-eu-de-1`) run with `openstackConfig.enabled: false`, so the duplicate-key rendering error was CI-only. Adding `filter/rgw` to `logs/ceph` changes behavior on ceph-enabled clusters — high-volume RGW debug logs will stop reaching OpenSearch. That is the intended behavior.