### PR TITLE
fix(logs): recover syslog appname from message for ESXi audit routing

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.26
+version: 0.4.27
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -9,15 +9,17 @@ SPDX-License-Identifier: Apache-2.0
   for VMware infrastructure sources (ESXi, vCSA, NSX-T).
 
   This implements:
-  1. Early drop of known non-audit-relevant log messages (by content pattern)
-  2. Process-based audit classification (whitelist of audit-relevant processes)
-  3. Drop of specific non-audit processes (vpxd-profiler, postgres-archiver)
-  4. Drop of verbose logs
-  5. Routing of non-audit logs to a separate index
-  6. User field extraction (ESXi user, failed login user)
-  7. Hostname parsing (node name, audit source: ESXi/NSX-T/VCSA, building block)
-  8. VM event parsing (ESXi reconfigure/error events)
-  9. SSH login parsing (ESXi sshd accepted keyboard-interactive)
+  1.  Early drop of known non-audit-relevant log messages (by content pattern)
+  2.  Process-based audit classification (whitelist of audit-relevant processes)
+  3.  Drop of specific non-audit processes (vpxd-profiler, postgres-archiver)
+  4.  Drop of verbose logs
+  5.  Routing of non-audit logs to a separate index
+  6.  User field extraction (ESXi user, failed login user)
+  7.  Hostname parsing (node name, audit source: ESXi/NSX-T/VCSA, building block)
+  8.  VM event parsing (ESXi reconfigure/error events)
+  9.  SSH login parsing (ESXi sshd accepted keyboard-interactive)
+  10. Appname recovery from message when the receiver's ISO8601 regex_parser
+      path did not populate it (fixes ESXi audit routing)
 
   Field mapping (syslog → OTel receiver attributes):
     The OTel syslog receiver (both rfc5424 and rfc3164) parses syslog fields
@@ -63,6 +65,18 @@ transform/syslog_forwarded_by:
         - 'set(attributes["forwarded_by"], "octobus_logstash") where attributes["message"] == nil and body != nil and IsMatch(body, ".*forwarded_by=octobus_logstash.*")'
         - 'replace_pattern(attributes["message"], " forwarded_by=octobus_logstash", "") where attributes["forwarded_by"] == "octobus_logstash" and attributes["message"] != nil'
         - 'replace_pattern(body, " forwarded_by=octobus_logstash", "") where attributes["forwarded_by"] == "octobus_logstash" and body != nil'
+
+{{/*
+  ============================================================================
+  Extract appname from message body
+  ============================================================================
+*/}}
+transform/syslog_extract_appname_from_message:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "^(?P<appname>[A-Za-z0-9_.-]+):"), "upsert") where log.attributes["appname"] == nil and log.attributes["message"] != nil'
 
 {{/*
   ============================================================================

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -367,6 +367,7 @@ logs/syslog_tcp:
     - filter/syslog_drop_verbose
     - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
+    - transform/syslog_extract_appname_from_message
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events
@@ -385,6 +386,7 @@ logs/syslog_udp:
     - filter/syslog_drop_verbose
     - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
+    - transform/syslog_extract_appname_from_message
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events
@@ -405,6 +407,7 @@ logs/syslog_tcp_tls:
     - filter/syslog_drop_verbose
     - transform/syslog_observed_timestamp_fallback
     - transform/syslog_forwarded_by
+    - transform/syslog_extract_appname_from_message
     - transform/syslog_user_extraction
     - transform/syslog_hostname_parsing
     - transform/syslog_esxi_vm_events

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.26
+  version: 0.15.27
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.26
+    version: 0.4.27
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Problem

ESXi audit-relevant syslog records (`Hostd`, `sshd`, `vpxd`, `sudo`, `ssoAudit`, `ssoadminserver`, `procstate`, `shell`, `NSX`) are silently routed to the **non-audit** datastream instead of the audit datastream. 

## Fix

New `transform/syslog_extract_appname_from_message` transform that:

1. Extracts the leading `<tag>:` token into `appname` when `appname` is nil.
2. Strips the tag from `message` so downstream matchers don't double-hit it.

