### PR TITLE
feat(kafka): add podAntiAffinity to spread brokers across nodes

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -85,6 +85,7 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | monitoring.podMonitor.labels | object | `{}` | Labels to add to the PodMonitor so Prometheus can discover it. |
 | nodeAffinity | object | `{}` | Node affinity rules for Kafka broker/controller pods. When set, placed at spec.template.pod.affinity.nodeAffinity in the KafkaNodePool. Leave empty ({}) for no affinity constraint (default). |
 | operator.enabled | bool | `true` | Enable or disable the Strimzi Kafka Operator installation |
+| podAntiAffinity | object | `{}` | Pod anti-affinity rules for Kafka broker/controller pods. When set, placed at spec.template.pod.affinity.podAntiAffinity in the KafkaNodePool. Use to spread brokers across nodes so a single node loss cannot take down quorum. Leave empty ({}) for no constraint (default). |
 | testFramework.enabled | bool | `true` | Activates the Helm chart testing framework. |
 | testFramework.image | object | ghcr.io/cloudoperators/greenhouse-extensions-integration-test:main | Test framework image configuration |
 | testFramework.image.pullPolicy | string | `"Always"` | Defines the image pull policy for the test framework. |

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.11
+version: 0.1.12
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/kafka-node-pool.yaml
+++ b/kafka/charts/templates/kafka-node-pool.yaml
@@ -21,11 +21,17 @@ spec:
   jvmOptions:
     -Xms: {{ .Values.kafka.jvmOptions.xms | quote }}
     -Xmx: {{ .Values.kafka.jvmOptions.xmx | quote }}
-  {{- if .Values.nodeAffinity }}
+  {{- if or .Values.nodeAffinity .Values.podAntiAffinity }}
   template:
     pod:
       affinity:
+        {{- with .Values.nodeAffinity }}
         nodeAffinity:
-          {{- toYaml .Values.nodeAffinity | nindent 10 }}
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
+        {{- with .Values.podAntiAffinity }}
+        podAntiAffinity:
+          {{- toYaml . | nindent 10 }}
+        {{- end }}
   {{- end }}
 {{- end }}

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -9,6 +9,12 @@ commonLabels: {}
 # Leave empty ({}) for no affinity constraint (default).
 nodeAffinity: {}
 
+# -- Pod anti-affinity rules for Kafka broker/controller pods.
+# When set, placed at spec.template.pod.affinity.podAntiAffinity in the KafkaNodePool.
+# Use to spread brokers across nodes so a single node loss cannot take down quorum.
+# Leave empty ({}) for no constraint (default).
+podAntiAffinity: {}
+
 # Strimzi Kafka Operator configuration
 operator:
   # -- Enable or disable the Strimzi Kafka Operator installation

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.11
+  version: 0.1.12
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.11
+    version: 0.1.12
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

Add Pod anti-affinity rules for Kafka broker/controller pods to spread brokers across nodes so a single node loss cannot take down quorum.