### PR TITLE
feat(storage): enable master reconciliation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,7 @@ Dockerfile.integration-test @cloudoperators/greenhouse-core @cloudoperators/gree
 /kubeconfig-generator/    @Nuckal777 @ivogoman @uwe-mayer
 /logshipper/              @cloudoperators/greenhouse-observability @cloudoperators/greenhouse-backend
 /logs/                    @cloudoperators/greenhouse-observability
+/netapp-monitoring/       @RockSolidScripts @crenduchinta88
 /opensearch/              @cloudoperators/greenhouse-observability
 /plutono                  @cloudoperators/greenhouse-observability
 /perses                   @cloudoperators/greenhouse-observability

--- a/netapp-monitoring/README.md
+++ b/netapp-monitoring/README.md
@@ -16,8 +16,21 @@ Components included in this plugin:
 
 - **Harvest** — Collects metrics from NetApp ONTAP systems using REST/ZAPI collectors and exports them in Prometheus format.
 - **NetApp SD (Service Discovery)** — Discovers filers from Netbox and manages Harvest worker instances dynamically.
-  - **Master** — Queries Netbox for filer inventory and coordinates workers.
-  - **Worker** — Runs Harvest instances for discovered filers and exposes metrics.
+  - **Master** — One Deployment per configured app (`--tag`). It queries Netbox for the filer inventory and reconciles one worker Deployment per discovered filer, rendering each from a deployment template mounted from a ConfigMap.
+  - **Worker** — Runs as a sidecar next to the Harvest poller. It learns its own filer name from the master (via `--filer-name`), fetches that filer's details from the master's `/filer/{name}` endpoint, and renders the Harvest exporter config.
+
+### Reconciliation model
+
+The master reconciles worker Deployments as filers come and go:
+
+1. It discovers filers from Netbox and probes each of them every 5 minutes.
+2. For every active, reachable filer, it **creates** a worker Deployment named after the filer — only if one does not already exist.
+3. When a filer goes inactive or disappears from Netbox, it **deletes** that filer's Deployment.
+
+Worker Deployments the master creates are labeled `app.kubernetes.io/managed-by=netappsd` and carry a `netappsd/filer=<name>` label identifying their filer. These Deployments are **not** tracked by Helm — they are created at runtime — which has two consequences the chart handles explicitly:
+
+- **Uninstall cleanup.** A `pre-delete` hook Job ([harvest-netappsd-cleanup-hook.yaml](charts/templates/harvest-netappsd-cleanup-hook.yaml)) deletes all `managed-by=netappsd` Deployments before the release is removed, so the master-created workers are not orphaned on `helm uninstall`. The hook image is configured via `netappsd.cleanup.image`.
+- **Template changes do not auto-propagate.** Because reconciliation is create-if-missing, editing the worker template ([files/deployment.yaml.tpl](charts/files/deployment.yaml.tpl)) does **not** update already-running worker Deployments — the master only applies the new template to workers it creates afterward (as filers churn). To roll existing workers onto a new template, delete the managed worker Deployments (`kubectl delete deploy -l app.kubernetes.io/managed-by=netappsd -n <namespace>`); the master recreates them from the current template within its next reconcile (~5 min).
 
 ## Quick Start
 
@@ -50,6 +63,7 @@ Configure the required options:
 | `netappsd.netapp_exporter_password` | NetApp exporter password | Yes |
 | `netappsd.netbox_api_token` | Netbox API token | Yes |
 | `netappsd.netbox_host` | Netbox host URL | Yes |
+| `netappsd.cleanup.image` | kubectl image used by the pre-delete cleanup hook | No |
 | `apps` | Map of app labels to enable discovery (for example cinder/manila/apod/cinder-manila) | No |
 
 ## Configuration
@@ -59,18 +73,20 @@ Configure the required options:
 The `netappsd` master component acts as a controller for discovered filers.
 
 - It monitors filer inventory from Netbox and reconciles the desired worker state.
