### PR TITLE
fix(opensearch): fire cluster red/yellow alerts on max not avg

### DIFF
--- a/opensearch/README.md
+++ b/opensearch/README.md
@@ -222,6 +222,7 @@ This guide provides a quick and straightforward way to use **OpenSearch** as a G
 | cluster.usersCredentials | object | <pre>usersCredentials:<br>  admin:<br>    username: "admin"<br>    password: "admin"<br>    hash: ""</pre> | List of OpenSearch user credentials. These credentials are used for authenticating users with OpenSearch. See values.yaml file for a full example. |
 | cluster.usersRoleBinding | list | <pre>usersRoleBinding:<br>  - name: "logs-write"<br>    users:<br>      - "logs"<br>      - "logs2"<br>    roles:<br>      - "logs-write-role"</pre> | Allows to link any number of users, backend roles and roles with a OpensearchUserRoleBinding. Each user in the binding will be granted each role |
 | extraManifests | list | `[]` | Extra Kubernetes manifests to deploy alongside the chart. Each entry can be a raw YAML string or a map object. |
+| kubernetesPrometheusRuleLabels | object | `{}` | Labels for the PrometheusRule holding alerts that use kube-side metrics (kubelet/kube-state/node-exporter), so it is picked up by the Prometheus that scrapes kubelet. Set per deployment (e.g. prometheus: kubernetes). |
 | operator.enabled | bool | `true` | Install the OpenSearch operator subchart with its ServiceMonitor and PrometheusRule alerts. Set false on additional releases that reuse the operator from another release. Note: CRDs in chart/crds/ are managed by Helm independently of this flag. |
 | operator.fullnameOverride | string | `""` |  |
 | operator.installCRDs | bool | `false` |  |

--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.17
+version: 0.2.18
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -5,9 +5,7 @@ groups:
     rules:
       - alert: OpenSearchClusterRed
         expr: |
-          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
-          /
-          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
+          max by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"})
           == 2
         for: 5m
         labels:
@@ -21,9 +19,7 @@ groups:
 
       - alert: OpenSearchClusterYellow
         expr: |
-          (sum by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
-          /
-          (count by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"}))
+          max by (opensearch_org_opensearch_cluster) (opensearch_cluster_status{namespace="{{ .Release.Namespace }}"})
           == 1
         for: 120m
         labels:
@@ -34,18 +30,6 @@ groups:
         annotations:
           summary: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is YELLOW"
           description: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
-
-      - alert: OpenSearchDiskSpaceRunningLow
-        expr: predict_linear(opensearch_fs_total_free_bytes{namespace="{{ .Release.Namespace }}"}[24h], 24*3600) < 0
-        for: 1h
-        labels:
-          severity: info # critical
-          component: opensearch
-          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighDiskUsage.md
-          {{- include "opensearch-alert-labels" . | nindent 10 }}
-        annotations:
-          summary: "OpenSearch disk space predicted to run out"
-          description: "OpenSearch node {{`{{ $labels.node }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is predicted to run out of disk space within 24 hours"
 
       - alert: OpenSearchIndexSizeTooLarge
         expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"}[15m]) > 1)

--- a/opensearch/chart/alerts/opensearch-kube-metrics.yaml
+++ b/opensearch/chart/alerts/opensearch-kube-metrics.yaml
@@ -1,0 +1,36 @@
+# Alerts using kube-side metrics (kubelet/kube-state/node-exporter); routed to the kube-monitoring Prometheus.
+groups:
+  - name: opensearch-kube-metrics
+    rules:
+      # Per-tier capacity alert: whole data tier running out of disk, needs more nodes/disk.
+      - alert: OpenSearchHotTierDiskFull
+        expr: |
+          sum(kubelet_volume_stats_used_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim=~"data-opensearch-.*-data-hot-.*"})
+          /
+          sum(kubelet_volume_stats_capacity_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim=~"data-opensearch-.*-data-hot-.*"})
+          > 0.85
+        for: 30m
+        labels:
+          severity: info # critical
+          component: opensearch
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighDiskUsage.md
+          {{- include "opensearch-alert-labels" . | nindent 10 }}
+        annotations:
+          summary: "OpenSearch hot tier in {{ .Release.Namespace }} above 85% disk usage"
+          description: "The OpenSearch hot data tier in namespace {{ .Release.Namespace }} is over 85% full across all nodes. Add disk or nodes."
+
+      - alert: OpenSearchWarmTierDiskFull
+        expr: |
+          sum(kubelet_volume_stats_used_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim=~"data-opensearch-.*-data-warm-.*"})
+          /
+          sum(kubelet_volume_stats_capacity_bytes{namespace="{{ .Release.Namespace }}", persistentvolumeclaim=~"data-opensearch-.*-data-warm-.*"})
+          > 0.85
+        for: 30m
+        labels:
+          severity: info # critical
+          component: opensearch
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchHighDiskUsage.md
+          {{- include "opensearch-alert-labels" . | nindent 10 }}
+        annotations:
+          summary: "OpenSearch warm tier in {{ .Release.Namespace }} above 85% disk usage"
+          description: "The OpenSearch warm data tier in namespace {{ .Release.Namespace }} is over 85% full across all nodes. Add disk or nodes."

