### PR TITLE
fix(trust-manager): Use correct repo for 0.24.0

### DIFF
--- a/trust-manager/plugindefinition.yaml
+++ b/trust-manager/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: trust-manager
 spec:
-  version: 0.24.0
+  version: 0.24.1
   displayName: Trust Manager
   description: Automated trust bundle management for Kubernetes
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/trust-manager/README.md
@@ -48,7 +48,7 @@ spec:
       type: string
     - name: trust-manager.defaultPackageImage.repository
       description: Repository for the default trust package image
-      default: "jetstack/trust-pkg-debian-bookworm"
+      default: "jetstack/trust-pkg-debian-trixie"
       required: false
       type: string
     - name: bundle.enabled


### PR DESCRIPTION
## Pull Request Details

Update trust package image repo to work with version 0.24.0 