-- It scales worker Deployments up and down based on filers discovered for each configured app label.
+- It creates and deletes worker Deployments per filer, rendered from the `deployment.yaml.tpl` template. The template is delivered per app through a per-app `deployment-template` ConfigMap ([harvest-netappsd-deployment-template-configmap.yaml](charts/templates/harvest-netappsd-deployment-template-configmap.yaml)), mounted into the master at `/etc/netappsd` and passed via the `--deployment-template` flag.
 - It patches Pod metadata to update the `filer` label, which is used to associate running workers with the discovered filer identity.
 
 For this reason, the chart grants the `netappsd` service account these permissions in its namespace:
 
 - `get`, `list`, `update`, `patch` on Pods
-- `get`, `list`, `update`, `patch` on Deployments
+- `get`, `list`, `update`, `patch`, `create`, `delete` on Deployments
 - `get`, `list` on Endpoints
 
-Without `patch` and `update`, the master cannot reconcile runtime labels or scaling decisions correctly.
+Without `create`/`delete` the master cannot reconcile worker Deployments, and without `patch`/`update` it cannot maintain runtime pod labels. The `delete` verb is also what lets the pre-delete cleanup hook remove managed workers on uninstall.
 
-The Deployment selectors and pod labels also stay app-specific on purpose. In [harvest-netappsd-master-deployment.yaml](charts/templates/harvest-netappsd-master-deployment.yaml) and [harvest-netappsd-worker-deployment.yaml](charts/templates/harvest-netappsd-worker-deployment.yaml), the shared helper labels used elsewhere in the chart are the same for every app (`cinder`, `manila`, `apod`, `cinder-manila`), so using them as the Deployment selector would make all master and worker Deployments select across each other's pods and break isolation. The `name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-master` label remains inline because it uniquely identifies pods per app and keeps each Deployment scoped to its own workload.
+The master Deployment selectors and pod labels stay app-specific on purpose. In [harvest-netappsd-master-deployment.yaml](charts/templates/harvest-netappsd-master-deployment.yaml), the shared helper labels used elsewhere in the chart are the same for every app (`cinder`, `manila`, `apod`, `cinder-manila`), so using them as the Deployment selector would make all master Deployments select across each other's pods and break isolation. The `name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-master` label remains inline because it uniquely identifies pods per app and keeps each Deployment scoped to its own workload.
+
+Worker pods created from the template carry two labels: a stable per-app `app: <fullname>-<app>-worker` label (set at chart install time) that the per-app worker Service selects on, and a `name: <filer>` label (filled by the master at runtime) that uniquely identifies each filer's pod. Keeping scraping keyed off the stable `app` label means the Service continues to select every filer's worker pod regardless of which filers are currently discovered.
 
 ### Harvest
 

--- a/netapp-monitoring/README.md
+++ b/netapp-monitoring/README.md
@@ -29,7 +29,7 @@ The master reconciles worker Deployments as filers come and go:
 
 Worker Deployments the master creates are labeled `app.kubernetes.io/managed-by=netappsd` and carry a `netappsd/filer=<name>` label identifying their filer. These Deployments are **not** tracked by Helm — they are created at runtime — which has two consequences the chart handles explicitly:
 
-- **Uninstall cleanup.** A `pre-delete` hook Job ([harvest-netappsd-cleanup-hook.yaml](charts/templates/harvest-netappsd-cleanup-hook.yaml)) deletes all `managed-by=netappsd` Deployments before the release is removed, so the master-created workers are not orphaned on `helm uninstall`. The hook image is configured via `netappsd.cleanup.image`.
+- **Uninstall cleanup.** A `pre-delete` hook Job ([harvest-netappsd-cleanup-hook.yaml](charts/templates/harvest-netappsd-cleanup-hook.yaml)) deletes all `managed-by=netappsd` Deployments before the release is removed, so the master-created workers are not orphaned on `helm uninstall`. The hook image is configured via `netappsd.cleanup.image.repository` and `netappsd.cleanup.image.tag`.
 - **Template changes do not auto-propagate.** Because reconciliation is create-if-missing, editing the worker template ([files/deployment.yaml.tpl](charts/files/deployment.yaml.tpl)) does **not** update already-running worker Deployments — the master only applies the new template to workers it creates afterward (as filers churn). To roll existing workers onto a new template, delete the managed worker Deployments (`kubectl delete deploy -l app.kubernetes.io/managed-by=netappsd -n <namespace>`); the master recreates them from the current template within its next reconcile (~5 min).
 
 ## Quick Start
