### PR TITLE
fix(kafka): enable kafka node pool custom naming and KafkaTopic

### DIFF
--- a/kafka/README.md
+++ b/kafka/README.md
@@ -70,6 +70,7 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | kafka.listeners | list | plaintext on 9092, TLS on 9093 | Listener configuration |
 | kafka.metricsEnabled | bool | `true` | Enable metrics |
 | kafka.name | string | `"kafka"` | Name of the Kafka cluster |
+| kafka.nodePoolName | string | `"broker"` | Name of the KafkaNodePool for cluster |
 | kafka.replicas | int | `3` | Number of Kafka broker/controller replicas (for KRaft mode) |
 | kafka.resources | object | requests: 2Gi memory, 1 CPU; limits: 4Gi memory, 2 CPU | Resource configuration for Kafka brokers |
 | kafka.storage | object | JBOD with 100Gi persistent volume per broker | Storage configuration for Kafka brokers |

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -70,7 +70,7 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | kafka.listeners | list | plaintext on 9092, TLS on 9093 | Listener configuration |
 | kafka.metricsEnabled | bool | `true` | Enable metrics |
 | kafka.name | string | `"kafka"` | Name of the Kafka cluster |
-| kafka.nodePoolName | string | `"broker"` | Name of the KafkaNodePool for cluster |
+| kafka.nodePoolName | string | `"broker"` | Name of the KafkaNodePool for the cluster |
 | kafka.replicas | int | `3` | Number of Kafka broker/controller replicas (for KRaft mode) |
 | kafka.resources | object | requests: 2Gi memory, 1 CPU; limits: 4Gi memory, 2 CPU | Resource configuration for Kafka brokers |
 | kafka.storage | object | JBOD with 100Gi persistent volume per broker | Storage configuration for Kafka brokers |

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -102,6 +102,7 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | topics.audit.replicas | int | `3` | Replication factor |
 | topics.audit.retention | int | `86400000` | Retention period (24 hours = 86400000 ms) |
 | topics.audit.segmentBytes | int | `1073741824` | Segment size (1 GB) |
+| topics.audit.useClusterPrefix | bool | `false` | Whether or not kafka cluster name (kafka.name) is added to KafkaTopic metadata.name (NOT the actual topic in kafka cluster!) |
 | topics.logs.cleanupPolicy | string | `"delete"` | Cleanup policy |
 | topics.logs.compressionType | string | `"producer"` | Compression type |
 | topics.logs.enabled | bool | `true` | Enable this topic |
@@ -111,3 +112,4 @@ If you discover bugs or want to add functionality to the plugin, feel free to cr
 | topics.logs.replicas | int | `3` | Replication factor |
 | topics.logs.retention | int | `86400000` | Retention period (24 hours = 86400000 ms) |
 | topics.logs.segmentBytes | int | `1073741824` | Segment size (1 GB) |
+| topics.logs.useClusterPrefix | bool | `false` | Whether or not kafka cluster name (kafka.name) is added to KafkaTopic metadata.name (NOT the actual topic in kafka cluster!) |

--- a/kafka/charts/Chart.yaml
+++ b/kafka/charts/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: kafka
-version: 0.1.13
+version: 0.1.14
 description: A Helm chart for Apache Kafka using the Strimzi Kafka Operator
 type: application
 maintainers:

--- a/kafka/charts/templates/kafka-node-pool.yaml
+++ b/kafka/charts/templates/kafka-node-pool.yaml
@@ -5,7 +5,7 @@
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaNodePool
 metadata:
-  name: broker
+  name: {{ .Values.kafka.nodePoolName }}
   labels:
     strimzi.io/cluster: {{ .Values.kafka.name }}
     {{- include "kafka.labels" . | nindent 4 }}

--- a/kafka/charts/templates/kafka-topics.yaml
+++ b/kafka/charts/templates/kafka-topics.yaml
@@ -4,7 +4,7 @@
 {{- if .Values.kafka.enabled }}
 {{- range $name, $topic := .Values.topics }}
 {{- if $topic.enabled }}
