### PR TITLE
feat(logs): make external audit message size limits configurable

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -104,9 +104,10 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.externalCollector.externalConfig | object | `{"alertmanager_port":1515,"deployments_port":1516,"enabled":false}` | Activates the external alertmanager webhook and deployment event receivers. |
 | openTelemetry.externalCollector.externalConfig.alertmanager_port | int | `1515` | Port for alertmanager webhook events |
 | openTelemetry.externalCollector.externalConfig.deployments_port | int | `1516` | Port for deployment TCP log events |
-| openTelemetry.externalCollector.externalHttpConfig | object | `{"enabled":false,"forwardedBy":"external-http","kafkaTopic":"audit","path":"/audit/external","port":1517,"tls":{"enabled":true}}` | HTTP-JSON receiver for Logstash/fluent-bit-style pushers. In Kafka mode records go to externalHttpConfig.kafkaTopic; in non-Kafka mode to the syslog audit OpenSearch failover (audit-datastream). |
+| openTelemetry.externalCollector.externalHttpConfig | object | `{"enabled":false,"forwardedBy":"external-http","kafkaTopic":"audit","maxRequestBodySize":10485760,"path":"/audit/external","port":1517,"tls":{"enabled":true}}` | HTTP-JSON receiver for Logstash/fluent-bit-style pushers. In Kafka mode records go to externalHttpConfig.kafkaTopic; in non-Kafka mode to the syslog audit OpenSearch failover (audit-datastream). |
 | openTelemetry.externalCollector.externalHttpConfig.forwardedBy | string | `"external-http"` | Neutral catch-all forwarder identity written to log attribute `forwarded_by` ONLY when the sender did not set one. Senders (Logstash, logshipper fluent-bit, other devices) should set their own `forwarded_by` and it is preserved. Sender-provided sap.cc.audit.source values (ESXi, NSX-T, VCSA, remoteboard, hsm, ucsc) are also preserved. |
 | openTelemetry.externalCollector.externalHttpConfig.kafkaTopic | string | `"audit"` | Kafka topic for the HTTP records (Kafka mode only). Separate from syslog audit, which uses syslogConfig.auditKafkaTopic. |
+| openTelemetry.externalCollector.externalHttpConfig.maxRequestBodySize | int | `10485760` | Max request body size in bytes. Requests larger than this get HTTP 400. Default 10 MiB. |
 | openTelemetry.externalCollector.externalHttpConfig.path | string | `"/audit/external"` | HTTP path the receiver serves. Sender must POST here. |
 | openTelemetry.externalCollector.externalHttpConfig.port | int | `1517` | TCP port for the HTTP-JSON receiver. |
 | openTelemetry.externalCollector.externalHttpConfig.tls | object | `{"enabled":true}` | TLS for the HTTP-JSON receiver. When enabled, the collector terminates TLS using the cert provisioned by syslogTLSConfig (secret logs-syslog-tls); requires syslogTLSConfig.dnsName / .issuerName. |
@@ -114,6 +115,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.externalCollector.externalTrafficPolicy | string | `"Local"` | External traffic policy for the external collector service (Local preserves source IP) |
 | openTelemetry.externalCollector.kafkaTopic | string | `""` | Kafka topic name for external logs — alerts, deployments, syslog (e.g., "logs-external") |
 | openTelemetry.externalCollector.kafkaTracesTopic | string | `""` | Kafka topic name for traces (e.g., "traces") |
+| openTelemetry.externalCollector.maxMessageLength | int | `32000` | Max bytes for the log body on the external audit paths (truncate_message processor). Body is a text field so this can be large. Raise to match Kafka message/fetch size. |
 | openTelemetry.externalCollector.nodeSelector | object | `{}` | Node Selector rules for the external collector CR |
 | openTelemetry.externalCollector.replicas | int | `2` | Number of replicas for the external collector StatefulSet |
 | openTelemetry.externalCollector.resources | object | `{}` | Pod resource requests/limits for the external collector container. Empty = unbounded. |
@@ -155,7 +157,9 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.kafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
 | openTelemetry.kafka.enabled | bool | `false` | Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering) |
 | openTelemetry.kafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw) |
-| openTelemetry.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
+| openTelemetry.kafka.max_fetch_size | int | `1048576` | Consumer max bytes per fetch request (ingester). Match producer max_message_bytes for large records. |
+| openTelemetry.kafka.max_message_bytes | int | `1048576` | Max producer message size in bytes before compression. Raise to match the Kafka topic/broker max.message.bytes. |
+| openTelemetry.kafka.max_partition_fetch_size | int | `1048576` | Consumer max bytes fetched per partition (ingester). Match producer max_message_bytes for large records. |
 | openTelemetry.kafka.producer | object | `{"flushMaxMessages":10000,"linger":"10ms"}` | Producer batching (raise linger to build larger batches per broker request) |
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
 | openTelemetry.kafka.sendingQueue | object | `{"enabled":true,"numConsumers":1,"queueSize":1000}` | Producer sending queue size |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.42