@@ -63,7 +63,8 @@ Configure the required options:
 | `netappsd.netapp_exporter_password` | NetApp exporter password | Yes |
 | `netappsd.netbox_api_token` | Netbox API token | Yes |
 | `netappsd.netbox_host` | Netbox host URL | Yes |
-| `netappsd.cleanup.image` | kubectl image used by the pre-delete cleanup hook | No |
+| `netappsd.cleanup.image.repository` | kubectl image repository for the pre-delete cleanup hook | No |
+| `netappsd.cleanup.image.tag` | kubectl image tag for the pre-delete cleanup hook | No |
 | `apps` | Map of app labels to enable discovery (for example cinder/manila/apod/cinder-manila) | No |
 
 ## Configuration

--- a/netapp-monitoring/charts/Chart.yaml
+++ b/netapp-monitoring/charts/Chart.yaml
@@ -5,7 +5,7 @@ apiVersion: v2
 name: netapp-monitoring
 description: A Helm chart for harvest.io - https://github.com/NetApp/harvest
 type: application
-version: 1.0.1
+version: 1.0.2
 
 # * Release tag of Harvest - https://github.com/NetApp/harvest/releases
 appVersion: "25.11.0"

--- a/netapp-monitoring/charts/files/deployment.yaml.tpl
+++ b/netapp-monitoring/charts/files/deployment.yaml.tpl
@@ -1,21 +1,31 @@
 # SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
-{{- if .Values.netappsd.enabled }}
-{{- range $appName, $appValues := .Values.apps }}
-{{- if $appValues.enabled }}
-{{- with $ }}
+# This file is the worker Deployment template consumed by the netappsd master
+# (via --deployment-template). It is rendered in TWO layers:
+#   1. Helm "tpl" (at chart install time) resolves all Values/Release/include
+#      actions below.
+#   2. The netappsd master (at runtime) fills the backtick-escaped Go-template
+#      placeholders (.Name etc.) — one worker Deployment per discovered filer.
+#      These are escaped so Helm passes them through verbatim, matching the
+#      pattern used in harvest-netappsd-configmap.yaml.
+#
+# NOTE: The netappsd runtime placeholders below follow the master's
+# --deployment-template field contract. Adjust the field names here if netappsd
+# exposes them differently.
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-worker
+  # netappsd runtime: per-filer deployment name
+  name: {{`{{ .Name }}`}}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "netapp-monitoring.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:
-      name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-worker
+      # netappsd runtime: per-filer pod identity
+      name: {{`{{ .Name }}`}}
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -31,8 +41,10 @@ spec:
         checksum/sd-secret: {{ include "netapp-monitoring.checksum.sdSecret" . }}
         checksum/basic-auth: {{ include "netapp-monitoring.checksum.basicAuthSecret" . }}
       labels:
-        app: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}
-        name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-worker
+        # Stable per-app label used by the worker Service selector (Helm-time).
+        app: {{ include "netapp-monitoring.fullname" . }}-{{ .appName }}-worker
+        # netappsd runtime: per-filer pod identity, filled by the master.
+        name: {{`{{ .Name }}`}}
     spec:
       serviceAccountName: {{ .Values.netappsd.serviceAccountName | default "netappsd" }}
       containers:
@@ -75,13 +87,16 @@ spec:
               readOnly: true
           securityContext:
             {{- toYaml .Values.harvest.securityContext | nindent 12 }}
-        - name: worker
+        - name: netappsd-worker
           image: "{{ required ".Values.netappsd.image.repository is required" .Values.netappsd.image.repository }}:{{ required ".Values.netappsd.image.tag is required" .Values.netappsd.image.tag }}"
           imagePullPolicy: {{ .Values.netappsd.image.pullPolicy | default "IfNotPresent" }}
           command: ["/netappsd", "worker"]
           args:
             - --master-url
