### PR TITLE
feat(audit-logs): translate old audit logstash into otelcol

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -102,6 +102,12 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.logsCollector.kafka.tls.insecure_skip_verify | bool | `false` | Skip server certificate verification. Leave false for production. |
 | auditLogs.logsCollector.kafka.topic | string | `""` | Kafka topic name for audit logs |
 | auditLogs.logsCollector.kubeApiAudit.enabled | bool | `false` | Activates export for kube-apiserver audit logs |
+| auditLogs.logstashExternal.http.enabled | bool | `false` | Activates the HTTP OTLP receiver with basic-auth and TLS. Translates the logstash http input (AUDIT_HTTP_USER/PWD). Parses JSON body and sets sap.cc.audit.source from event.details.serviceProvider or logger_name. |
+| auditLogs.logstashExternal.http.port | int | `443` | Port to listen on for the HTTP OTLP receiver. |
+| auditLogs.logstashExternal.mtls.enabled | bool | `false` | Activates the mTLS OTLP receiver for kube-api audit events. Translates the logstash mtls input (kube-api tag). Parses kube-api audit JSON, fixes managedFields/status type conflicts and uses requestReceivedTimestamp. |
+| auditLogs.logstashExternal.mtls.port | int | `1081` | Port to listen on for the mTLS OTLP receiver. |
+| auditLogs.logstashExternal.syslog.enabled | bool | `false` | Activates syslog UDP/TCP receivers (rfc3164). Translates the logstash syslog input with source detection for remoteboard/ucsc/hsm. |
+| auditLogs.logstashExternal.syslog.port | int | `514` | Port to listen on for syslog UDP and TCP. |
 | auditLogs.nodeSelector | object | `{}` |  |
 | auditLogs.openSearchLogs.endpoint | string | `nil` | Endpoint URL for OpenSearch |
 | auditLogs.openSearchLogs.failover_password_a | string | `nil` | Password for OpenSearch endpoint |
@@ -117,7 +123,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.prometheus.rules.additionalRuleLabels | string | `nil` | Additional labels for PrometheusRule alerts. |
 | auditLogs.prometheus.rules.create | bool | `true` | Enables PrometheusRule resources to be created. |
 | auditLogs.prometheus.rules.labels | object | `{}` | Labels for PrometheusRules. |
-| auditLogs.prometheus.serviceMonitor | object | `{"enabled":false}` | Activates the pod-monitoring for the Logs Collector. |
+| auditLogs.prometheus.serviceMonitor.enabled | bool | `false` |  |
 | auditLogs.region | string | `nil` | Region label for Logging |
 | auditLogs.terminationGracePeriodSeconds | int | `30` | Grace period for pod termination in seconds |
 | auditPoller.enabled | bool | `false` | Enables the audit-poller deployment for polling IAS audit logs |

--- a/audit-logs/charts/ci/test-values.yaml
+++ b/audit-logs/charts/ci/test-values.yaml
@@ -39,6 +39,16 @@ auditLogs:
       protocol_version: "3.9.0"
       encoding: otlp_json
       compression: snappy
+    logstashExternal:
+      syslog:
+        enabled: true
+        port: 514
+      http:
+        enabled: true
+        port: 443
+      mtls:
+        enabled: true
+        port: 1081
   prometheus:
     podMonitor:
       enabled: true

--- a/audit-logs/charts/templates/_http-audit-config.tpl
+++ b/audit-logs/charts/templates/_http-audit-config.tpl
@@ -1,0 +1,42 @@
+{{- define "http_audit.receiver" }}
+otlp/http_audit:
+  protocols:
+    http:
+      endpoint: "0.0.0.0:{{ .Values.auditLogs.logstashExternal.http.port }}"
+      auth:
+        authenticator: basicauth/http_audit
+      tls:
+        cert_file: /tls-secret/tls.crt
+        key_file: /usr/share/otelcol/config/tls.key
+        min_version: "1.2"
+{{- end }}
+
+
+{{- define "http_audit.processors" }}
+transform/http_audit:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - merge_maps(attributes, ParseJSON(body), "upsert") where IsMatch(body, "^\\{")
+        - set(attributes["sap.cc.region"], "${region}")
+        - set(attributes["sap.cc.cluster"], "${cluster}")
+        - set(attributes["sap.cc.audit.source"], "awx") where IsMatch(attributes["logger_name"], "awx")
+        - set(attributes["sap.cc.audit.source"], attributes["event.details.serviceProvider"]) where attributes["event.details.serviceProvider"] != nil
+{{- end }}
+
+
+{{- define "http_audit.extension" }}
+basicauth/http_audit:
+  htpasswd:
+    inline: |
+      ${AUDIT_HTTP_USER}:${AUDIT_HTTP_PWD}
+{{- end }}
+
+
+{{- define "http_audit.pipeline" }}
+logs/http_audit:
+  receivers: [otlp/http_audit]
+  processors: [transform/http_audit, attributes/cluster, batch]
+  exporters: [routing]
+{{- end }}

