### PR TITLE
fix(logs): recover syslog appname from message for ESXi audit routing

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.26
+version: 0.4.27
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -9,15 +9,17 @@ SPDX-License-Identifier: Apache-2.0
   for VMware infrastructure sources (ESXi, vCSA, NSX-T).
 
   This implements:
-  1. Early drop of known non-audit-relevant log messages (by content pattern)
-  2. Process-based audit classification (whitelist of audit-relevant processes)
-  3. Drop of specific non-audit processes (vpxd-profiler, postgres-archiver)
-  4. Drop of verbose logs
-  5. Routing of non-audit logs to a separate index
-  6. User field extraction (ESXi user, failed login user)
-  7. Hostname parsing (node name, audit source: ESXi/NSX-T/VCSA, building block)
-  8. VM event parsing (ESXi reconfigure/error events)
-  9. SSH login parsing (ESXi sshd accepted keyboard-interactive)
+  1.  Early drop of known non-audit-relevant log messages (by content pattern)
+  2.  Process-based audit classification (whitelist of audit-relevant processes)
+  3.  Drop of specific non-audit processes (vpxd-profiler, postgres-archiver)
+  4.  Drop of verbose logs
+  5.  Routing of non-audit logs to a separate index
+  6.  User field extraction (ESXi user, failed login user)
+  7.  Hostname parsing (node name, audit source: ESXi/NSX-T/VCSA, building block)
+  8.  VM event parsing (ESXi reconfigure/error events)
+  9.  SSH login parsing (ESXi sshd accepted keyboard-interactive)
+  10. Appname recovery from message when the receiver's ISO8601 regex_parser
+      path did not populate it (fixes ESXi audit routing)
 
   Field mapping (syslog → OTel receiver attributes):
     The OTel syslog receiver (both rfc5424 and rfc3164) parses syslog fields
@@ -63,6 +65,40 @@ transform/syslog_forwarded_by:
         - 'set(attributes["forwarded_by"], "octobus_logstash") where attributes["message"] == nil and body != nil and IsMatch(body, ".*forwarded_by=octobus_logstash.*")'
         - 'replace_pattern(attributes["message"], " forwarded_by=octobus_logstash", "") where attributes["forwarded_by"] == "octobus_logstash" and attributes["message"] != nil'
         - 'replace_pattern(body, " forwarded_by=octobus_logstash", "") where attributes["forwarded_by"] == "octobus_logstash" and body != nil'
