### PR TITLE
feat(audit-logs): tag vault-tec container logs with audit.source

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.6
+version: 0.2.7
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -122,6 +122,7 @@ spec:
           - /var/log/pods/*/keystone-api/*.log
           - /var/log/pods/dns_coredns-api*/audit/*.log
           - /var/log/pods/vault*/audit/*.log
+          - /var/log/pods/vault_vault-tec-*/vault-tec*/*.log
           - /var/log/pods/kube-monitoring_kube-monitoring-metal-falco*/*/*.log
           - /var/log/pods/kube-monitoring_kube-monitoring-scaleout-falco*/*/*.log
         max_log_size: 16384
@@ -217,6 +218,15 @@ spec:
               - resource.attributes["k8s.namespace.name"] == "vault"
             statements:
               - set(log.attributes["audit.source"], "vault")
+
+      transform/vault-tec_attributes:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            conditions:
+              - resource.attributes["k8s.container.name"] == "vault-tec"
+            statements:
+              - set(log.attributes["audit.source"], "vault-tec")
 
       transform/falco_attributes:
         error_mode: ignore
@@ -683,7 +693,7 @@ spec:
 {{- if .Values.auditLogs.logsCollector.containerd.enabled }}
         logs/containerd:
           receivers: [file_log/containerd]
-          processors: [k8s_attributes,attributes/cluster,transform/keystone_api,transform/keystone_api_json,transform/keystone_attributes,transform/keystone_global_attributes,transform/vault,transform/vault_attributes,transform/falco_attributes,transform/ingress,batch]
+          processors: [k8s_attributes,attributes/cluster,transform/keystone_api,transform/keystone_api_json,transform/keystone_attributes,transform/keystone_global_attributes,transform/vault,transform/vault_attributes,transform/vault-tec_attributes,transform/falco_attributes,transform/ingress,batch]
           exporters: [routing]
 {{- end }}
 

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.6
+    version: 0.2.7
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.6
+        version: 0.2.7
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
## Details

Adds /var/log/pods/vault_vault-tec-*/vault-tec*/*.log to the containerd file_log receiver, and a transform/vault-tec_attributes processor that sets audit.source="vault-tec" for pods whose container name is vault-tec. Wired into the logs/containerd pipeline next to the existing transform/vault_attributes.

Translates the fluentd-style entry:
  - id: vault-tec path: /var/log/containers/vault-tec-*vault_vault-tec-*.log tag: vault-tec.* field: name: sap.cc.audit.source value: vault-tec


Bumps chart + plugindefinition to 0.2.7.
