### PR TITLE
feat(logs): tune external syslog kafka producer throughput

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -146,9 +146,9 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.kafka.enabled | bool | `false` | Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering) |
 | openTelemetry.kafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw) |
 | openTelemetry.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
-| openTelemetry.kafka.producer | object | `{"flushMaxMessages":10000,"linger":"100ms"}` | Producer batching (raise linger to build larger batches per broker request) |
+| openTelemetry.kafka.producer | object | `{"flushMaxMessages":10000,"linger":"10ms"}` | Producer batching (raise linger to build larger batches per broker request) |
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
-| openTelemetry.kafka.sendingQueue | object | `{"queueSize":10000}` | Producer sending queue size |
+| openTelemetry.kafka.sendingQueue | object | `{"queueSize":1000}` | Producer sending queue size |
 | openTelemetry.kafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
 | openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.batch | object | `{"sendBatchMaxSize":5000,"sendBatchSize":100,"timeout":"30s"}` | Batch processor settings for the logs collector. |

--- a/logs/README.md
+++ b/logs/README.md
@@ -148,7 +148,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
 | openTelemetry.kafka.producer | object | `{"flushMaxMessages":10000,"linger":"10ms"}` | Producer batching (raise linger to build larger batches per broker request) |
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
-| openTelemetry.kafka.sendingQueue | object | `{"queueSize":1000}` | Producer sending queue size |
+| openTelemetry.kafka.sendingQueue | object | `{"enabled":true,"queueSize":1000}` | Producer sending queue size |
 | openTelemetry.kafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
 | openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.batch | object | `{"sendBatchMaxSize":5000,"sendBatchSize":100,"timeout":"30s"}` | Batch processor settings for the logs collector. |

--- a/logs/README.md
+++ b/logs/README.md
@@ -140,13 +140,15 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.ingesterCollector.prometheus.podMonitor.enabled | bool | `true` | Render a PodMonitor per enabled ingest collector. |
 | openTelemetry.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
 | openTelemetry.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
-| openTelemetry.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"protocol_version":"","tls":{"enabled":false}}` | Kafka exporter configuration shared by all collectors |
+| openTelemetry.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"producer":{"flushMaxMessages":10000,"linger":"100ms"},"protocol_version":"","sendingQueue":{"queueSize":10000},"tls":{"enabled":false}}` | Kafka exporter configuration shared by all collectors |
 | openTelemetry.kafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
 | openTelemetry.kafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
 | openTelemetry.kafka.enabled | bool | `false` | Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering) |
 | openTelemetry.kafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw) |
 | openTelemetry.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
+| openTelemetry.kafka.producer | object | `{"flushMaxMessages":10000,"linger":"100ms"}` | Producer batching (raise linger to build larger batches per broker request) |
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
+| openTelemetry.kafka.sendingQueue | object | `{"queueSize":10000}` | Producer sending queue size |
 | openTelemetry.kafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
 | openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.batch | object | `{"sendBatchMaxSize":5000,"sendBatchSize":100,"timeout":"30s"}` | Batch processor settings for the logs collector. |

--- a/logs/README.md
+++ b/logs/README.md
@@ -140,7 +140,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.ingesterCollector.prometheus.podMonitor.enabled | bool | `true` | Render a PodMonitor per enabled ingest collector. |
 | openTelemetry.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
 | openTelemetry.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