+
+{{/*
+  ============================================================================
+  Extract appname from message body
+  The tcp_log syslog receiver routes lines with an ISO8601 timestamp
+  (e.g. "<166>2026-08-06T07:28:13.586Z host Hostd: …") through a
+  regex_parser that only captures priority/timestamp/hostname/message —
+  it does NOT populate `appname`. The tag ("Hostd", "sshd", "vpxd", …)
+  stays glued to the front of `message`.
+
+  Without `appname`:
+    - transform/syslog_audit_classification cannot flip audit_relevant to
+      "true" for audit-relevant processes (Hostd, NSX, procstate, shell,
+      sshd, ssoAudit, vpxd, ssoadminserver, sudo), so ESXi audit records
+      wrongly land in the non-audit datastream.
+    - transform/syslog_user_extraction skips its Hostd/vobd/vpxd-guarded
+      login-failure grok.
+    - transform/syslog_esxi_sshd and its VM-event parser never fire.
+
+  This transform recovers appname from the leading "<tag>:" token in
+  `message` when appname is not already set, then strips the tag from
+  `message` so downstream matchers do not re-match it.
+
+  Must be wired AFTER transform/syslog_forwarded_by and BEFORE
+  transform/syslog_user_extraction in every syslog pipeline.
+  ============================================================================
+*/}}
+transform/syslog_extract_appname_from_message:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "^(?P<appname>[A-Za-z0-9_.-]+):"), "upsert") where log.attributes["appname"] == nil and log.attributes["message"] != nil'
+        - 'replace_pattern(log.attributes["message"], "^[A-Za-z0-9_.-]+:\\s*", "") where log.attributes["appname"] != nil and log.attributes["message"] != nil and IsMatch(log.attributes["message"], "^[A-Za-z0-9_.-]+:\\s*")'
 
 {{/*
   ============================================================================

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -367,6 +367,7 @@ logs/syslog_tcp:
     - filter/syslog_drop_verbose
     - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
+    - transform/syslog_extract_appname_from_message
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events
@@ -385,6 +386,7 @@ logs/syslog_udp:
     - filter/syslog_drop_verbose
     - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
+    - transform/syslog_extract_appname_from_message
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events
@@ -405,6 +407,7 @@ logs/syslog_tcp_tls:
     - filter/syslog_drop_verbose
     - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
+    - transform/syslog_extract_appname_from_message
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.26
+  version: 0.15.27
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.26
+    version: 0.4.27
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Problem

ESXi audit-relevant syslog records (`Hostd`, `sshd`, `vpxd`, `sudo`, `ssoAudit`, `ssoadminserver`, `procstate`, `shell`, `NSX`) are silently routed to the **non-audit** datastream instead of the audit datastream. On `eu-de-1/fortlogs-logs`, 100 % of ESXi traffic lands in `logs.fortlogs`; `audit.fortlogs` receives none.

## Root cause

`receivers.tcp_log/syslog` has a router operator that dispatches based on the timestamp shape in the body:

- `^<\d+>\d+ ` → `syslog_5424_parser` (native `syslog_parser`, populates `appname`) ✅
- `^<\d+>(Jan|Feb|…)` → `syslog_3164_parser` (native `syslog_parser`, populates `appname`) ✅
- `^<\d+>\d{4}-\d{2}-\d{2}T` → `syslog_iso_parser` — a **plain `regex_parser`** that only captures `priority`, `timestamp`, `hostname`, `message`. **Does not populate `appname`.** ❌

VMware/ESXi hosts forwarding through Logstash emit the ISO8601 form, so the tag (`Hostd:`) stays glued to the start of `attributes["message"]`.

Downstream, `transform/syslog_audit_classification` reads `attributes["appname"]`:

```yaml
- set(log.attributes["audit_relevant"], "false")
- set(log.attributes["audit_relevant"], "true") where log.attributes["appname"] != nil and IsMatch(log.attributes["appname"], "(?i)^(Hostd|NSX|procstate|shell|sshd|ssoAudit|vpxd|ssoadminserver|sudo):?$")
```

With `appname == nil`, the second statement no-ops (`error_mode: ignore` swallows it), `audit_relevant` stays `"false"`, and the routing connector sends every record to `logs/syslog_non_audit`.

Same starvation affects `transform/syslog_user_extraction`'s login-failure grok (gated on `appname ~= /^(Hostd|vobd|vpxd):?$/`) and `transform/syslog_esxi_sshd` (gated on `appname == "sshd"`).

## Sample record (from `.ds-syslog-*` on eu-de-1)

```json
{
  "attributes": {
    "audit_relevant": "false",
    "audit_source": "ESXi",
    "message": "Hostd: info hostd[2099704] [Originator@6876 sub=Vimsvc.TaskManager opID=6b90f099 user=vpxuser] Task Completed …",
    "syslog": { "format": "rfc3164_iso8601" }
    /* no appname attribute */
  },
  "body": "<166>2026-08-06T07:28:13.586Z node014-bb201.cc.eu-de-1.cloud.sap Hostd: info hostd[2099704] …"
}
```

## Fix

New `transform/syslog_extract_appname_from_message` transform that:

1. Extracts the leading `<tag>:` token into `appname` when `appname` is nil.
2. Strips the tag from `message` so downstream matchers don't double-hit it.

Wired into all three syslog pipelines (`logs/syslog_tcp`, `logs/syslog_udp`, `logs/syslog_tcp_tls`), positioned **after** `transform/syslog_forwarded_by` and **before** `transform/syslog_user_extraction` — so user extraction, ESXi VM events, ESXi sshd, and audit classification all see a populated `appname`.

Records already produced by the native `syslog_parser` branches (RFC5424, RFC3164) have `appname` set → the extraction no-ops (guarded by `where appname == nil`).

## Alternative considered

Fixing the receiver-level `syslog_iso_parser` to also extract `appname` (e.g. extend the regex or chain a second parser). Rejected here because:

- The transform-level fix is a strict superset — it also recovers `appname` for any future receiver path that forgets to set it.
- Receiver-level operator changes require more careful validation of the router regex + parser interaction.

Happy to switch approaches if maintainers prefer.

## Verification

Applied the same OTTL statements live to the `external` `OpenTelemetryCollector` CR in `eu-de-1/fortlogs-logs`:

- StatefulSet `external-collector` rolled all 3 replicas cleanly (`1/1 Running`).
- No new error/warning logs from the new processor.
- Pre-existing `syslog_user_extraction` nil-message warnings and RFC3164 stamp-parse errors were unchanged (independent of this patch).
- Running config pipeline order (verified via `kubectl get otelcol external -o jsonpath=…`):

  ```
  filter/syslog_early_drop
  filter/syslog_drop_verbose
  transform/syslog_observed_timestamp_fallback
  transform/syslog_forwarded_by
  transform/syslog_extract_appname_from_message   ← NEW
  transform/syslog_user_extraction
  transform/syslog_hostname_parsing
  transform/syslog_esxi_vm_events
  transform/syslog_esxi_sshd
  transform/syslog_audit_classification
  transform/syslog_semconv_normalization
  transform/syslog_drop_legacy_fields
  transform/truncate_message
  attributes/cluster
  ```

Note: the live patch will be reverted by Flux on the next reconcile — this PR is the permanent fix.

## Non-audit ESXi processes unchanged

`vmkernel`, `Vpxa`, `vobd`, `fdm`, etc. are not in the audit allowlist; they will still correctly route to `logs-datastream` — this PR does not change that.

## Version bumps

- `logs/charts/Chart.yaml`: `0.4.26` → `0.4.27`
- `logs/plugindefinition.yaml` `spec.version`: `0.15.26` → `0.15.27`
- `logs/plugindefinition.yaml` `spec.helmChart.version`: `0.4.26` → `0.4.27`
