### PR TITLE
fix(logs, audit-logs): unify label back to sap.cc.audit.source

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.7
+version: 0.2.8
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -199,7 +199,7 @@ spec:
             conditions:
               - resource.attributes["k8s.container.name"] == "keystone-api"
             statements:
-              - set(log.attributes["audit.source"], "keystone-api")
+              - set(log.attributes["sap.cc.audit.source"], "keystone-api")
 
       transform/keystone_global_attributes:
         error_mode: ignore
@@ -208,7 +208,7 @@ spec:
             conditions:
               - resource.attributes["k8s.namespace.name"] == "monsoon3global"
             statements:
-              - set(log.attributes["audit.source"], "keystone-global-api")
+              - set(log.attributes["sap.cc.audit.source"], "keystone-global-api")
 
       transform/vault_attributes:
         error_mode: ignore
@@ -217,7 +217,7 @@ spec:
             conditions:
               - resource.attributes["k8s.namespace.name"] == "vault"
             statements:
-              - set(log.attributes["audit.source"], "vault")
+              - set(log.attributes["sap.cc.audit.source"], "vault")
 
       transform/vault-tec_attributes:
         error_mode: ignore
@@ -226,7 +226,7 @@ spec:
             conditions:
               - resource.attributes["k8s.container.name"] == "vault-tec"
             statements:
-              - set(log.attributes["audit.source"], "vault-tec")
+              - set(log.attributes["sap.cc.audit.source"], "vault-tec")
 
       transform/falco_attributes:
         error_mode: ignore
@@ -235,7 +235,7 @@ spec:
             conditions:
               - resource.attributes["k8s.container.name"] == "falco"
             statements:
-              - set(log.attributes["audit.source"], "falco")
+              - set(log.attributes["sap.cc.audit.source"], "falco")
 
       transform/keystone_api:
         error_mode: ignore

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.7
+    version: 0.2.8
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.7
+        version: 0.2.8
     options:
         - name: auditLogs.region
           description: Region label for logging

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.29
+version: 0.4.30
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -241,16 +241,16 @@ transform/syslog_hostname_parsing:
         # Fallback: try net.peer.name if hostname attribute is not set (common for RFC3164)
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["net.peer.name"], "(?P<node_nodename>node(\\d{3}|swift\\d{2})[a-zA-Z0-9.-]+)"), "upsert") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil'
         # Set audit source to ESXi if node name was extracted
-        - 'set(log.attributes["audit.source"], "ESXi") where log.attributes["node_nodename"] != nil'
+        - 'set(log.attributes["sap.cc.audit.source"], "ESXi") where log.attributes["node_nodename"] != nil'
         # NSX-T hostname detection (nsx-ctl*) - check both hostname and net.peer.name
-        - 'set(log.attributes["audit.source"], "NSX-T") where log.attributes["hostname"] != nil and IsMatch(log.attributes["hostname"], "nsx-ctl.*")'
-        - 'set(log.attributes["audit.source"], "NSX-T") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and IsMatch(log.attributes["net.peer.name"], "nsx-ctl.*")'
+        - 'set(log.attributes["sap.cc.audit.source"], "NSX-T") where log.attributes["hostname"] != nil and IsMatch(log.attributes["hostname"], "nsx-ctl.*")'
+        - 'set(log.attributes["sap.cc.audit.source"], "NSX-T") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and IsMatch(log.attributes["net.peer.name"], "nsx-ctl.*")'
         # VCSA hostname detection (vc-*) - check both hostname and net.peer.name
-        - 'set(log.attributes["audit.source"], "VCSA") where log.attributes["hostname"] != nil and IsMatch(log.attributes["hostname"], "vc-.*")'
-        - 'set(log.attributes["audit.source"], "VCSA") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and IsMatch(log.attributes["net.peer.name"], "vc-.*")'
+        - 'set(log.attributes["sap.cc.audit.source"], "VCSA") where log.attributes["hostname"] != nil and IsMatch(log.attributes["hostname"], "vc-.*")'
+        - 'set(log.attributes["sap.cc.audit.source"], "VCSA") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and IsMatch(log.attributes["net.peer.name"], "vc-.*")'
         # Extract building block from hostname (for ESXi and NSX-T)
-        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["hostname"], "(?P<node_building_block>bb\\d{3})"), "upsert") where log.attributes["hostname"] != nil and (log.attributes["audit.source"] == "ESXi" or log.attributes["audit.source"] == "NSX-T")'
-        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["net.peer.name"], "(?P<node_building_block>bb\\d{3})"), "upsert") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and (log.attributes["audit.source"] == "ESXi" or log.attributes["audit.source"] == "NSX-T")'
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["hostname"], "(?P<node_building_block>bb\\d{3})"), "upsert") where log.attributes["hostname"] != nil and (log.attributes["sap.cc.audit.source"] == "ESXi" or log.attributes["sap.cc.audit.source"] == "NSX-T")'
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["net.peer.name"], "(?P<node_building_block>bb\\d{3})"), "upsert") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and (log.attributes["sap.cc.audit.source"] == "ESXi" or log.attributes["sap.cc.audit.source"] == "NSX-T")'
 
 {{/*
   ============================================================================
@@ -262,7 +262,7 @@ transform/syslog_esxi_vm_events:
   log_statements:
     - context: log
       conditions:
-        - 'log.attributes["audit.source"] == "ESXi"'
+        - 'log.attributes["sap.cc.audit.source"] == "ESXi"'
       statements:
         # Parse VM reconfigure/error events
         - 'merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["message"], "Event %{NONNEGINT:event_id} : (?:Reconfigured|Error message on) %{DATA:cloud_instance_name} \\(%{UUID:cloud_instance_id}\\)%{GREEDYDATA}", true), "upsert")'
@@ -277,7 +277,7 @@ transform/syslog_esxi_sshd:
   log_statements:
     - context: log
       conditions:
-        - 'log.attributes["audit.source"] == "ESXi"'
+        - 'log.attributes["sap.cc.audit.source"] == "ESXi"'
         - 'log.attributes["appname"] == "sshd"'
         - 'IsMatch(log.attributes["message"], ".*Accepted keyboard-interactive/pam for root from.*")'
       statements:

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.29
+  version: 0.15.30
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.29
+    version: 0.4.30
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Details

 Reverts the unification key from `audit.source` to `sap.cc.audit.source` across both plugins to align with the namespaced attribute convention.