--- a/audit-logs/charts/templates/_mtls-audit-config.tpl
+++ b/audit-logs/charts/templates/_mtls-audit-config.tpl
@@ -1,0 +1,39 @@
+{{- define "mtls_audit.receiver" }}
+otlp/mtls_audit:
+  protocols:
+    http:
+      endpoint: "0.0.0.0:{{ .Values.auditLogs.logstashExternal.mtls.port }}"
+      tls:
+        cert_file: /tls-secret/tls.crt
+        key_file: /usr/share/otelcol/config/tls.key
+        client_ca_file: /tls-secret/ca.crt
+        min_version: "1.2"
+{{- end }}
+
+
+{{- define "mtls_audit.processors" }}
+transform/kube_api:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      statements:
+        - merge_maps(attributes, ParseJSON(body), "upsert") where IsMatch(body, "^\\{")
+        - set(attributes["sap.cc.audit.source"], "kube-api")
+        - set(attributes["sap.cc.cluster"], attributes["annotations.shoot.gardener.cloud/name"]) where attributes["annotations.shoot.gardener.cloud/name"] != nil
+        - set(attributes["sap.cc.audit.gardener_seed"], attributes["annotations.seed.gardener.cloud/name"]) where attributes["annotations.seed.gardener.cloud/name"] != nil
+        - set(time_unix_nano, UnixNano(Time(attributes["requestReceivedTimestamp"], "%Y-%m-%dT%H:%M:%S.%fZ"))) where attributes["requestReceivedTimestamp"] != nil
+        - delete_key(attributes, "requestObject.metadata.managedFields")
+        - delete_key(attributes, "responseObject.metadata.managedFields")
+        - set(attributes["responseObject.statusText"], attributes["responseObject.status"]) where attributes["responseObject.kind"] == "Status"
+        - delete_key(attributes, "responseObject.status") where attributes["responseObject.kind"] == "Status"
+        - set(attributes["responseStatus.statusText"], attributes["responseStatus.status"]) where attributes["responseStatus.status"] != nil
+        - delete_key(attributes, "responseStatus.status") where attributes["responseStatus.statusText"] != nil
+{{- end }}
+
+
+{{- define "mtls_audit.pipeline" }}
+logs/mtls_audit:
+  receivers: [otlp/mtls_audit]
+  processors: [transform/kube_api, attributes/cluster, batch]
+  exporters: [routing]
+{{- end }}

--- a/audit-logs/charts/templates/_syslog-config.tpl
+++ b/audit-logs/charts/templates/_syslog-config.tpl
@@ -1,0 +1,42 @@
+{{- define "syslog.receivers" }}
+syslog/udp:
+  udp:
+    listen_address: "0.0.0.0:{{ .Values.auditLogs.logstashExternal.syslog.port }}"
+  protocol: rfc3164
+
+syslog/tcp:
+  tcp:
+    listen_address: "0.0.0.0:{{ .Values.auditLogs.logstashExternal.syslog.port }}"
+  protocol: rfc3164
+{{- end }}
+
+
+{{- define "syslog.processors" }}
+transform/syslog_source:
+  error_mode: ignore
+  log_statements:
+    - context: log
+      conditions:
+        - attributes["log.type"] == "syslog"
+      statements:
+        - set(attributes["sap.cc.region"], "${region}")
+        - set(attributes["sap.cc.cluster"], "${cluster}")
+        - set(attributes["sap.cc.audit.source"], "remoteboard") where IsMatch(attributes["hostname"], "^node\\d{2,3}r")
+        - set(attributes["sap.cc.audit.source"], "ucsc") where attributes["net.host.ip"] == "10.46.22.24" or attributes["net.host.ip"] == "10.67.75.240"
+        - set(attributes["sap.cc.audit.source"], "hsm") where IsMatch(attributes["hostname"], "hsm") or IsMatch(attributes["syslog.hostname"], "hsm")
+        - set(attributes["dropped_syslog"], true) where attributes["sap.cc.audit.source"] == nil
+
+filter/dropped_syslog:
+  error_mode: ignore
+  logs:
+    log_record:
+      - 'attributes["dropped_syslog"] == true'
+{{- end }}
+
+
+{{- define "syslog.pipeline" }}
+logs/syslog:
+  receivers: [syslog/udp, syslog/tcp]
+  processors: [transform/syslog_source, filter/dropped_syslog, attributes/cluster, batch]
+  exporters: [routing]
+{{- end }}

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -146,6 +146,16 @@ spec:
   {{- include "auditpoller.receiver" . | nindent 6 -}}
 {{- end }}
 
