### PR TITLE
fix(fortlogs): tag opensearch-fortlogs 3.7.0.3

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -39,7 +39,7 @@ jobs:
           - Context: https://github.com/SAP-cloud-infrastructure/opensearch-fortlogs.git#main
             Dockerfiles: Dockerfile
             Imagename: opensearch-fortlogs
-            Imagetag: 3.7.0-dev03
+            Imagetag: 3.7.0.3
             Platform: linux/amd64
 
     permissions:


### PR DESCRIPTION
## Pull Request Details

The image tag uses a four-segment `3.7.0.N` scheme: `3.7.0` is the base OpenSearch version and `N` is the build counter (`3.7.0.3`, `3.7.0.4`, ...). Increment `N` for each rebuild. Do **not** use a prerelease suffix like `3.7.0-devNN`: the OpenSearch operator derives the cluster version from this tag and its semver gate (`>=2.0.0`) excludes prerelease versions, which makes it mis-render `plugins.security.authcz.admin_dn`.
