### PR TITLE
feat(kafka): add alerts 

### DIFF
--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.12
+version: 0.1.13
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/alerts.yaml
+++ b/kafka/charts/templates/alerts.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+{{- if and (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") .Values.kafka.enabled .Values.monitoring.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ printf "%s-alerts" .Values.kafka.name | trunc 63 }}
+  labels:
+    {{- include "kafka.labels" . | nindent 4 }}
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: kafka.rules
+      rules:
+        - alert: KafkaConsumerLagTooHigh
+          expr: sum by (topic, consumergroup) (kafka_consumergroup_lag{namespace="{{ .Release.Namespace }}", topic!="__consumer_offsets", consumergroup!=""}) > 1000
+          for: 15m
+          labels:
+            severity: info # real severity: warning
+            playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/kafka/playbooks/KafkaConsumerLagTooHigh.md
+            {{- include "kafka.alert-labels" . | nindent 12 }}
+          annotations:
+            summary: Kafka consumer lag is too high.
+            description: 'Consumer group {{`{{ $labels.consumergroup }}`}} on topic {{`{{ $labels.topic }}`}} has a lag of {{`{{ printf "%.0f" $value }}`}} messages.'
+        - alert: KafkaUnderReplicatedPartitions
+          expr: sum by (topic) (kafka_topic_partition_under_replicated_partition{namespace="{{ .Release.Namespace }}"}) > 0
+          for: 15m
+          labels:
+            severity: info # real severity: critical
+            playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/kafka/playbooks/KafkaUnderReplicatedPartitions.md
+            {{- include "kafka.alert-labels" . | nindent 12 }}
+          annotations:
+            summary: Kafka has under-replicated partitions.
+            description: 'Topic {{`{{ $labels.topic }}`}} has {{`{{ printf "%.0f" $value }}`}} under-replicated partition(s).'
+        - alert: KafkaNoBrokersOnline
+          expr: absent(kafka_server_kafkaserver_brokerstate{namespace="{{ .Release.Namespace }}"})
+          for: 5m
+          labels:
+            severity: info # real severity: critical
+            playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/kafka/playbooks/KafkaNoBrokersOnline.md
+            {{- include "kafka.alert-labels" . | nindent 12 }}
+          annotations:
+            summary: Kafka has no brokers online.
+            description: No Kafka brokers are reporting metrics. The cluster is likely down.
+{{- end }}

--- a/kafka/playbooks/KafkaConsumerLagTooHigh.md
+++ b/kafka/playbooks/KafkaConsumerLagTooHigh.md
@@ -1,0 +1,36 @@
+---
+title: KafkaConsumerLagTooHigh
+weight: 20
+---
+
+# KafkaConsumerLagTooHigh
+
+## Problem
+
+A consumer group's lag on a topic has exceeded 1000 messages for more than 15 minutes. Consumers are falling behind the producers.
+
+## Impact
+
+- Data reaches downstream systems (e.g. OpenSearch) later than expected.
+- If lag keeps growing, messages may be dropped once they exceed the topic retention before being consumed.
+
+## Diagnosis
+
+1. Identify the affected `consumergroup` and `topic` from the alert labels. In fortlogs deployments the consumers are the ingesters.
+
+2. Check the consumer pods and their logs for crashes, restarts, or errors (bad credentials, unreachable backend, downstream rejects):
+
+   ```
+   kubectl get pods -n <ingester-namespace> | grep -i ingester
+   kubectl logs <ingester-pod> -n <ingester-namespace> --tail=200
+   ```
+
+3. Decide whether a consumer is stalled/failing, whether it simply can't keep up with sustained load, or whether producer volume spiked (e.g. a log storm).
+
+## Solution
+
+- **Stalled or failing consumer:** fix the root cause from the logs and restart the pod; confirm it rejoins the group and lag drains.
+- **Can't keep up with load:** increase consuming capacity. Scale up the ingester pods (parallelism is capped at the topic's partition count) and/or increase `num_sender` so each pod pushes more batches concurrently. If already at the partition count, raise the topic partitions and downstream backend capacity.
+- **Expected spike:** if the lag is a known, temporary spike that is already draining, mute the alert and notify the service owner.
+
+Confirm lag returns below the threshold and stays there.

--- a/kafka/playbooks/KafkaNoBrokersOnline.md
+++ b/kafka/playbooks/KafkaNoBrokersOnline.md
@@ -1,0 +1,45 @@
+---
+title: KafkaNoBrokersOnline
+weight: 20
+---
+
+# KafkaNoBrokersOnline
+
+## Problem
+
+The `kafka_server_kafkaserver_brokerstate` metric is entirely absent, meaning no Kafka broker is reporting metrics. The cluster is almost certainly down or unreachable from Prometheus.
+
+## Impact
+
+- Total outage: no producers can write and no consumers can read.
+- Downstream pipelines (e.g. OpenSearch ingestion) stop receiving data, and unconsumed messages may be lost once retention expires.
+
+## Diagnosis
+
+1. Check the broker pods:
+
+   ```
+   kubectl get pods -n <kafka-namespace> -l strimzi.io/component-type=kafka -o wide
+   ```
+
+   - No pods → the Kafka cluster is not deployed or the pods are failing to schedule (check the `Kafka`/`KafkaNodePool` resources, the Strimzi operator, and node capacity). Less likely, the resource or namespace was removed.
+   - Pods present but not `Running` → the brokers are failing to start.
+   - Pods `Running` and healthy → the problem is metrics scraping, not Kafka itself.
+
+2. For failing brokers, inspect logs and events for the root cause (storage unavailable, config error, node or KRaft quorum problem):
+
+   ```
+   kubectl logs <kafka-broker-pod> -n <kafka-namespace> --tail=200
+   kubectl describe pod <kafka-broker-pod> -n <kafka-namespace>
+   ```
+
+3. Check for infrastructure outages affecting all brokers at once (node pool down, storage backend unavailable).
+
+## Solution
+
+- **Brokers failing to start:** fix the underlying issue (restore storage, correct config) and let Strimzi bring the brokers back.
+- **Infrastructure outage:** resolve the node/storage problem; brokers recover once nodes and volumes return.
+- **Metrics-only problem:** if brokers are healthy, restart the affected pod or reconcile the PodMonitor so Prometheus resumes scraping.
+- **Expected downtime:** mute the alert and notify the service owner.
+
+Confirm broker pods are `Running` and the metric reappears in Prometheus.

--- a/kafka/playbooks/KafkaUnderReplicatedPartitions.md
+++ b/kafka/playbooks/KafkaUnderReplicatedPartitions.md
@@ -1,0 +1,40 @@
+---
+title: KafkaUnderReplicatedPartitions
+weight: 20
+---
+
+# KafkaUnderReplicatedPartitions
+
+## Problem
+
+One or more topic partitions have had fewer in-sync replicas (ISR) than configured for more than 15 minutes. A follower replica is not keeping up with, or has lost contact with, the leader.
+
+## Impact
+
+- Reduced fault tolerance: if the leader for an under-replicated partition fails, data loss or unavailability may occur.
+- Producers using `acks=all` may start failing writes if ISR drops below `min.insync.replicas`.
+
+## Diagnosis
+
+1. Check the broker pods. A brief window of under-replication during a rolling restart or rebalance is normal and self-heals; a persistent 15-minute alert means a broker is genuinely unhealthy:
+
+   ```
+   kubectl get pods -n <kafka-namespace> -l strimzi.io/component-type=kafka -o wide
+   ```
+
+2. Inspect the affected broker's logs and disk. A crashing broker or a full/slow disk is the usual cause of a follower falling out of ISR:
+
+   ```
+   kubectl logs <kafka-broker-pod> -n <kafka-namespace> --tail=200
+   kubectl exec <kafka-broker-pod> -n <kafka-namespace> -- df -h /var/lib/kafka
+   ```
+
+3. Check for node-level problems (node under pressure, drained, or network partition).
+
+## Solution
+
+- **Unhealthy broker:** let Strimzi recover it; delete a stuck pod so the operator recreates it, and confirm it rejoins and ISR is restored.
+- **Disk full:** free space or expand the broker's volume; review topic retention if disks fill repeatedly.
+- **Node problem:** cordon/drain the bad node and let the pod reschedule (anti-affinity keeps brokers spread across nodes).
+
+Confirm `kafka_topic_partition_under_replicated_partition` returns to 0 for the affected topic.

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.12
+  version: 0.1.13
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.12
+    version: 0.1.13
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

Add PrometheusRule alerts for the Kafka plugin, based on monitoring.mixins.dev/kafka.

- 3 alerts: consumer lag too high, under-replicated partitions, no brokers online
- Each alert links to an initial playbook 
- All fire at severity: info for now, with the intended real severity noted inline
