### PR TITLE
fix(audit-logs): audit collector need to use prometheus metrics suffix

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.1.6
+version: 0.1.7
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -437,6 +437,7 @@ spec:
                 prometheus:
                   host: 0.0.0.0
                   port: 8888
+                  without_type_suffix: false
                   with_resource_constant_labels:
                     included:
                     - k8s_node_name

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.1.6
+    version: 0.1.7
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.1.6
+        version: 0.1.7
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
## Pull Request Details

Adding `without_type_suffix: false` to audit-logs-collector so the metrics going to prometheus have proper naming convention.
e.g.
`otelcol_exporter_sent_log_records` -> `otelcol_exporter_sent_log_records_total `