### PR TITLE
logs: mark stnpa sources as audit-relevant so it gets routed to audit cluster

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.37
+version: 0.4.38
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -236,6 +236,8 @@ transform/syslog_hostname_parsing:
         # VCSA hostname detection (vc-*) - check both hostname and net.peer.name
         - 'set(log.attributes["sap.cc.audit.source"], "VCSA") where log.attributes["hostname"] != nil and IsMatch(log.attributes["hostname"], "vc-.*")'
         - 'set(log.attributes["sap.cc.audit.source"], "VCSA") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and IsMatch(log.attributes["net.peer.name"], "vc-.*")'
+        # STNPA source detection from appname prefix (do not overwrite an existing source)
+        - 'set(log.attributes["sap.cc.audit.source"], "stnpa") where log.attributes["sap.cc.audit.source"] == nil and log.attributes["appname"] != nil and IsMatch(log.attributes["appname"], "(?i)^stnpa")'
         # Extract building block from hostname (for ESXi and NSX-T)
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["hostname"], "(?P<node_building_block>bb\\d{3})"), "upsert") where log.attributes["hostname"] != nil and (log.attributes["sap.cc.audit.source"] == "ESXi" or log.attributes["sap.cc.audit.source"] == "NSX-T")'
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["net.peer.name"], "(?P<node_building_block>bb\\d{3})"), "upsert") where log.attributes["hostname"] == nil and log.attributes["net.peer.name"] != nil and (log.attributes["sap.cc.audit.source"] == "ESXi" or log.attributes["sap.cc.audit.source"] == "NSX-T")'

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.37
+  version: 0.15.38
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.37
+    version: 0.4.38
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
# Submit a pull request

Thank you for submitting a pull request!  
To speed up the review process, please ensure that everything below
is true:

1. This is not a duplicate of an existing Plugin.
2. No existing features have been broken without good reason.
3. The Documentation has been updated to reflect your changes.
4. Tests have been added or updated to reflect your changes.
5. All tests pass.

---

Replace any ":question:" below with information about your pull request.

## Pull Request Details


This PR adds source derivation logic for logs with an appname beginning with stnpa, ensuring they are correctly classified as audit-relevant and routed to the audit stream.

Key changes:

Derives a source value for stnpa* appname logs in _syslog-audit-filter-config.tpl.
Preserves any pre-existing source to avoid overwriting earlier detection.
Reuses the existing audit classification rule that flags logs as audit-relevant when sap.cc.audit.source is present.

:question:

## Breaking Changes

Describe what features are broken by this pull request and why, if any.

:question:

## Issues Fixed

Enter the issue numbers resolved by this pull request below, if any.

1. :question:

## Other Relevant Information

Provide any other important details below.

:question:
