### PR TITLE
feat: add agentgateway-crds and agentgateway PluginDefinitions

### DIFF
--- a/agentgateway-crds/README.md
+++ b/agentgateway-crds/README.md
@@ -1,0 +1,26 @@
+<!--
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# agentgateway-crds
+
+Installs the Custom Resource Definitions (CRDs) required by the [agentgateway](https://agentgateway.dev/) controller:
+
+- `AgentgatewayBackend` — defines MCP, LLM, agent, and static backends
+- `AgentgatewayPolicy` — configures JWT authentication, authorization, CORS, and traffic policies
+- `AgentgatewayParameters` — GatewayClass provisioning parameters
+- `AgentgatewayModel` — AI model routing (experimental)
+
+## Prerequisites
+
+- Kubernetes Gateway API CRDs must be installed first (`k8s-gateway-api` plugin)
+
+## Usage
+
+Install this plugin before the `agentgateway` plugin. It has no configurable options.
+
+## Links
+
+- [agentgateway documentation](https://agentgateway.dev/docs/)
+- [agentgateway GitHub](https://github.com/agentgateway/agentgateway)

--- a/agentgateway-crds/plugindefinition.yaml
+++ b/agentgateway-crds/plugindefinition.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: agentgateway-crds
+spec:
+  version: 1.4.1
+  displayName: AgentGateway CRDs
+  description: >-
+    Installs the agentgateway Custom Resource Definitions (AgentgatewayBackend,
+    AgentgatewayPolicy, AgentgatewayParameters, AgentgatewayModel) required by
+    the agentgateway controller. Install this before the agentgateway plugin.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/agentgateway-crds/README.md
+  helmChart:
+    name: agentgateway-crds
+    repository: oci://cr.agentgateway.dev/charts
+    version: v1.4.1

--- a/agentgateway/README.md
+++ b/agentgateway/README.md
@@ -1,0 +1,41 @@
+<!--
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# agentgateway
+
+Deploys the [agentgateway](https://agentgateway.dev/) controller — an AI-native reverse proxy for MCP (Model Context Protocol) and A2A protocols. It runs as a Kubernetes controller using the Kubernetes Gateway API.
+
+## Features
+
+- **MCP federation** — multiplex multiple MCP servers behind a single endpoint via `AgentgatewayBackend`
+- **JWT authentication** — validate tokens against any OIDC provider via `AgentgatewayPolicy`
+- **Per-tool authorization** — CEL-based rules to control which tools a caller can invoke
+- **LLM routing** — proxy LLM requests with guardrails, circuit breakers, and rate limiting
+- **OpenTelemetry** — built-in tracing and metrics
+
+## Prerequisites
+
+1. `k8s-gateway-api` plugin (Kubernetes Gateway API CRDs)
+2. `agentgateway-crds` plugin (agentgateway CRDs)
+
+## Installation order
+
+```
+k8s-gateway-api  →  agentgateway-crds  →  agentgateway
+```
+
+## Configuration
+
+| Option | Description | Default |
+|---|---|---|
+| `image.registry` | Container image registry. Override if the cluster cannot reach `cr.agentgateway.dev` (e.g. use a Keppel mirror). | `cr.agentgateway.dev` |
+| `image.tag` | Image tag. Uses chart `appVersion` when empty. | `""` |
+| `controller.replicaCount` | Number of controller replicas. | `1` |
+
+## Links
+
+- [agentgateway documentation](https://agentgateway.dev/docs/)
+- [Install guide](https://agentgateway.dev/docs/kubernetes/latest/install/helm/)
+- [agentgateway GitHub](https://github.com/agentgateway/agentgateway)

--- a/agentgateway/README.md
+++ b/agentgateway/README.md
@@ -30,7 +30,7 @@ k8s-gateway-api  →  agentgateway-crds  →  agentgateway
 
 | Option | Description | Default |
 |---|---|---|
-| `image.registry` | Container image registry. Override if the cluster cannot reach `cr.agentgateway.dev` (e.g. use a Keppel mirror). | `cr.agentgateway.dev` |
+| `image.registry` | Container image registry. Override with a mirror registry if the cluster cannot reach `cr.agentgateway.dev` directly. | `cr.agentgateway.dev` |
 | `image.tag` | Image tag. Uses chart `appVersion` when empty. | `""` |
 | `controller.replicaCount` | Number of controller replicas. | `1` |
 

--- a/agentgateway/plugindefinition.yaml
+++ b/agentgateway/plugindefinition.yaml
@@ -21,8 +21,7 @@ spec:
   options:
     - name: image.registry
       description: >-
-        Container image registry. Override to use a regional Keppel mirror
-        (e.g. keppel.eu-de-1.cloud.sap/ccloud-agentgateway-mirror) if the
+        Container image registry. Override with a mirror registry if the
         cluster cannot reach cr.agentgateway.dev directly.
       default: "cr.agentgateway.dev"
       required: false

--- a/agentgateway/plugindefinition.yaml
+++ b/agentgateway/plugindefinition.yaml
@@ -21,9 +21,9 @@ spec:
   options:
     - name: image.registry
       description: >-
-        Container image registry. Override to use a mirror (e.g.
-        keppel.global.cloud.sap/ccloud-ghcr-io-mirror) if the cluster cannot
-        reach cr.agentgateway.dev directly.
+        Container image registry. Override to use a regional Keppel mirror
+        (e.g. keppel.eu-de-1.cloud.sap/ccloud-agentgateway-mirror) if the
+        cluster cannot reach cr.agentgateway.dev directly.
       default: "cr.agentgateway.dev"
       required: false
       type: string

--- a/agentgateway/plugindefinition.yaml
+++ b/agentgateway/plugindefinition.yaml
@@ -1,0 +1,39 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: agentgateway
+spec:
+  version: 1.4.1
+  displayName: AgentGateway
+  description: >-
+    AI-native reverse proxy for MCP and A2A protocols. Runs as a Kubernetes
+    controller using the Gateway API. Routes tool calls with JWT authentication,
+    per-tool authorization, guardrails, circuit breakers, and OpenTelemetry.
+    Requires the agentgateway-crds and k8s-gateway-api plugins to be installed first.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/agentgateway/README.md
+  helmChart:
+    name: agentgateway
+    repository: oci://cr.agentgateway.dev/charts
+    version: v1.4.1
+  options:
+    - name: image.registry
+      description: >-
+        Container image registry. Override to use a mirror (e.g.
+        keppel.global.cloud.sap/ccloud-ghcr-io-mirror) if the cluster cannot
+        reach cr.agentgateway.dev directly.
+      default: "cr.agentgateway.dev"
+      required: false
+      type: string
+    - name: image.tag
+      description: Container image tag. Defaults to the chart appVersion when empty.
+      default: ""
+      required: false
+      type: string
+    - name: controller.replicaCount
+      description: Number of agentgateway controller replicas.
+      default: 1
+      required: false
+      type: int

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 resources:
+  - agentgateway-crds/plugindefinition.yaml
+  - agentgateway/plugindefinition.yaml
   - alerts/plugindefinition.yaml
   - audit-logs/plugindefinition.yaml
   - blackbox-exporter/plugindefinition.yaml


### PR DESCRIPTION
## Summary

Adds two PluginDefinitions for [agentgateway](https://agentgateway.dev/) — an AI-native reverse proxy for MCP and A2A protocols:

- **`agentgateway-crds`** — installs the agentgateway CRDs (`AgentgatewayBackend`, `AgentgatewayPolicy`, `AgentgatewayParameters`, `AgentgatewayModel`) from `oci://cr.agentgateway.dev/charts/agentgateway-crds:v1.4.1`
- **`agentgateway`** — deploys the agentgateway controller (Kubernetes/CRD mode) from `oci://cr.agentgateway.dev/charts/agentgateway:v1.4.1`

Both follow the `ingress-nginx` pattern — direct upstream OCI reference, no local chart, not published to GHCR.

## Installation order

```
k8s-gateway-api  →  agentgateway-crds  →  agentgateway
```

The `k8s-gateway-api` PluginDefinition is tracked in #1783. This PR addresses #2105.

## Notes

- `image.registry` is exposed as a configurable option so clusters that cannot reach `cr.agentgateway.dev` directly can override it with a regional Keppel mirror (e.g. `keppel.eu-de-1.cloud.sap/ccloud-agentgateway-mirror`).
- No local chart is needed — Greenhouse fetches directly from the upstream OCI registry at install time.

## Related issues

- Closes #2105
- Depends on #1783 (k8s-gateway-api CRDs — install that first)