### PR TITLE
fix(logs): mark audit log if field sap.cc.audit.source is not nil

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.30
+version: 0.4.31
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -287,6 +287,7 @@ transform/syslog_esxi_sshd:
   ============================================================================
   Adds an attribute to identify audit logs for routing.
   Audit-relevant processes: Hostd, NSX, procstate, shell, sshd, ssoAudit, vpxd, ssoadminserver, sudo
+  Also marks any log with a known audit source (sap.cc.audit.source) as audit-relevant.
   Everything else is non-audit (and goes to logs-datastream).
   ============================================================================
 */}}
@@ -299,6 +300,8 @@ transform/syslog_audit_classification:
         - 'set(log.attributes["audit_relevant"], "false")'
         # Mark as audit if process IS in the audit-relevant whitelist
         - 'set(log.attributes["audit_relevant"], "true") where log.attributes["appname"] != nil and IsMatch(log.attributes["appname"], "(?i)^(Hostd|NSX|procstate|shell|sshd|ssoAudit|vpxd|ssoadminserver|sudo):?$")'
+        # Mark as audit if the log has a known audit source (e.g. ESXi, NSX-T, VCSA)
+        - 'set(log.attributes["audit_relevant"], "true") where log.attributes["sap.cc.audit.source"] != nil'
 # Uses observedTimestamp as fallback when no timestamp could be parsed from the log body
 # (e.g. unknown format logs that end up with @timestamp = 1970-01-01T00:00:00Z)
 transform/syslog_observed_timestamp_fallback:

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.30
+  version: 0.15.31
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.30
+    version: 0.4.31
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Extend transform/syslog_audit_classification so that any log with a populated
sap.cc.audit.source attribute (ESXi, NSX-T, VCSA — set by transform/syslog_hostname_parsing)
is routed to the audit datastream in addition to logs matching the appname whitelist.