+{{- if .Values.auditLogs.logstashExternal.syslog.enabled }}
+  {{- include "syslog.receivers" . | nindent 6 -}}
+{{- end }}
+{{- if .Values.auditLogs.logstashExternal.http.enabled }}
+  {{- include "http_audit.receiver" . | nindent 6 -}}
+{{- end }}
+{{- if .Values.auditLogs.logstashExternal.mtls.enabled }}
+  {{- include "mtls_audit.receiver" . | nindent 6 -}}
+{{- end }}
+
 {{- if .Values.auditLogs.logsCollector.kubeApiAudit.enabled }}
       file_log/kube_audit:
         include: [ /var/log/kubernetes/audit/audit.log ]
@@ -353,6 +363,16 @@ spec:
               - set(log.body, "") where log.attributes["type"] != nil
 {{- end }}
 
+
+{{- if .Values.auditLogs.logstashExternal.syslog.enabled }}
+  {{- include "syslog.processors" . | nindent 6 -}}
+{{- end }}
+{{- if .Values.auditLogs.logstashExternal.http.enabled }}
+  {{- include "http_audit.processors" . | nindent 6 -}}
+{{- end }}
+{{- if .Values.auditLogs.logstashExternal.mtls.enabled }}
+  {{- include "mtls_audit.processors" . | nindent 6 -}}
+{{- end }}
 
 {{- if .Values.auditLogs.logsCollector.kubeApiAudit.enabled }}
       transform/kube_audit:
@@ -591,6 +611,9 @@ spec:
           username: ${failover_username_a}
           password: ${failover_password_a}
   {{- include "failover.extension" . | nindent 6 }}
+{{- if .Values.auditLogs.logstashExternal.http.enabled }}
+  {{- include "http_audit.extension" . | nindent 6 -}}
+{{- end }}
 {{- end }}
     connectors:
       routing:
@@ -626,6 +649,8 @@ spec:
 {{- else }}
         - basicauth/failover_a
         - basicauth/failover_b
+{{- if .Values.auditLogs.logstashExternal.http.enabled }}
+        - basicauth/http_audit
 {{- end }}
 {{- if .Values.auditLogs.prometheus.podMonitor.enabled }}
       telemetry:
@@ -698,4 +723,15 @@ spec:
           receivers: [k8s_events]
           processors: [attributes/k8sevents,transform/consolidate_label,resource,batch]
           exporters: [routing]
