### PR TITLE
Add patterns to transform/syslog_nsxt for field parsing

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.42
+version: 0.4.43
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -257,6 +257,12 @@ transform/syslog_nsxt:
         # Extract NSX-T transport-node FQDN (shape: node###-bb###.<domain>).
         # Handles both message encodings: free-text "Transport node X (" and JSON "transport_node_name":"X".
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "(?P<fqdn>node\\d{3}-bb\\d{3}\\.\\S+?)(?:[\\s\\)\"]|$)"), "upsert") where log.attributes["fqdn"] == nil and log.attributes["message"] != nil'
+        # Extract username: prefer Username= value inside LdapUserDetailsImpl wrapper
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "Username=(?P<syslog_user>[^@]+)@"), "upsert") where log.attributes["syslog_user"] == nil and log.attributes["message"] != nil'
+        # Extract audit operation fields
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "ModuleName=\"(?P<nsx_module>[^\"]+)\""), "upsert") where log.attributes["message"] != nil'
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "Operation=\"(?P<nsx_operation>[^\"]+)\""), "upsert") where log.attributes["message"] != nil'
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "Operation status=\"(?P<nsx_operation_status>[^\"]+)\""), "upsert") where log.attributes["message"] != nil'
 
 {{/*
   ============================================================================

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -259,10 +259,8 @@ transform/syslog_nsxt:
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "(?P<fqdn>node\\d{3}-bb\\d{3}\\.\\S+?)(?:[\\s\\)\"]|$)"), "upsert") where log.attributes["fqdn"] == nil and log.attributes["message"] != nil'
         # Extract username: prefer Username= value inside LdapUserDetailsImpl wrapper
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "Username=(?P<syslog_user>[^@]+)@"), "upsert") where log.attributes["syslog_user"] == nil and log.attributes["message"] != nil'
-        # Extract audit operation fields
-        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "ModuleName=\"(?P<nsx_module>[^\"]+)\""), "upsert") where log.attributes["message"] != nil'
-        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "Operation=\"(?P<nsx_operation>[^\"]+)\""), "upsert") where log.attributes["message"] != nil'
-        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "Operation status=\"(?P<nsx_operation_status>[^\"]+)\""), "upsert") where log.attributes["message"] != nil'
+        # Extract audit operation fields in a single pass
+        - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "ModuleName=\"(?P<nsx_module>[^\"]+)\", Operation=\"(?P<nsx_operation>[^\"]+)\", Operation status=\"(?P<nsx_operation_status>[^\"]+)\""), "upsert") where log.attributes["nsx_module"] == nil and log.attributes["message"] != nil'
 
 {{/*
   ============================================================================

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.42
+  version: 0.15.43
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.42
+    version: 0.4.43
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details
The existing transform/syslog_nsxt processor already detected NSX-T logs and extracted transport-node FQDNs. This extends it to parse the structured audit fields present in NSX-T ACCESS_CONTROL log messages.

| Field | Example value | Source pattern |
|---|---|---|
| `syslog_user` | `TCP-AUTO2-NSXTMON` | `Username=<value>@` |
| `nsx_module` | `ACCESS_CONTROL` | `ModuleName="<value>"` |
| `nsx_operation` | `LOGIN` | `Operation="<value>"` |
| `nsx_operation_status` | `success` | `Operation status="<value>"` |

## Other Relevant Information
- syslog_user uses the same field name as ESXi/VCSA transforms for consistency. The pattern matches the value before @ inside a Username= key, which handles both the bare format (nsxtagent0001@...) and the LdapUserDetailsImpl wrapper (Username=TCP-AUTO2-NSXTMON@ad.global...).
- comp and subcomp are intentionally not extracted here — the RFC5424 receiver already populates these under attributes.structured_data.nsx@6876.comp and .subcomp automatically.
- No pipeline changes required — transform/syslog_nsxt is already wired into all three syslog pipelines (tcp, udp, tls).