+version: 0.4.43
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -7,6 +7,7 @@ webhookevent/external-http:
   endpoint: "0.0.0.0:{{ .Values.openTelemetry.externalCollector.externalHttpConfig.port }}"
   path: {{ .Values.openTelemetry.externalCollector.externalHttpConfig.path | quote }}
   health_path: {{ printf "%s/health" .Values.openTelemetry.externalCollector.externalHttpConfig.path | quote }}
+  max_request_body_size: {{ .Values.openTelemetry.externalCollector.externalHttpConfig.maxRequestBodySize | int64 }}
   split_logs_at_newline: false
 {{- if .Values.openTelemetry.externalCollector.externalHttpConfig.tls.enabled }}
   tls:

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -166,9 +166,10 @@ spec:
         log_statements:
           - context: log
             statements:
+              # Attribute values map to keyword fields. Keep below Lucene's 32766-byte term limit or OpenSearch rejects the document.
               - "truncate_all(attributes, 32000)"
               - "truncate_all(resource.attributes, 32000)"
-              - 'set(log.body, Substring(log.body, 0, 32000)) where log.body != nil and Len(log.body) > 32000'
+              - 'set(log.body, Substring(log.body, 0, {{ .Values.openTelemetry.externalCollector.maxMessageLength | int64 }})) where log.body != nil and Len(log.body) > {{ .Values.openTelemetry.externalCollector.maxMessageLength | int64 }}'
 {{- end }}
       resource:
         attributes:

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -78,6 +78,8 @@ spec:
           topics:
             - {{ $cfg.topic | quote }}
           encoding: {{ $kafka.encoding }}
+        max_fetch_size: {{ dig "max_fetch_size" $root.Values.openTelemetry.kafka.max_fetch_size $kafka | int64 }}
+        max_partition_fetch_size: {{ dig "max_partition_fetch_size" $root.Values.openTelemetry.kafka.max_partition_fetch_size $kafka | int64 }}
         group_id: {{ printf "logs-ingester-%s" $name | quote }}
         initial_offset: {{ $cfg.initialOffset | default "latest" | quote }}
         autocommit:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -84,8 +84,12 @@ openTelemetry:
     encoding: ""
     # -- Compression type (none, gzip, snappy, lz4, zstd)
     compression: ""
-    # -- Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes.
-    max_message_bytes: 1000000
+    # -- Max producer message size in bytes before compression. Raise to match the Kafka topic/broker max.message.bytes.
+    max_message_bytes: 1048576
+    # -- Consumer max bytes per fetch request (ingester). Match producer max_message_bytes for large records.
+    max_fetch_size: 1048576
+    # -- Consumer max bytes fetched per partition (ingester). Match producer max_message_bytes for large records.
+    max_partition_fetch_size: 1048576
     # -- Producer sending queue size
     sendingQueue:
       enabled: true
@@ -175,6 +179,8 @@ openTelemetry:
     kafkaTopic: ""
     # -- Kafka topic name for traces (e.g., "traces")
     kafkaTracesTopic: ""
+    # -- Max bytes for the log body on the external audit paths (truncate_message processor). Body is a text field so this can be large. Raise to match Kafka message/fetch size.
+    maxMessageLength: 32000
     # -- Activates syslog TCP/UDP ingestion (rfc5424/rfc3164).
     syslogConfig:
       enabled: false
@@ -236,6 +242,8 @@ openTelemetry:
       enabled: false
       # -- TCP port for the HTTP-JSON receiver.
       port: 1517
+      # -- Max request body size in bytes. Requests larger than this get HTTP 400. Default 10 MiB.
+      maxRequestBodySize: 10485760
       # -- HTTP path the receiver serves. Sender must POST here.
       path: /audit/external
       # -- Kafka topic for the HTTP records (Kafka mode only). Separate from

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.42
+  version: 0.15.43
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.42
+    version: 0.4.43
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Make external audit message size limits configurable so large records flow.

- External HTTP receiver `max_request_body_size` configurable (default 10MB), off the 100KB default that rejected large POSTs
- Body truncation via `maxMessageLength`; attribute truncation hardcoded at 32000 (below Lucene's 32766-byte keyword limit to avoid OpenSearch doc rejection)
- Kafka consumer `max_fetch_size` / `max_partition_fetch_size` knobs
