### PR TITLE
fix(audit-logs): fixes for containerd

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.2
+version: 0.2.3
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -119,10 +119,10 @@ spec:
       file_log/containerd:
         include_file_path: true
         include:
-        - /var/log/pods/*/keystone-api/*.log
-        - /var/log/pods/dns_coredns-api*/audit/*.log
-        - /var/log/pods/vault*/audit/*.log
-        - /var/log/pods/kube-monitoring_kube-monitoring-metal-falco*/*/*.log
+          - /var/log/pods/*/keystone-api/*.log
+          - /var/log/pods/dns_coredns-api*/audit/*.log
+          - /var/log/pods/vault*/audit/*.log
+          - /var/log/pods/kube-monitoring_kube-monitoring-metal-falco*/*/*.log
         max_log_size: 16384
         operators:
           - id: container-parser
@@ -172,10 +172,10 @@ spec:
       transform/fix_log_attribute:
         error_mode: ignore
         log_statements:
-        - context: log
-          statements:
-          - set(attributes["log_message"], attributes["log"]) where IsString(attributes["log"])
-          - delete_key(attributes, "log") where IsString(attributes["log"]) 
+          - context: log
+            statements:
+            - set(attributes["log_message"], attributes["log"]) where IsString(attributes["log"])
+            - delete_key(attributes, "log") where IsString(attributes["log"]) 
 
 {{- if .Values.auditLogs.elastic.enabled }}
     {{- include "es.labels" . | nindent 6 -}}
@@ -598,11 +598,11 @@ spec:
           - logs/es
 {{- end }}
         table:
-        - statement: route()
-          pipelines:
-          - logs/default
+          - statement: route()
+            pipelines:
+            - logs/default
 {{- if .Values.auditLogs.elastic.enabled }}
-          - logs/es
+            - logs/es
 {{- end }}
 {{- if not .Values.auditLogs.logsCollector.kafka.enabled }}
       failover:

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -118,12 +118,11 @@ spec:
 {{- if .Values.auditLogs.logsCollector.containerd.enabled }}
       file_log/containerd:
         include_file_path: true
-        include: [ /var/log/pods/*/*/*.log ]
-        exclude:
-        - /var/log/pods/audit-logs*
-        - /var/log/pods/logs_*
-        - /var/log/pods/dns-recursor_unbound*/*/*.log
-        - /var/log/pods/kube-system_wormhole*/*/*.log
+        include:
+        - /var/log/pods/*/keystone-api/*.log
+        - /var/log/pods/dns_coredns-api*/audit/*.log
+        - /var/log/pods/vault*/audit/*.log
+        - /var/log/pods/kube-monitoring_kube-monitoring-metal-falco*/*/*.log
         max_log_size: 16384
         operators:
           - id: container-parser

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -118,8 +118,12 @@ spec:
 {{- if .Values.auditLogs.logsCollector.containerd.enabled }}
       file_log/containerd:
         include_file_path: true
-        include: [ /var/log/pods/*.log ]
-        exclude: [ /var/log/pods/audit-logs* ]
+        include: [ /var/log/pods/*/*/*.log ]
+        exclude:
+        - /var/log/pods/audit-logs*
+        - /var/log/pods/logs_*
+        - /var/log/pods/dns-recursor_unbound*/*/*.log
+        - /var/log/pods/kube-system_wormhole*/*/*.log
         max_log_size: 16384
         operators:
           - id: container-parser
@@ -166,6 +170,14 @@ spec:
         send_batch_max_size: 500
         timeout: 5s
         send_batch_size : 10
+      transform/fix_log_attribute:
+        error_mode: ignore
+        log_statements:
+        - context: log
+          statements:
+          - set(attributes["log_message"], attributes["log"]) where IsString(attributes["log"])
+          - delete_key(attributes, "log") where IsString(attributes["log"]) 
+
 {{- if .Values.auditLogs.elastic.enabled }}
     {{- include "es.labels" . | nindent 6 -}}
 {{- end }}
@@ -586,7 +598,13 @@ spec:
 {{- if .Values.auditLogs.elastic.enabled }}
           - logs/es
 {{- end }}
-        table: []
+        table:
+        - statement: route()
+          pipelines:
+          - logs/default
+{{- if .Values.auditLogs.elastic.enabled }}
+          - logs/es
+{{- end }}
 {{- if not .Values.auditLogs.logsCollector.kafka.enabled }}
       failover:
         retry_interval: 2m
@@ -632,7 +650,7 @@ spec:
       pipelines:
         logs/default:
           receivers: [routing]
-          processors: [batch]
+          processors: [transform/fix_log_attribute, batch]
 {{- if .Values.auditLogs.logsCollector.kafka.enabled }}
           exporters: [kafka]
 {{- else }}

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.2
+    version: 0.2.3
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.2
+        version: 0.2.3
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
  ## Summary                                                                                                                                                                   
                                                                                                                                                                               
  Bug fixes for the `audit-logs` OpenTelemetry collector chart (v0.2.2 → 0.2.3).                                                                                               
                                                                                                                                                                               
  ### Changes                                                                                                                                                                  
                  
  **containerd log collection (`file_log/containerd`)**                                                                                                                        
  - Added include for relevant data:    (similar to: https://github.com/sapcc/helm-charts/blob/9cbad02d51a88a30a8959a62aa90d0028d56d796/system/audit-logs-otel/templates/audit-logs-collector.yaml#L143)                                                                                                                                                                                                                                                       
                                                                                                                                                                               
  **Log attribute normalization (`transform/fix_log_attribute`)**                                                                                                              
  - New processor: renames `log` attribute → `log_message` to avoid field name collision in OpenSearch mappings                                                                
  - Runs before `batch` in the `logs/default` pipeline                                                                                                                         
  **Routing fix (`router` connector)**                                                                                                                                         
  - `table` was empty (`[]`), causing logs to be silently dropped                                                                                                              
  - Now routes all logs to `logs/default` (and `logs/es` when Elastic enabled)                                                                                                 
                                                                                                                                                                               
  ### Version bump                                                                                                                                                             
                                                                                                                                                                               
  `Chart.yaml` and `plugindefinition.yaml`: `0.2.2` → `0.2.3`                                                                                                                  
                                                             