-| openTelemetry.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"producer":{"flushMaxMessages":10000,"linger":"100ms"},"protocol_version":"","sendingQueue":{"queueSize":10000},"tls":{"enabled":false}}` | Kafka exporter configuration shared by all collectors |
+| openTelemetry.kafka | object | See values.yaml | Kafka exporter configuration shared by all collectors |
 | openTelemetry.kafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
 | openTelemetry.kafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
 | openTelemetry.kafka.enabled | bool | `false` | Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering) |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.21
+version: 0.4.22
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -339,9 +339,9 @@ kafka/syslog_audit:
     compression: {{ .Values.openTelemetry.kafka.compression }}
     max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
     flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
-    linger: {{ dig "producer" "linger" "100ms" .Values.openTelemetry.kafka | quote }}
+    linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
   sending_queue:
-    queue_size: {{ dig "sendingQueue" "queueSize" 10000 .Values.openTelemetry.kafka | int64 }}
+    queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false
@@ -359,9 +359,9 @@ kafka/syslog_non_audit:
     compression: {{ .Values.openTelemetry.kafka.compression }}
     max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
     flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
-    linger: {{ dig "producer" "linger" "100ms" .Values.openTelemetry.kafka | quote }}
+    linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
   sending_queue:
-    queue_size: {{ dig "sendingQueue" "queueSize" 10000 .Values.openTelemetry.kafka | int64 }}
+    queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -337,6 +337,11 @@ kafka/syslog_audit:
     encoding: {{ .Values.openTelemetry.kafka.encoding }}
   producer:
     compression: {{ .Values.openTelemetry.kafka.compression }}
+    max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
+    flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
+    linger: {{ dig "producer" "linger" "100ms" .Values.openTelemetry.kafka | quote }}
+  sending_queue:
+    queue_size: {{ dig "sendingQueue" "queueSize" 10000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false
@@ -352,6 +357,11 @@ kafka/syslog_non_audit:
     encoding: {{ .Values.openTelemetry.kafka.encoding }}
   producer:
     compression: {{ .Values.openTelemetry.kafka.compression }}
+    max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
+    flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
+    linger: {{ dig "producer" "linger" "100ms" .Values.openTelemetry.kafka | quote }}
+  sending_queue:
+    queue_size: {{ dig "sendingQueue" "queueSize" 10000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -341,7 +341,7 @@ kafka/syslog_audit:
     flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
     linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
   sending_queue:
-    enabled: true
+    enabled: {{ dig "sendingQueue" "enabled" true .Values.openTelemetry.kafka }}
     queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
@@ -362,7 +362,7 @@ kafka/syslog_non_audit:
     flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
     linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
   sending_queue:
-    enabled: true
+    enabled: {{ dig "sendingQueue" "enabled" true .Values.openTelemetry.kafka }}
     queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -338,11 +338,11 @@ kafka/syslog_audit:
   producer:
     compression: {{ .Values.openTelemetry.kafka.compression }}
     max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
-    flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
-    linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
+    flush_max_messages: {{ .Values.openTelemetry.kafka.producer.flushMaxMessages | int64 }}
+    linger: {{ .Values.openTelemetry.kafka.producer.linger | quote }}
   sending_queue:
-    enabled: {{ dig "sendingQueue" "enabled" true .Values.openTelemetry.kafka }}
-    queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
+    enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+    queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false
@@ -359,11 +359,11 @@ kafka/syslog_non_audit:
   producer:
     compression: {{ .Values.openTelemetry.kafka.compression }}
     max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
-    flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
-    linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
+    flush_max_messages: {{ .Values.openTelemetry.kafka.producer.flushMaxMessages | int64 }}
+    linger: {{ .Values.openTelemetry.kafka.producer.linger | quote }}
   sending_queue:
-    enabled: {{ dig "sendingQueue" "enabled" true .Values.openTelemetry.kafka }}
-    queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
+    enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+    queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -341,6 +341,7 @@ kafka/syslog_audit:
     flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
     linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
   sending_queue:
+    enabled: true
     queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
@@ -361,6 +362,7 @@ kafka/syslog_non_audit:
     flush_max_messages: {{ dig "producer" "flushMaxMessages" 10000 .Values.openTelemetry.kafka | int64 }}
     linger: {{ dig "producer" "linger" "10ms" .Values.openTelemetry.kafka | quote }}
   sending_queue:
+    enabled: true
     queue_size: {{ dig "sendingQueue" "queueSize" 1000 .Values.openTelemetry.kafka | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -72,6 +72,7 @@ openTelemetry:
   # -- Region label for Logging
   region:
   # -- Kafka exporter configuration shared by all collectors
+  # @default -- See values.yaml
   kafka:
     # -- Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering)
     enabled: false

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -88,11 +88,11 @@ openTelemetry:
     max_message_bytes: 1000000
     # -- Producer sending queue size
     sendingQueue:
-      queueSize: 10000
+      queueSize: 1000
     # -- Producer batching (raise linger to build larger batches per broker request)
     producer:
       flushMaxMessages: 10000
-      linger: 100ms
+      linger: 10ms
     # -- TLS configuration for Kafka connections
     tls:
       # -- Enable TLS for Kafka connections

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -88,6 +88,7 @@ openTelemetry:
     max_message_bytes: 1000000
     # -- Producer sending queue size
     sendingQueue:
+      enabled: true
       queueSize: 1000
     # -- Producer batching (raise linger to build larger batches per broker request)
     producer:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -85,6 +85,13 @@ openTelemetry:
     compression: ""
     # -- Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes.
     max_message_bytes: 1000000
+    # -- Producer sending queue size
+    sendingQueue:
+      queueSize: 10000
+    # -- Producer batching (raise linger to build larger batches per broker request)
+    producer:
+      flushMaxMessages: 10000
+      linger: 100ms
     # -- TLS configuration for Kafka connections
     tls:
       # -- Enable TLS for Kafka connections

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.21
+  version: 0.15.22
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.21
+    version: 0.4.22
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Tune the kafka syslog exporters. Larger batches per broker request, match topic/broker limits and larger burst buffer