### PR TITLE
logs: tune external collector batch + silence syslog parser errors

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.38
+version: 0.4.39
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -23,7 +23,7 @@ tcp_log/syslog:
     id: syslog_deframe_promote
     from: attributes.syslogmsg
     to: body
-    on_error: send
+    on_error: send_quiet
     output: syslog_format_router
   # Routes incoming syslog messages based on their header format:
   #   RFC 5424:              "<priority>VERSION timestamp ..." e.g. "<134>1 2026-07-10T09:32:35..."
@@ -59,12 +59,12 @@ tcp_log/syslog:
   - type: syslog_parser
     id: syslog_5424_parser
     protocol: rfc5424
-    on_error: send
+    on_error: send_quiet
     output: add_format_rfc5424
   - type: syslog_parser
     id: syslog_3164_parser
     protocol: rfc3164
-    on_error: send
+    on_error: send_quiet
     output: add_format_rfc3164
 
   # Single-digit-day RFC3164 fallback (Fortinet, Cisco ACI, etc.), days 1-9 only,
@@ -76,7 +76,7 @@ tcp_log/syslog:
   - type: regex_parser
     id: syslog_3164_padded_parser
     regex: '^<(?P<priority>\d+)>(?P<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2} \d{2}:\d{2}:\d{2})\s+(?P<hostname>\S+)\s+(?:(?P<appname>[^\s:\[]+)(?:\[(?P<proc_id>\d+)\])?:\s+)?(?P<message>.*)$'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: 'Jan _2 15:04:05'
@@ -91,7 +91,7 @@ tcp_log/syslog:
   - type: regex_parser
     id: syslog_iso_parser
     regex: '^<(?P<priority>\d+)>(?P<timestamp>\d{4}-\d{2}-\d{2}T\S+)\s+(?P<hostname>\S+)\s+(?P<message>.*)'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: '2006-01-02T15:04:05.999999999Z07:00'
@@ -105,7 +105,7 @@ tcp_log/syslog:
   - type: regex_parser
     id: syslog_cisco_parser
     regex: '^<(?P<priority>\d+)>(?P<sequence>\d+): (?P<hostname>\S+): (?P<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d+\s+\d+:\d+:\d+(?:\.\d+)?): (?P<message>.*)'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: 'Jan _2 15:04:05.999999999'
@@ -174,19 +174,19 @@ udp_log/syslog:
   - type: syslog_parser
     id: syslog_udp_5424_parser
     protocol: rfc5424
-    on_error: send
+    on_error: send_quiet
     output: add_udp_format_rfc5424
   - type: syslog_parser
     id: syslog_udp_3164_parser
     protocol: rfc3164
-    on_error: send
+    on_error: send_quiet
     output: add_udp_format_rfc3164
 
   # Single-digit-day RFC3164 fallback (UDP), days 1-9 only, zero- or space-padded.
   - type: regex_parser
     id: syslog_udp_3164_padded_parser
     regex: '^<(?P<priority>\d+)>(?P<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2} \d{2}:\d{2}:\d{2})\s+(?P<hostname>\S+)\s+(?:(?P<appname>[^\s:\[]+)(?:\[(?P<proc_id>\d+)\])?:\s+)?(?P<message>.*)$'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: 'Jan _2 15:04:05'
@@ -201,7 +201,7 @@ udp_log/syslog:
   - type: regex_parser
     id: syslog_udp_iso_parser
     regex: '^<(?P<priority>\d+)>(?P<timestamp>\d{4}-\d{2}-\d{2}T\S+)\s+(?P<hostname>\S+)\s+(?P<message>.*)'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: '2006-01-02T15:04:05.999999999Z07:00'
@@ -215,7 +215,7 @@ udp_log/syslog:
   - type: regex_parser
     id: syslog_udp_cisco_parser
     regex: '^<(?P<priority>\d+)>(?P<sequence>\d+): (?P<hostname>\S+): (?P<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d+\s+\d+:\d+:\d+(?:\.\d+)?): (?P<message>.*)'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: 'Jan _2 15:04:05.999999999'
@@ -277,13 +277,13 @@ tcp_log/syslog_tls:
     id: syslog_tls_deframe
     regex: '^(?:\d+ )?(?P<syslogmsg><\d+>.*)$'
     parse_from: body
-    on_error: send
+    on_error: send_quiet
     output: syslog_tls_deframe_promote
   - type: move
     id: syslog_tls_deframe_promote
     from: attributes.syslogmsg
     to: body
-    on_error: send
+    on_error: send_quiet
     output: syslog_tls_format_router
   # Same routing logic as tcp_log/syslog. See comments above for format details.
   - type: router
@@ -303,19 +303,19 @@ tcp_log/syslog_tls:
   - type: syslog_parser
     id: syslog_tls_5424_parser
     protocol: rfc5424
-    on_error: send
+    on_error: send_quiet
     output: add_tls_format_rfc5424
   - type: syslog_parser
     id: syslog_tls_3164_parser
     protocol: rfc3164
-    on_error: send
+    on_error: send_quiet
     output: add_tls_format_rfc3164
 
   # Single-digit-day RFC3164 fallback (TLS), days 1-9 only, zero- or space-padded.
   - type: regex_parser
     id: syslog_tls_3164_padded_parser
     regex: '^<(?P<priority>\d+)>(?P<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2} \d{2}:\d{2}:\d{2})\s+(?P<hostname>\S+)\s+(?:(?P<appname>[^\s:\[]+)(?:\[(?P<proc_id>\d+)\])?:\s+)?(?P<message>.*)$'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: 'Jan _2 15:04:05'
@@ -330,7 +330,7 @@ tcp_log/syslog_tls:
   - type: regex_parser
     id: syslog_tls_iso_parser
     regex: '^<(?P<priority>\d+)>(?P<timestamp>\d{4}-\d{2}-\d{2}T\S+)\s+(?P<hostname>\S+)\s+(?P<message>.*)'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: '2006-01-02T15:04:05.999999999Z07:00'
@@ -344,7 +344,7 @@ tcp_log/syslog_tls:
   - type: regex_parser
     id: syslog_tls_cisco_parser
     regex: '^<(?P<priority>\d+)>(?P<sequence>\d+): (?P<hostname>\S+): (?P<timestamp>(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d+\s+\d+:\d+:\d+(?:\.\d+)?): (?P<message>.*)'
-    on_error: send
+    on_error: send_quiet
     timestamp:
       parse_from: attributes.timestamp
       layout: 'Jan _2 15:04:05.999999999'

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -121,9 +121,9 @@ spec:
 {{- end }}
     processors:
       batch:
-        send_batch_max_size: 5000
-        timeout: 30s
-        send_batch_size: 100
+        send_batch_max_size: 10000
+        timeout: 5s
+        send_batch_size: 5000
       attributes/cluster:
         actions:
           - action: insert

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.38
+  version: 0.15.39
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.38
+    version: 0.4.39
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Summary

Two operational fixes on the external OTel collector:

1. **Batch processor tuning** — was emitting ~88% of batches at exactly `send_batch_size: 100`. Raise the batch triggers so Kafka producer calls carry ~50× more records each. Throughput win at zero risk (exporter queues and Kafka broker both had large headroom).
2. **`on_error: send` → `send_quiet`** on the 18 syslog parser / move operators.