-            - http://{{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-master.{{ .Release.Namespace }}.svc:{{ .Values.netappsd.ports.master }}
+            - http://{{ include "netapp-monitoring.fullname" . }}-{{ .appName }}-master.{{ .Release.Namespace }}.svc:{{ .Values.netappsd.ports.master }}
+            - --filer-name
+            # netappsd runtime: master fills .Name with the discovered filer name.
+            - {{`{{ .Name }}`}}
             - --listen-addr
             - :{{ .Values.netappsd.ports.worker }}
             - --template-file
@@ -110,22 +125,6 @@ spec:
           ports:
             - name: liveness
               containerPort: {{ .Values.netappsd.ports.worker }}
-          livenessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.netappsd.ports.worker }}
-            initialDelaySeconds: 15
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
-          readinessProbe:
-            httpGet:
-              path: /healthz
-              port: {{ .Values.netappsd.ports.worker }}
-            initialDelaySeconds: 10
-            periodSeconds: 10
-            timeoutSeconds: 5
-            failureThreshold: 3
           resources:
             {{- toYaml .Values.netappsd.resources | nindent 12 }}
           volumeMounts:
@@ -143,8 +142,3 @@ spec:
         - name: basic-auth
           secret:
             secretName: {{ required ".Values.netappsd.credentials_secret is required" .Values.netappsd.credentials_secret }}
----
-{{- end }}
-{{- end }}
-{{- end }}
-{{- end }}

--- a/netapp-monitoring/charts/templates/_helpers.tpl
+++ b/netapp-monitoring/charts/templates/_helpers.tpl
@@ -103,3 +103,7 @@ when config or secret templates change.
 {{ include (print $.Template.BasePath "/harvest-basic-auth.yaml") . | sha256sum }}
 {{- end }}
 
+{{- define "netapp-monitoring.checksum.deploymentTemplate" -}}
+{{ include (print $.Template.BasePath "/harvest-netappsd-deployment-template-configmap.yaml") . | sha256sum }}
+{{- end }}
+

--- a/netapp-monitoring/charts/templates/_helpers.tpl
+++ b/netapp-monitoring/charts/templates/_helpers.tpl
@@ -103,7 +103,12 @@ when config or secret templates change.
 {{ include (print $.Template.BasePath "/harvest-basic-auth.yaml") . | sha256sum }}
 {{- end }}
 
+{{/*
+Per-app checksum of the rendered worker deployment template. Scoped per app so
+only the affected master rolls when its own deployment-template ConfigMap
+changes. Call with (dict "root" . "appName" $appName).
+*/}}
 {{- define "netapp-monitoring.checksum.deploymentTemplate" -}}
-{{ include (print $.Template.BasePath "/harvest-netappsd-deployment-template-configmap.yaml") . | sha256sum }}
+{{ tpl (.root.Files.Get "files/deployment.yaml.tpl") (merge (dict "appName" .appName) .root) | sha256sum }}
 {{- end }}
 

--- a/netapp-monitoring/charts/templates/harvest-netappsd-cleanup-hook.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-cleanup-hook.yaml
@@ -26,7 +26,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: cleanup
-          image: {{ .Values.netappsd.cleanup.image }}
+          image: "{{ required ".Values.netappsd.cleanup.image.repository is required" .Values.netappsd.cleanup.image.repository }}:{{ required ".Values.netappsd.cleanup.image.tag is required" .Values.netappsd.cleanup.image.tag }}"
           command:
             - kubectl
             - delete

--- a/netapp-monitoring/charts/templates/harvest-netappsd-cleanup-hook.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-cleanup-hook.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+# Helm pre-delete hook: on `helm uninstall`, delete the per-filer worker
+# Deployments the master created at runtime. Helm does not track these (they
+# are not part of the chart), so without this hook they would be orphaned.
+# Runs as a short-lived Job before the rest of the release is removed.
+{{- if .Values.netappsd.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "netapp-monitoring.fullname" . }}-cleanup
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "netapp-monitoring.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-delete
+    "helm.sh/hook-delete-policy": hook-succeeded,hook-failed
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: {{ include "netapp-monitoring.fullname" . }}-cleanup
+    spec:
+      serviceAccountName: {{ .Values.netappsd.serviceAccountName | default "netappsd" }}
+      restartPolicy: Never
+      containers:
+        - name: cleanup
+          image: {{ .Values.netappsd.cleanup.image }}
+          command:
+            - kubectl
+            - delete
+            - deployments
+            - --namespace
+            - {{ .Release.Namespace }}
+            - --selector
+            - app.kubernetes.io/managed-by=netappsd
+            - --ignore-not-found
+{{- end }}

