### PR TITLE
feat(digicert-issuer): bump helm chart to 2.8.2

### DIFF
--- a/digicert-issuer/plugindefinition.yaml
+++ b/digicert-issuer/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: digicert-issuer
 spec:
-  version: 1.3.3
+  version: 1.4.0
   displayName: DigiCert extensions
   description: Extensions to the cert-manager for DigiCert support
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/digicert-issuer/README.md
   helmChart:
     name: digicert-issuer
     repository: oci://ghcr.io/sapcc/helm-charts
-    version: 2.6.0
+    version: 2.8.2
   options:
     - name: provisioner.apiToken
       description: DigiCert cert-central API token


### PR DESCRIPTION
## Summary

Bump `digicert-issuer` PluginDefinition:
- `spec.version`: 1.3.3 → 1.4.0
- `spec.helmChart.version`: 2.6.0 → 2.8.2

## Notable changes in chart 2.8.2

- Guard PodMonitor template with CRD capability check (https://github.com/sapcc/helm-charts/pull/12510)
  - Prevents Helm install failures when `monitoring.coreos.com/v1` CRDs (prometheus-operator) are not yet installed on the cluster

## After merge

Please create tag `digicert-issuer/1.4.0` so consumers can pin to it.