+
+{{- if .Values.auditLogs.logstashExternal.syslog.enabled }}
+  {{- include "syslog.pipeline" . | nindent 8 -}}
+{{- end }}
+{{- if .Values.auditLogs.logstashExternal.http.enabled }}
+  {{- include "http_audit.pipeline" . | nindent 8 -}}
+{{- end }}
+{{- if .Values.auditLogs.logstashExternal.mtls.enabled }}
+  {{- include "mtls_audit.pipeline" . | nindent 8 -}}
+{{- end }}
+{{- end }}
 {{- end }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -150,11 +150,27 @@ auditLogs:
     collectors: {}
 
 
+  logstashExternal:
+    syslog:
+      # -- Activates syslog UDP/TCP receivers (rfc3164). Translates the logstash syslog input with source detection for remoteboard/ucsc/hsm.
+      enabled: false
+      # -- Port to listen on for syslog UDP and TCP.
+      port: 514
+    http:
+      # -- Activates the HTTP OTLP receiver with basic-auth and TLS. Translates the logstash http input (AUDIT_HTTP_USER/PWD). Parses JSON body and sets sap.cc.audit.source from event.details.serviceProvider or logger_name.
+      enabled: false
+      # -- Port to listen on for the HTTP OTLP receiver.
+      port: 443
+    mtls:
+      # -- Activates the mTLS OTLP receiver for kube-api audit events. Translates the logstash mtls input (kube-api tag). Parses kube-api audit JSON, fixes managedFields/status type conflicts and uses requestReceivedTimestamp.
+      enabled: false
+      # -- Port to listen on for the mTLS OTLP receiver.
+      port: 1081
+    
   prometheus:
     # -- Activates the service-monitoring for the Logs Collector.
     podMonitor:
       enabled: false
-    # -- Activates the pod-monitoring for the Logs Collector.
     serviceMonitor:
       enabled: false
 

--- a/audit-logs/charts/vendor/README.md
+++ b/audit-logs/charts/vendor/README.md
@@ -1,0 +1,83 @@
+---
+title: Audit Logs Plugin
+---
+
+Learn more about the **Audit Logs** Plugin. Use it to enable the ingestion, collection and export of telemetry signals (logs and metrics) for your Greenhouse cluster.
+
+The main terminologies used in this document can be found in [core-concepts](https://cloudoperators.github.io/greenhouse/docs/getting-started/core-concepts).
+
+## Overview
+
+OpenTelemetry is an observability framework and toolkit for creating and managing telemetry data such as metrics, logs and traces. Unlike other observability tools, OpenTelemetry is vendor and tool agnostic, meaning it can be used with a variety of observability backends, including open source tools such as _OpenSearch_ and _Prometheus_.
+
+The focus of the Plugin is to provide easy-to-use configurations for common use cases of receiving, processing and exporting telemetry data in Kubernetes. The storage and visualization of the same is intentionally left to other tools.
+
+Components included in this Plugin:
+
+- [Collector](https://github.com/open-telemetry/opentelemetry-collector)
+- [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md)
+    - [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
+    - [k8sevents Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver)
+    - [journald Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)
+    - [prometheus/internal](https://opentelemetry.io/docs/collector/internal-telemetry/)
+- [Connector](https://opentelemetry.io/docs/collector/building/connector/)
+- [OpenSearch Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter)
+
+## Architecture
+
+![OpenTelemetry Architecture](img/otel-arch.png)
+
+## Note
+
+It is the intention to add more configuration over time and contributions of your very own configuration is highly appreciated. If you discover bugs or want to add functionality to the Plugin, feel free to create a pull request.
+
+## Quick Start
+
+This guide provides a quick and straightforward way to use **OpenTelemetry** for Logs as a Greenhouse Plugin on your Kubernetes cluster.
+
+**Prerequisites**
+
+- A running and Greenhouse-onboarded Kubernetes cluster. If you don't have one, follow the [Cluster onboarding](https://cloudoperators.github.io/greenhouse/docs/user-guides/cluster/onboarding) guide.
+- For logs, a OpenSearch instance to store. If you don't have one, reach out to your observability team to get access to one.
+- We recommend a running cert-manager in the cluster before installing the **Logs** Plugin
+- To gather metrics, you **must** have a Prometheus instance in the onboarded cluster for storage and for managing Prometheus specific CRDs. If you don not have an instance, install the [kube-monitoring](https://cloudoperators.github.io/greenhouse/docs/reference/catalog/kube-monitoring) Plugin first.
+- The **Audit Logs** Plugin currently requires the OpenTelemetry Operator bundled in the **Logs Plugin** to be installed in the same cluster beforehand. This is a technical limitation of the **Audit Logs** Plugin and will be removed in future releases.
+
+**Step 1:**
+
+You can install the `Logs` package in your cluster by installing it with [Helm](https://helm.sh/docs/helm/helm_install) manually or let the Greenhouse platform lifecycle do it for you automatically. For the latter, you can either:
+  1. Go to Greenhouse dashboard and select the **Logs** Plugin from the catalog. Specify the cluster and required option values.
+  2. Create and specify a `Plugin` resource in your Greenhouse central cluster according to the [examples](#examples).
+
+**Step 2:**
+
+The package will deploy the OpenTelemetry collectors and auto-instrumentation of the workload. By default, the package will include a configuration for collecting metrics and logs. The log-collector is currently processing data from the [preconfigured receivers](#Overview):
+- Files via the Filelog Receiver
+- Kubernetes Events from the Kubernetes API server
+- Journald events from systemd journal
+- its own metrics
+
+Based on the backend selection the telemetry data will be exporter to the backend.
+
+## Failover Connector
+
+The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/failoverconnector) for OpenSearch for two users. The connector will periodically try to establish a stable connection for the prefered user (`failover_username_a`) and in case of a failed try, the connector will try to establish a connection with the fallback user (`failover_username_b`). This feature can be used to secure the shipping of logs in case of expiring credentials or password rotation.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| iasApi.fileName | string | `"ias_api.log"` |  |
+| iasApi.interval | int | `5` |  |
+| iasChangelog.fileName | string | `"ias_changelog.log"` |  |
+| iasChangelog.interval | int | `30` |  |
+| image.repository | string | `""` |  |
+| image.tag | string | `""` |  |
+| logDir | string | `"/audit-poller"` |  |
+| logLevel | string | `"info"` |  |
+| metricsPort | int | `9298` |  |
+| persistence.enabled | bool | `false` |  |
+
+### Examples
+
+TBD


### PR DESCRIPTION
This should add the conversion of old logstash log shippers into the new modern otelcol format.

Adds three new external inputs:
- syslog
- http
- mtls

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>