--- a/netapp-monitoring/charts/templates/harvest-netappsd-deployment-template-configmap.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-deployment-template-configmap.yaml
@@ -1,0 +1,22 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+{{- if .Values.netappsd.enabled }}
+{{- range $appName, $appValues := .Values.apps }}
+{{- if $appValues.enabled }}
+{{- with $ }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-deployment-template
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "netapp-monitoring.labels" . | nindent 4 }}
+data:
+  deployment.yaml.tpl: |
+{{ tpl (.Files.Get "files/deployment.yaml.tpl") (merge (dict "appName" $appName) .) | indent 4 }}
+---
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/netapp-monitoring/charts/templates/harvest-netappsd-master-deployment.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-master-deployment.yaml
@@ -24,7 +24,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: storage
         checksum/sd-secret: {{ include "netapp-monitoring.checksum.sdSecret" . }}
-        checksum/deployment-template: {{ include "netapp-monitoring.checksum.deploymentTemplate" . }}
+        checksum/deployment-template: {{ include "netapp-monitoring.checksum.deploymentTemplate" (dict "root" . "appName" $appName) }}
       labels:
         app: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}
         name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-master

--- a/netapp-monitoring/charts/templates/harvest-netappsd-master-deployment.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-master-deployment.yaml
@@ -24,6 +24,7 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/targets: storage
         checksum/sd-secret: {{ include "netapp-monitoring.checksum.sdSecret" . }}
+        checksum/deployment-template: {{ include "netapp-monitoring.checksum.deploymentTemplate" . }}
       labels:
         app: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}
         name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-master
@@ -41,8 +42,8 @@ spec:
             - {{ $appName }}
             - --listen-addr
             - 0.0.0.0:{{ .Values.netappsd.ports.master }}