--- a/opensearch/chart/templates/alerts.yaml
+++ b/opensearch/chart/templates/alerts.yaml
@@ -15,6 +15,21 @@ metadata:
 spec:
 {{ tpl (printf "%s" $bytes) $root | indent 2 }}
 {{- end }}
+{{- range $path, $bytes := .Files.Glob "alerts/opensearch-kube-metrics.yaml" }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-%s" $.Release.Name ($path | trimSuffix ".yaml") | replace "/" "-" | trunc 63 }}
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "opensearch.labels" $ | nindent 4 }}
+    {{- with $.Values.kubernetesPrometheusRuleLabels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+{{ tpl (printf "%s" $bytes) $root | indent 2 }}
+{{- end }}
 {{- end }}
 {{- if and .Values.operator.enabled .Values.cluster.cluster.general.monitoring.enable }}
 {{- range $path, $bytes := .Files.Glob "alerts/opensearch-operator.yaml" }}

--- a/opensearch/chart/values.yaml
+++ b/opensearch/chart/values.yaml
@@ -204,6 +204,9 @@ operator:
 # -- Additional labels for PrometheusRule alerts
 additionalRuleLabels: {}
 
+# -- Labels for the PrometheusRule holding alerts that use kube-side metrics (kubelet/kube-state/node-exporter), so it is picked up by the Prometheus that scrapes kubelet. Set per deployment (e.g. prometheus: kubernetes).
+kubernetesPrometheusRuleLabels: {}
+
 cluster:
   nameOverride: ""
   fullnameOverride: ""

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.17
+  version: 0.2.18
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.17
+    version: 0.2.18
   options:
     - name: queryExporter.enabled
       description: "Enable the OpenSearch query exporter for custom Prometheus metrics from OpenSearch queries"


### PR DESCRIPTION
## Pull Request Details

- Fix dead red/yellow alerts (an average across per-node samples hat never hits the exact threshold when nodes report inconsistently, so a genuinely RED cluster never alerted
- Replace the disk alert. Dropped OpenSearchDiskSpaceRunningLow which on warm/searchable-snapshot nodes reports the logical remote budget, not physical disk, misleading and false-firing on rebalance. Added per-tier OpenSearchHotTierDiskFull / OpenSearchWarmTierDiskFull using kubelet_volume_stats, alerting at 85% aggregate per tier
- Route kube-metric alerts to the right Prometheus. The new rules query kubelet metrics, so they render as a separate PrometheusRule. Cluster/operator/guardian alerts keep going to their existing Prometheus via monitoring.labels.
