### PR TITLE
Feat/opensearch dashboards unavailable alert

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.18
+version: 0.2.19
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -44,7 +44,7 @@ groups:
           description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."
 
       - alert: OpenSearchDashboardsUnavailable
-        expr: (sum by (deployment) (kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"})) == 0
+        expr: (sum by (deployment) (kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"})) == 0 and (sum by (deployment) (kube_deployment_spec_replicas{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"}) > 0)
         for: 10m
         labels:
           severity: info # warning
@@ -52,5 +52,5 @@ groups:
           playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
-          summary: "OpenSearch Dashboards (UI) is unavailabe."
+          summary: "OpenSearch Dashboards (UI) is unavailable."
           description: "Deployment for OpenSearch Dashboards {{`{{ $labels.deployment }}`}} in namespace {{ .Release.Namespace }} is unavailable. Users cannot see their logs."

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -42,3 +42,15 @@ groups:
         annotations:
           summary: "Index size of {{`{{ $labels.index }}`}} has exceeded the threshold."
           description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."
+
+      - alert: OpenSearchDashboardsUnavailable
+        expr: (sum by (deployment) (kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"})) == 0
+        for: 10m
+        labels:
+          severity: info # warning
+          component: opensearch
+          playbook: https://github.com/cloudoperators/greenhouse-extensions/tree/main/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
+          {{- include "opensearch-alert-labels" . | nindent 10 }}
+        annotations:
+          summary: "OpenSearch Dashboards (UI) is unavailabe."
+          description: "Deployment for OpenSearch Dashboards {{`{{ $labels.deployment }}`}} in namespace {{ .Release.Namespace }} is unavailable. Users cannot see their logs."

--- a/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
+++ b/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
@@ -24,14 +24,16 @@ OpenSearch Dashboard (UI) is unavailable which means there is no running pod.
 ## Resolution Steps
 
 1. **Migration problem**:
-    - Delete problematic index mentioned in the pod's logs (`.kibana_4`). As DevTools is not accessible you need to `curl` command. The credentials for admin user to perform the curl you can find in k8s secret `admin-credentials` or in vault under `/secrets/{{ $region }}/fortlogs/audit/users/{{ $user.name }}/username` and `/secrets/{{ $region }}/fortlogs/audit/users/{{ $user.name }}/password`
+    - Delete problematic index mentioned in the pod's logs (`.kibana_4`). As DevTools is not accessible you need to use a `curl` command against the current OpenSearch endpoint for your environment. The credentials for admin user to perform the curl you can find in k8s secret `admin-credentials` or in vault under `/secrets/{{ $region }}/fortlogs/audit/users/{{ $user.name }}/username` and `/secrets/{{ $region }}/fortlogs/audit/users/{{ $user.name }}/password` . Use `-k` or better use CA from secret `opensearch-http-cert-external`.
     ```
-    # e.g. logs-api.fortlogs.eu-de-1.cloud.sap
-    curl -X -k DELETE https://logs-api.fortlogs.eu-de-1.cloud.sap/.kibana_4 -u username:password
+    # e.g. DASHBOARDS_URL=https://logs-api.fortlogs.eu-de-1.cloud.sap
+    curl -X DELETE ${DASHBOARDS_URL}/.kibana_4 -u username
     ```
-    - Delete the opensearch dashboards pod and let the pod recreate `.kibana_4` index.
+    - Delete the opensearch dashboards pod using a label selector and let Kubernetes recreate the pod and the `.kibana_4` index.
     ```
-    kubectl delete pod opensearch-logs-dashboards-9669f5d95-xzzdk
+    kubectl delete pods -l opensearch.cluster.dashboards=opensearch-logs # logs cluster
+    or
+    kubectl delete pods -l opensearch.cluster.dashboards=opensearch-audit # audit cluster
     ```
 
 2. **Contact support**: If the opensearch dashboard is not getting up after these steps, investigate further or seek assistance from your operations team.

--- a/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
+++ b/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
@@ -34,4 +34,4 @@ OpenSearch Dashboard (UI) is unavailable which means there is no running pod.
     kubectl delete pod opensearch-logs-dashboards-9669f5d95-xzzdk
     ```
 
-2. **Contact support**: If the cluster doesn't start rerouting after these steps, investigate further or seek assistance from your operations team.
+2. **Contact support**: If the opensearch dashboard is not getting up after these steps, investigate further or seek assistance from your operations team.

--- a/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
+++ b/opensearch/playbooks/OpenSearchDashboardsUnavailable.md
@@ -1,0 +1,37 @@
+---
+title: OpenSearchDashboardsUnavailable
+weight: 20
+---
+
+# OpenSearchDashboardsUnavailable
+
+## Problem
+
+OpenSearch Dashboard (UI) is unavailable which means there is no running pod.
+
+## Impact
+
+- Users cannot access OpenSearch Dashboards, therefore cannot see their logs
+
+## Diagnosis
+
+1. Look into logs of the crashing pods and see if there is migration problem:
+```
+{"type":"log","@timestamp":"2026-08-12T08:38:40Z","tags":["warning","savedobjects-service"],"pid":1,"message":"Unable to connect to OpenSearch. Error: resource_already_exists_exception: [resource_already_exists_exception] Reason: index [.kibana_4/p7tJbmCRTc2AjoIJiC8YsQ] already exists"}
+{"type":"log","@timestamp":"2026-08-12T08:38:40Z","tags":["warning","savedobjects-service"],"pid":1,"message":"Another OpenSearch Dashboards instance appears to be migrating the index. Waiting for that migration to complete. If no other OpenSearch Dashboards instance is attempting migrations, you can get past this message by deleting index .kibana_4 and restarting OpenSearchDashboards."}
+```
+
+## Resolution Steps
+
+1. **Migration problem**:
+    - Delete problematic index mentioned in the pod's logs (`.kibana_4`). As DevTools is not accessible you need to `curl` command. The credentials for admin user to perform the curl you can find in k8s secret `admin-credentials` or in vault under `/secrets/{{ $region }}/fortlogs/audit/users/{{ $user.name }}/username` and `/secrets/{{ $region }}/fortlogs/audit/users/{{ $user.name }}/password`
+    ```
+    # e.g. logs-api.fortlogs.eu-de-1.cloud.sap
+    curl -X -k DELETE https://logs-api.fortlogs.eu-de-1.cloud.sap/.kibana_4 -u username:password
+    ```
+    - Delete the opensearch dashboards pod and let the pod recreate `.kibana_4` index.
+    ```
+    kubectl delete pod opensearch-logs-dashboards-9669f5d95-xzzdk
+    ```
+
+2. **Contact support**: If the cluster doesn't start rerouting after these steps, investigate further or seek assistance from your operations team.

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.18
+  version: 0.2.19
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.18
+    version: 0.2.19
   options:
     - name: queryExporter.enabled
       description: "Enable the OpenSearch query exporter for custom Prometheus metrics from OpenSearch queries"


### PR DESCRIPTION
## Pull Request Details

Adding `OpenSearchDashboardsUnavailable` alert so we get notify if OpenSearch Dashboards is unavailable, therefore users cannot see their logs.

