### PR TITLE
fix(gatekeeper-config): avoid fresh-install constraint deadlock

### DIFF
--- a/gatekeeper-config/charts/Chart.yaml
+++ b/gatekeeper-config/charts/Chart.yaml
@@ -4,8 +4,8 @@
 apiVersion: v2
 description: Helm chart deploying OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes admission control.
 name: gatekeeper-config
-version: 0.4.1
-appVersion: 0.4.1
+version: 0.4.2
+appVersion: 0.4.2
 icon: https://raw.githubusercontent.com/open-policy-agent/gatekeeper/master/logo/gatekeeper-horizontal-color.png
 keywords:
   - gatekeeper

--- a/gatekeeper-config/charts/templates/constraint-deprecated-api-version-k8s1-32.yaml
+++ b/gatekeeper-config/charts/templates/constraint-deprecated-api-version-k8s1-32.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.deprecatedApiVersion.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.deprecatedApiVersion.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkDeprecatedApiVersion") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkDeprecatedApiVersion
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-forbidden-clusterwide-objects.yaml
+++ b/gatekeeper-config/charts/templates/constraint-forbidden-clusterwide-objects.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.forbiddenClusterwideObjects.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.forbiddenClusterwideObjects.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkForbiddenClusterwideObjects") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkForbiddenClusterwideObjects
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
+++ b/gatekeeper-config/charts/templates/constraint-high-cpu-requests.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.highCpuRequests.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.highCpuRequests.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkHighCPURequests") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkHighCPURequests
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-images-from-approved-registries.yaml
+++ b/gatekeeper-config/charts/templates/constraint-images-from-approved-registries.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.imagesFromApprovedRegistries.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.imagesFromApprovedRegistries.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkImagesFromApprovedRegistries") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkImagesFromApprovedRegistries
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-ingress-annotations-insecure-snippets.yaml
+++ b/gatekeeper-config/charts/templates/constraint-ingress-annotations-insecure-snippets.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.ingressAnnotations.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.ingressAnnotations.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkIngressAnnotations") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkIngressAnnotations
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-ingress-annotations-migration.yaml
+++ b/gatekeeper-config/charts/templates/constraint-ingress-annotations-migration.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.ingressAnnotationsMigration.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.ingressAnnotationsMigration.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkIngressAnnotationsMigration") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkIngressAnnotationsMigration
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-ingress-annotations-wrong-prefix.yaml
+++ b/gatekeeper-config/charts/templates/constraint-ingress-annotations-wrong-prefix.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.ingressAnnotations.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.ingressAnnotations.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkIngressAnnotations") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkIngressAnnotations
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-oli-labels-required.yaml
+++ b/gatekeeper-config/charts/templates/constraint-oli-labels-required.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.oliLabelsRequired.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.oliLabelsRequired.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkOliLabelsRequired") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkOliLabelsRequired
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-outdated-image-bases.yaml
+++ b/gatekeeper-config/charts/templates/constraint-outdated-image-bases.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.outdatedImageBases.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.outdatedImageBases.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkOutdatedImageBases") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkOutdatedImageBases
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-pci-forbidden-images.yaml
+++ b/gatekeeper-config/charts/templates/constraint-pci-forbidden-images.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.pciForbiddenImages.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.pciForbiddenImages.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkPCIForbiddenImages") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkPCIForbiddenImages
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-pod-required-labels.yaml
+++ b/gatekeeper-config/charts/templates/constraint-pod-required-labels.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.podRequiredLabels.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.podRequiredLabels.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkPodRequiredLabels") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkPodRequiredLabels
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-pod-security-v2.yaml
+++ b/gatekeeper-config/charts/templates/constraint-pod-security-v2.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.podSecurityV2.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.podSecurityV2.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkPodSecurityV2") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkPodSecurityV2
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-prometheus-scrape-annotations.yaml
+++ b/gatekeeper-config/charts/templates/constraint-prometheus-scrape-annotations.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.prometheusScrapeAnnotations.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.prometheusScrapeAnnotations.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkPrometheusScrapeAnnotations") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkPrometheusScrapeAnnotations
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-unmanaged-pods.yaml
+++ b/gatekeeper-config/charts/templates/constraint-unmanaged-pods.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.unmanagedPods.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.unmanagedPods.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkUnmanagedPods") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkUnmanagedPods
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod-owner.yaml
+++ b/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod-owner.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.vulnerableImages.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.vulnerableImages.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkVulnerableImages") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkVulnerableImages
 metadata:

--- a/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod.yaml
+++ b/gatekeeper-config/charts/templates/constraint-vulnerable-images-on-pod.yaml
@@ -1,6 +1,7 @@
-{{- if .Values.policies.vulnerableImages.enabled }}
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
+
+{{- if and .Values.policies.vulnerableImages.enabled (or (.Capabilities.APIVersions.Has "constraints.gatekeeper.sh/v1beta1/GkVulnerableImages") .Values.tests.enabled) }}
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: GkVulnerableImages
 metadata:

--- a/gatekeeper-config/plugindefinition.yaml
+++ b/gatekeeper-config/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: gatekeeper-config
 spec:
-  version: 0.4.1
+  version: 0.4.2
   displayName: Gatekeeper Config
   description: |
     Deploys OPA Gatekeeper ConstraintTemplates and Constraints for Kubernetes
@@ -17,7 +17,7 @@ spec:
   helmChart:
     name: gatekeeper-config
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.1
+    version: 0.4.2
   options:
     - name: policies.highCpuRequests.enabled
       displayName: High CPU requests policy enabled

--- a/gatekeeper/plugindefinition.yaml
+++ b/gatekeeper/plugindefinition.yaml
@@ -34,7 +34,7 @@ spec:
       type: int
     - name: gatekeeper.validatingWebhookFailurePolicy
       displayName: Webhook failure policy
-      description: Failure policy for the main validation webhook: `Ignore` or `Fail`.
+      description: "Failure policy for the main validation webhook: `Ignore` or `Fail`."
       default: Ignore
       required: false
       type: string
@@ -74,7 +74,7 @@ spec:
       type: map
     - name: gatekeeper.validatingWebhookCheckIgnoreFailurePolicy
       displayName: Check-ignore-label webhook failure policy
-      description: Failure policy for the `check-ignore-label.gatekeeper.sh` webhook: `Ignore` or `Fail`.
+      description: "Failure policy for the `check-ignore-label.gatekeeper.sh` webhook: `Ignore` or `Fail`."
       default: Fail
       required: false
       type: string


### PR DESCRIPTION
## Pull Request Details

On a fresh cluster `helm install` of `gatekeeper-config` fails while building the manifest (`no matches for kind GkHighCPURequests`) and applies nothing: ConstraintTemplates and their `Gk*` Constraints ship in one release, but the Constraint CRDs only exist after gatekeeper processes the templates, and Flux/Greenhouse retries rebuild the same manifest so it never recovers.

Each Constraint is now guarded on `.Capabilities.APIVersions.Has` for its CRD (or `.Values.tests.enabled` for offline gator), so templates install first and the next reconcile adds the Constraints once their CRDs exist. Constraints stay normal release resources, so Helm still prunes disabled ones. 

This PR also quotes two option descriptions in `gatekeeper/plugindefinition.yaml` that contained an unquoted `: `, which made the operator PluginDefinition invalid YAML (both `kubectl apply` and `yq` fail to parse it).

## Breaking Changes

None.

## Issues Fixed

None.

## Other Relevant Information

- verified on a live KinD + Greenhouse + Gatekeeper cluster: fresh install applies templates only (no deadlock), `helm upgrade` adds the constraint once the CRD exists, uninstall prunes it
- `gator verify` and `helm lint` pass
