### PR TITLE
Feat/transform external http

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.44
+version: 0.4.45
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -51,11 +51,11 @@ transform/external-http:
         - set(log.attributes["log.http"], log.attributes["log"]) where log.attributes["log.http"] == nil and log.attributes["log"] != nil and IsString(log.attributes["log"])
         - delete_key(log.attributes, "log") where log.attributes["log.http"] != nil and log.attributes["log"] != nil and IsString(log.attributes["log"])
         # Flatten nested event object into dotted event.* fields.
-        - set(log.attributes["event.action"], log.attributes["event"]["action"]) where log.attributes["event"] != nil and log.attributes["event"]["action"] != nil
-        - set(log.attributes["event.outcome"], log.attributes["event"]["outcome"]) where log.attributes["event"] != nil and log.attributes["event"]["outcome"] != nil
+        - set(log.attributes["event.action"], log.attributes["event"]["action"]) where log.attributes["event.action"] == nil and log.attributes["event"] != nil and log.attributes["event"]["action"] != nil
+        - set(log.attributes["event.outcome"], log.attributes["event"]["outcome"]) where log.attributes["event.outcome"] == nil and log.attributes["event"] != nil and log.attributes["event"]["outcome"] != nil
         # Collapse category to a single string field regardless of scalar or array.
-        - set(log.attributes["event.category"], log.attributes["event"]["category"]) where log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and IsString(log.attributes["event"]["category"])
-        - set(log.attributes["event.category"], String(log.attributes["event"]["category"])) where log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and not IsString(log.attributes["event"]["category"])
+        - set(log.attributes["event.category"], log.attributes["event"]["category"]) where log.attributes["event.category"] == nil and log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and IsString(log.attributes["event"]["category"])
+        - set(log.attributes["event.category"], String(log.attributes["event"]["category"])) where log.attributes["event.category"] == nil and log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and not IsString(log.attributes["event"]["category"])
         - delete_key(log.attributes, "event") where log.attributes["event"] != nil
         
 {{- end }}

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -48,10 +48,15 @@ transform/external-http:
         - delete_key(log.attributes, "host") where log.attributes["host.name"] != nil and log.attributes["host"] != nil and IsString(log.attributes["host"])
         - set(log.attributes["sourceIPs.0"], log.attributes["sourceIPs"]) where log.attributes["sourceIPs.0"] == nil and log.attributes["sourceIPs"] != nil and IsString(log.attributes["sourceIPs"])
         - delete_key(log.attributes, "sourceIPs") where log.attributes["sourceIPs.0"] != nil and log.attributes["sourceIPs"] != nil and IsString(log.attributes["sourceIPs"])
-        - set(log.attributes["event.category.0"], log.attributes["event.category"]) where log.attributes["event.category.0"] == nil and log.attributes["event.category"] != nil and IsString(log.attributes["event.category"])
-        - delete_key(log.attributes, "event.category") where log.attributes["event.category.0"] != nil and log.attributes["event.category"] != nil and IsString(log.attributes["event.category"])
         - set(log.attributes["log.http"], log.attributes["log"]) where log.attributes["log.http"] == nil and log.attributes["log"] != nil and IsString(log.attributes["log"])
         - delete_key(log.attributes, "log") where log.attributes["log.http"] != nil and log.attributes["log"] != nil and IsString(log.attributes["log"])
+        # Flatten nested event object into dotted event.* fields.
+        - set(log.attributes["event.action"], log.attributes["event"]["action"]) where log.attributes["event"] != nil and log.attributes["event"]["action"] != nil
+        - set(log.attributes["event.outcome"], log.attributes["event"]["outcome"]) where log.attributes["event"] != nil and log.attributes["event"]["outcome"] != nil
+        # Collapse category to a single string field regardless of scalar or array.
+        - set(log.attributes["event.category"], log.attributes["event"]["category"]) where log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and IsString(log.attributes["event"]["category"])
+        - set(log.attributes["event.category"], String(log.attributes["event"]["category"])) where log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and not IsString(log.attributes["event"]["category"])
+        - delete_key(log.attributes, "event") where log.attributes["event"] != nil
         
 {{- end }}
 

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.44
+  version: 0.15.45
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.44
+    version: 0.4.45
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
**Pull Request Details**
Parse out fields from event object in the body, as they're required for rules.
- event.action and event.outcome added 
- Fix event.category mapping conflict in transform/external-http for flatcar/Auditbeat logs.
Flatcar logs send **event.category** as either a scalar string (e.g. "mac-decision") or an array (e.g. ["configuration","network"]). The previous logic split these into two different field names: scalar → event.category.0, array → event.category. When both types appear in the same index, OpenSearch rejects the second type with a mapper_parsing_exception because event.category is already mapped as text and event.category.0 cannot be created as a sibling sub-field.

The fix collapses both cases to a single event.category field: scalar strings are written as-is, arrays are serialised to a JSON string via String(). This eliminates the mapping conflict while keeping the category value searchable.

**Breaking Changes**
None. Documents that previously landed in event.category.0 will now land in event.category and event.action + event.outcome will also get parsed. Any existing dashboards or detection rules querying attributes.event.category.0 will need to be updated to attributes.event.category. But that didn't exist, as it wasn't parsed correctly until now. 