### PR TITLE
fix(opensearch): use min_primary_shard_size for rollover

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.14
+version: 0.2.15
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/files/snapshot-lifecycle/ds-ism-policy.json.tpl
+++ b/opensearch/chart/files/snapshot-lifecycle/ds-ism-policy.json.tpl
@@ -7,24 +7,6 @@
     "states": [
       {
         "name": "initial",
-        "actions": [],
-        "transitions": [
-          {
-            "state_name": "rollover",
-            "conditions": {
-              "min_index_age": "{{ .stream.retention.local }}"
-            }
-          },
-          {
-            "state_name": "rollover",
-            "conditions": {
-              "min_primary_shard_size": "{{ .stream.minPrimaryShardSize }}"
-            }
-          }
-        ]
-      },
-      {
-        "name": "rollover",
         "actions": [
           {
             "retry": {
@@ -33,8 +15,13 @@
               "delay": "1m"
             },
             "rollover": {
-              "min_doc_count": 5,
-              "min_index_age": "1d",
+{{- if .stream.minPrimaryShardSize }}
+              "min_primary_shard_size": "{{ .stream.minPrimaryShardSize }}",
+{{- else }}
+              "min_size": "{{ .stream.minSize }}",
+{{- end }}
+              "min_index_age": "{{ .stream.retention.local }}",
+              "prevent_empty_rollover": true,
               "copy_alias": false
             }
           }

--- a/opensearch/chart/files/snapshot-lifecycle/ds-ism-policy.json.tpl
+++ b/opensearch/chart/files/snapshot-lifecycle/ds-ism-policy.json.tpl
@@ -18,7 +18,7 @@
           {
             "state_name": "rollover",
             "conditions": {
-              "min_size": "{{ .stream.minSize }}"
+              "min_primary_shard_size": "{{ .stream.minPrimaryShardSize }}"
             }
           }
         ]

--- a/opensearch/chart/templates/snapshot-lifecycle.yaml
+++ b/opensearch/chart/templates/snapshot-lifecycle.yaml
@@ -82,7 +82,7 @@ volumes:
 {{- range $stream := $cfg.streams }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].name is required" $stream.name) $stream.name }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].repository is required" $stream.name) $stream.repository }}
-  {{- $_ := required (printf "snapshotLifecycle.streams[%s].minPrimaryShardSize is required" $stream.name) $stream.minPrimaryShardSize }}
+  {{- $_ := required (printf "snapshotLifecycle.streams[%s]: one of minPrimaryShardSize or minSize is required" $stream.name) (or $stream.minPrimaryShardSize $stream.minSize) }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].indexPatterns is required" $stream.name) $stream.indexPatterns }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].indexPatterns.hot is required" $stream.name) $stream.indexPatterns.hot }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].indexPatterns.remote is required" $stream.name) $stream.indexPatterns.remote }}

--- a/opensearch/chart/templates/snapshot-lifecycle.yaml
+++ b/opensearch/chart/templates/snapshot-lifecycle.yaml
@@ -82,7 +82,7 @@ volumes:
 {{- range $stream := $cfg.streams }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].name is required" $stream.name) $stream.name }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].repository is required" $stream.name) $stream.repository }}
-  {{- $_ := required (printf "snapshotLifecycle.streams[%s].minSize is required" $stream.name) $stream.minSize }}
+  {{- $_ := required (printf "snapshotLifecycle.streams[%s].minPrimaryShardSize is required" $stream.name) $stream.minPrimaryShardSize }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].indexPatterns is required" $stream.name) $stream.indexPatterns }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].indexPatterns.hot is required" $stream.name) $stream.indexPatterns.hot }}
   {{- $_ := required (printf "snapshotLifecycle.streams[%s].indexPatterns.remote is required" $stream.name) $stream.indexPatterns.remote }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -941,6 +941,8 @@ cluster:
     #   # Optional override for the convert_index_to_remote rename_pattern.
     #   # Default is `remote_{name}_$1`.
     #   # renamePattern: "remote_my-stream_$1"
+    #   # Rollover trigger: one of minPrimaryShardSize (largest single primary
+    #   # shard) or minSize (total primary storage).
     #   minPrimaryShardSize: "40gb"
     #   retention:
     #     local: "7d"

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -941,7 +941,7 @@ cluster:
     #   # Optional override for the convert_index_to_remote rename_pattern.
     #   # Default is `remote_{name}_$1`.
     #   # renamePattern: "remote_my-stream_$1"
-    #   minSize: "50gb"
+    #   minPrimaryShardSize: "40gb"
     #   retention:
     #     local: "7d"
     #     remote: "31d"

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.14
+  version: 0.2.15
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.14
+    version: 0.2.15
   options:
     - name: queryExporter.enabled
       description: "Enable the OpenSearch query exporter for custom Prometheus metrics from OpenSearch queries"


### PR DESCRIPTION
## Pull Request Details

Switch the datastream rollover condition from `min_size` (total primary storage) to `min_primary_shard_size` (largest single primary shard). `min_size` triggers on the sum across all shards, so under skewed routing one hot shard can grow very large while the total stays under the threshold, the rollover fires too late and leaves a single oversized shard. `min_primary_shard_size` caps the largest shard directly, so no individual shard can balloon regardless of balance.
