### PR TITLE
feat(logs): external collector resources + kafka num_consumers

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -109,6 +109,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.externalCollector.kafkaTopic | string | `""` | Kafka topic name for external logs — alerts, deployments, syslog (e.g., "logs-external") |
 | openTelemetry.externalCollector.kafkaTracesTopic | string | `""` | Kafka topic name for traces (e.g., "traces") |
 | openTelemetry.externalCollector.replicas | int | `2` | Number of replicas for the external collector StatefulSet |
+| openTelemetry.externalCollector.resources | object | `{}` | Pod resource requests/limits for the external collector container. Empty = unbounded. |
 | openTelemetry.externalCollector.serviceAnnotations | object | `{}` | Additional annotations on the external Service |
 | openTelemetry.externalCollector.serviceType | string | `"LoadBalancer"` | Service type for the external collector service |
 | openTelemetry.externalCollector.syslogConfig | object | `{"auditKafkaTopic":"","enabled":false,"nonAuditKafkaTopic":"","openSearchLogs":{"auditEndpoint":"","audit_failover_password_a":"","audit_failover_password_b":"","audit_failover_username_a":"","audit_failover_username_b":"","nonAuditEndpoint":""},"tcp_port":514,"udp_port":514}` | Activates syslog TCP/UDP ingestion (rfc5424/rfc3164). |
@@ -150,7 +151,8 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
 | openTelemetry.kafka.producer | object | `{"flushMaxMessages":10000,"linger":"10ms"}` | Producer batching (raise linger to build larger batches per broker request) |
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
-| openTelemetry.kafka.sendingQueue | object | `{"enabled":true,"queueSize":1000}` | Producer sending queue size |
+| openTelemetry.kafka.sendingQueue | object | `{"enabled":true,"numConsumers":1,"queueSize":1000}` | Producer sending queue size |
+| openTelemetry.kafka.sendingQueue.numConsumers | int | `1` | Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput. |
 | openTelemetry.kafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
 | openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.affinity | object | See values.yaml | Pod affinity rules for the logs collector CR |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.31
+version: 0.4.32
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.30
+version: 0.4.31
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -428,6 +428,7 @@ kafka/syslog_audit:
     linger: {{ .Values.openTelemetry.kafka.producer.linger | quote }}
   sending_queue:
     enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+    num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
     queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
@@ -449,6 +450,7 @@ kafka/syslog_non_audit:
     linger: {{ .Values.openTelemetry.kafka.producer.linger | quote }}
   sending_queue:
     enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+    num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
     queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -16,6 +16,10 @@ metadata:
 spec:
   mode: statefulset
   replicas: {{ .Values.openTelemetry.externalCollector.replicas }}
+{{- with .Values.openTelemetry.externalCollector.resources }}
+  resources:
+    {{- toYaml . | nindent 4 }}
+{{- end }}
 {{- with .Values.openTelemetry.externalCollector.affinity }}
   affinity:
     {{- toYaml . | nindent 4 }}

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -174,6 +174,10 @@ spec:
           encoding: {{ .Values.openTelemetry.kafka.encoding }}
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
+        sending_queue:
+          enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+          num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
+          queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
@@ -190,6 +194,10 @@ spec:
           encoding: {{ .Values.openTelemetry.kafka.encoding }}
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
+        sending_queue:
+          enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+          num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
+          queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -243,6 +243,10 @@ spec:
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
           max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
+        sending_queue:
+          enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+          num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
+          queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
@@ -259,6 +263,10 @@ spec:
         producer:
           compression: {{ .Values.openTelemetry.kafka.compression }}
           max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
+        sending_queue:
+          enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
+          num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
+          queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -90,6 +90,8 @@ openTelemetry:
     sendingQueue:
       enabled: true
       queueSize: 1000
+      # -- Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput.
+      numConsumers: 1
     # -- Producer batching (raise linger to build larger batches per broker request)
     producer:
       flushMaxMessages: 10000

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -153,6 +153,8 @@ openTelemetry:
     enabled: false
     # -- Number of replicas for the external collector StatefulSet
     replicas: 2
+    # -- Pod resource requests/limits for the external collector container. Empty = unbounded.
+    resources: {}
     # -- Pod affinity rules for the external collector CR
     affinity: {}
     # -- External IP exposed on the service

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.30
+  version: 0.15.31
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.30
+    version: 0.4.31
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.31
+  version: 0.15.32
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.31
+    version: 0.4.32
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Adds two knobs to the external collector
- externalCollector.resources (the CR previously set no requests/limits)
- kafka.sendingQueue.numConsumers