-{{- $metadataName := ternary (printf "%s-%s" $.Values.kafka.name $name) $name $topic.useClusterPrefix }}
+{{- $metadataName := ternary (printf "%s-%s" $.Values.kafka.name $name) $name ($topic.useClusterPrefix | default false) }}
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
@@ -20,8 +20,8 @@ spec:
   # Replication factor - should match kafka.config.default.replication.factor
   replicas: {{ $topic.replicas | default (index $.Values.kafka.config "default.replication.factor" | default 3) }}
 
+  {{- if ($topic.useClusterPrefix | default false) }}
   # The name of the topic. When absent this will default to the metadata.name of the topic.
-  {{- if $topic.useClusterPrefix }}
   topicName: {{ $name }}
   {{- end }}
 

--- a/kafka/charts/templates/kafka-topics.yaml
+++ b/kafka/charts/templates/kafka-topics.yaml
@@ -4,11 +4,12 @@
 {{- if .Values.kafka.enabled }}
 {{- range $name, $topic := .Values.topics }}
 {{- if $topic.enabled }}
+{{- $metadataName := ternary (printf "%s-%s" $.Values.kafka.name $name) $name $topic.useClusterPrefix }}
 ---
 apiVersion: kafka.strimzi.io/v1
 kind: KafkaTopic
 metadata:
-  name: {{ $name }}
+  name: {{ $metadataName }}
   labels:
     {{- include "kafka.labels" $ | nindent 4 }}
     strimzi.io/cluster: {{ $.Values.kafka.name }}
@@ -18,6 +19,11 @@ spec:
 
   # Replication factor - should match kafka.config.default.replication.factor
   replicas: {{ $topic.replicas | default (index $.Values.kafka.config "default.replication.factor" | default 3) }}
+
+  # The name of the topic. When absent this will default to the metadata.name of the topic.
+  {{- if $topic.useClusterPrefix }}
+  topicName: {{ $name }}
+  {{- end }}
 
   config:
     # Retention period in milliseconds

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -28,7 +28,7 @@ kafka:
   # -- Name of the Kafka cluster
   name: kafka
 
-  # -- Name of the KafkaNodePool for cluster
+  # -- Name of the KafkaNodePool for the cluster
   nodePoolName: broker
 
   # -- Kafka version

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -28,6 +28,9 @@ kafka:
   # -- Name of the Kafka cluster
   name: kafka
 
+  # -- Name of the KafkaNodePool for cluster
+  nodePoolName: broker
+
   # -- Kafka version
   version: "4.2.0"
 

--- a/kafka/charts/values.yaml
+++ b/kafka/charts/values.yaml
@@ -201,6 +201,8 @@ topics:
   logs:
     # -- Enable this topic
     enabled: true
+    # -- Whether or not kafka cluster name (kafka.name) is added to KafkaTopic metadata.name (NOT the actual topic in kafka cluster!)
+    useClusterPrefix: false
     # -- Number of partitions (should match OpenSearch index shards)
     partitions: 3
     # -- Replication factor
@@ -222,6 +224,8 @@ topics:
   audit:
     # -- Enable this topic
     enabled: true
+    # -- Whether or not kafka cluster name (kafka.name) is added to KafkaTopic metadata.name (NOT the actual topic in kafka cluster!)
+    useClusterPrefix: false
     # -- Number of partitions (should match OpenSearch index shards)
     partitions: 3
     # -- Replication factor

--- a/kafka/plugindefinition.yaml
+++ b/kafka/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: kafka
 spec:
-  version: 0.1.13
+  version: 0.1.14
   displayName: Kafka
   description: Creates and manages an Apache Kafka environment using the Strimzi Kafka Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kafka/logo.png'
   helmChart:
     name: kafka
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.1.13
+    version: 0.1.14
   options:
     - name: operator.enabled
       description: "Enable or disable the Strimzi Kafka Operator installation."


### PR DESCRIPTION
## Pull Request Details

Need to make `KafkaNodePool` name configurable.