-            - --worker
-            - {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-worker
+            - --deployment-template
+            - /etc/netappsd/deployment.yaml.tpl
           env:
             - name: NETAPP_USERNAME
               valueFrom:
@@ -73,6 +74,13 @@ spec:
               containerPort: {{ .Values.netappsd.ports.master }}
           resources:
             {{- toYaml .Values.netappsd.resources | nindent 12 }}
+          volumeMounts:
+            - name: deployment-template
+              mountPath: /etc/netappsd
+      volumes:
+        - name: deployment-template
+          configMap:
+            name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-deployment-template
 ---
 {{- end }}
 {{- end }}

--- a/netapp-monitoring/charts/templates/harvest-netappsd-serviceaccount.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-serviceaccount.yaml
@@ -22,7 +22,7 @@ rules:
     verbs: ["get", "list", "update", "patch"]
   - apiGroups: ["apps"]
     resources: ["deployments"]
-    verbs: ["get", "list", "update", "patch"]
+    verbs: ["get", "list", "update", "patch", "create", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/netapp-monitoring/charts/templates/harvest-netappsd-worker-service.yaml
+++ b/netapp-monitoring/charts/templates/harvest-netappsd-worker-service.yaml
@@ -14,7 +14,7 @@ metadata:
     {{- include "netapp-monitoring.labels" . | nindent 4 }}
 spec:
   selector:
-    name: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-worker
+    app: {{ include "netapp-monitoring.fullname" . }}-{{ $appName }}-worker
   ports:
     - name: metrics
       port: {{ required ".Values.netappsd.ports.harvest is required" .Values.netappsd.ports.harvest }}

--- a/netapp-monitoring/charts/values.yaml
+++ b/netapp-monitoring/charts/values.yaml
@@ -4,8 +4,8 @@
 ---
 harvest:
   image:
-    repository: keppel.eu-de-1.cloud.sap/ccloud/harvest
-    tag: 25.11.0-20251126205434
+    repository:
+    tag:
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -51,14 +51,16 @@ netappsd:
   serviceAccountName: netappsd
   lob: CCloud
   image:
-    repository: keppel.eu-de-1.cloud.sap/ccloud/netappsd
-    tag: dme-strg-ganesh-test-6
-    pullPolicy: Always
+    repository:
+    tag:
+    pullPolicy: IfNotPresent
   # Image for the pre-delete cleanup hook (kubectl) that removes the per-filer
   # worker Deployments the master created at runtime.
   cleanup:
-    image: keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror/kubectl:v1.36.1
-  region: "qa-de-1"
+    image:
+      repository:
+      tag:
+  region: ""
   ports:
     master: 8000
     harvest: 13000
@@ -70,12 +72,12 @@ netappsd:
     limits:
       cpu: 200m
       memory: 256Mi
-  netapp_exporter_user: vault+kvv2:///secrets/shared/harvest/harvest-ad/local-user/username
-  netapp_exporter_password: vault+kvv2:///secrets/shared/harvest/harvest-ad/local-user/password
-  netbox_api_token: vault+kvv2:///secrets/shared/harvest/netapp/token
-  netbox_host: vault+kvv2:///secrets/shared/harvest/netapp/host
-  credentials_file: /app/secrets/local-basic-auth.yml
-  credentials_secret: local-basic-auth
+  netapp_exporter_user: ""
+  netapp_exporter_password: ""
+  netbox_api_token: ""
+  netbox_host: ""
+  credentials_file:
+  credentials_secret:
 
 # apps: Configures which filers are discovered by the service discovery.
 # Each key corresponds to a label assigned to devices in Netbox.

--- a/netapp-monitoring/charts/values.yaml
+++ b/netapp-monitoring/charts/values.yaml
@@ -4,8 +4,8 @@
 ---
 harvest:
   image:
-    repository:
-    tag:
+    repository: keppel.eu-de-1.cloud.sap/ccloud/harvest
+    tag: 25.11.0-20251126205434
     pullPolicy: IfNotPresent
   resources:
     requests:
@@ -51,10 +51,14 @@ netappsd:
   serviceAccountName: netappsd
   lob: CCloud
   image:
-    repository:
-    tag:
-    pullPolicy: IfNotPresent
-  region: ""
+    repository: keppel.eu-de-1.cloud.sap/ccloud/netappsd
+    tag: dme-strg-ganesh-test-6
+    pullPolicy: Always
+  # Image for the pre-delete cleanup hook (kubectl) that removes the per-filer
+  # worker Deployments the master created at runtime.
+  cleanup:
+    image: keppel.eu-de-1.cloud.sap/ccloud-registry-k8s-io-mirror/kubectl:v1.36.1
+  region: "qa-de-1"
   ports:
     master: 8000
     harvest: 13000
@@ -66,12 +70,12 @@ netappsd:
     limits:
       cpu: 200m
       memory: 256Mi
-  netapp_exporter_user: ""
-  netapp_exporter_password: ""
-  netbox_api_token: ""
-  netbox_host: ""
-  credentials_file:
-  credentials_secret:
+  netapp_exporter_user: vault+kvv2:///secrets/shared/harvest/harvest-ad/local-user/username
+  netapp_exporter_password: vault+kvv2:///secrets/shared/harvest/harvest-ad/local-user/password
+  netbox_api_token: vault+kvv2:///secrets/shared/harvest/netapp/token
+  netbox_host: vault+kvv2:///secrets/shared/harvest/netapp/host
+  credentials_file: /app/secrets/local-basic-auth.yml
+  credentials_secret: local-basic-auth
 
 # apps: Configures which filers are discovered by the service discovery.
 # Each key corresponds to a label assigned to devices in Netbox.

--- a/netapp-monitoring/plugindefinition.yaml
+++ b/netapp-monitoring/plugindefinition.yaml
@@ -68,6 +68,14 @@ spec:
       description: Netbox host URL
       required: true
       type: secret
+    - name: netappsd.cleanup.image.repository
+      description: kubectl image repository used by the pre-delete cleanup hook to remove master-created worker Deployments
+      required: false
+      type: string
+    - name: netappsd.cleanup.image.tag
+      description: kubectl image tag used by the pre-delete cleanup hook
+      required: false
+      type: string
     - name: apps
       description: "Map of apps to enable (e.g. cinder, manila, apod, cinder-manila)"
       required: false

--- a/netapp-monitoring/plugindefinition.yaml
+++ b/netapp-monitoring/plugindefinition.yaml
@@ -6,13 +6,13 @@ kind: PluginDefinition
 metadata:
   name: netapp-monitoring
 spec:
-  version: 1.0.1
+  version: 1.0.2
   displayName: NetApp Monitoring
   description: Helm chart for NetApp storage monitoring using harvest.io
   helmChart:
     name: netapp-monitoring
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts/netapp-monitoring
-    version: 1.0.1
+    version: 1.0.2
   options:
     - name: harvest.image.repository
       description: Harvest container image repository


### PR DESCRIPTION
# Submit a pull request

Thank you for submitting a pull request!  
To speed up the review process, please ensure that everything below
is true:

1. This is not a duplicate of an existing Plugin.
2. No existing features have been broken without good reason.
3. The Documentation has been updated to reflect your changes.
4. Tests have been added or updated to reflect your changes.
5. All tests pass.

---

Replace any ":question:" below with information about your pull request.

## Pull Request Details

Restructures the `netapp-monitoring` chart to move worker provisioning from **static per-app Deployments** to a **master-driven, per-filer reconciliation model**.

Previously the chart rendered one static worker Deployment per app and the netappsd master coordinated those pre-existing workers via `--worker <name>`. Now the master creates one worker Deployment **per discovered filer** at runtime from a deployment template it reads from a mounted ConfigMap.

**Changes:**

- **New** `charts/files/deployment.yaml.tpl` — the per-filer worker Deployment template consumed by the master. Rendered in two layers: Helm resolves `.Values`/`.Release`/`.appName` at install time, while netappsd runtime placeholders (`{{ .Name }}`) are backtick-escaped so the master fills them per filer.
- **New** `harvest-netappsd-deployment-template-configmap.yaml` — per-app ConfigMap embedding the `tpl`-rendered template, mounted into the master at `/etc/netappsd`.
- **New** `harvest-netappsd-cleanup-hook.yaml` — a `pre-delete` hook Job that deletes `app.kubernetes.io/managed-by=netappsd` Deployments so master-created workers aren't orphaned on `helm uninstall`. Image configurable via `netappsd.cleanup.image`.
- **Master deployment** — replaced `--worker <name>` with `--deployment-template /etc/netappsd/deployment.yaml.tpl`; added the template volume/mount and a `checksum/deployment-template` roll annotation.
- **Worker Service** — selector changed from the (now per-filer) `name` label to a stable per-app `app` label so it keeps selecting all filer worker pods.
- **RBAC** — deployments verbs now include `create`/`delete` (master reconcile + cleanup hook).
- **Deleted** `harvest-netappsd-worker-deployment.yaml` (superseded by the template file).
- **README** — documented the reconciliation model, template plumbing, cleanup hook, and the template-propagation limitation.

Verified with `helm lint` (clean) and `helm template` (per-app ConfigMaps render, Helm values resolved while `{{ .Name }}` stays literal, no `--worker` flag, no standalone worker Deployment).

### Test-Results
<img width="983" height="214" alt="image" src="https://github.com/user-attachments/assets/ee2d1e79-7283-49fb-b9af-ae34e83416f6" />

## Breaking Changes

Describe what features are broken by this pull request and why, if any.

- **Worker Deployment topology changed.** The chart no longer ships static per-app worker Deployments; workers are now created at runtime by the master, one per filer. On upgrade, the old static worker Deployments should be removed (they are no longer chart-managed).
- **`--worker` flag removed** from the master in favor of `--deployment-template`; requires a netappsd image that supports the `--deployment-template` reconcile mode.
- **Template changes do not auto-propagate.** Because the master reconciles create-if-missing, editing `deployment.yaml.tpl` does not roll already-running workers — existing managed Deployments must be deleted (the master recreates them from the new template within ~5 min).
- **New value** `netappsd.cleanup.image` is required for the pre-delete cleanup hook.

## Issues Fixed

Enter the issue numbers resolved by this pull request below, if any.

N/A

## Other Relevant Information

Provide any other important details below.

N/A
