### PR TITLE
fix(kube-monitoring): disable Prometheus compaction by default

### DIFF
--- a/kube-monitoring/plugindefinition.yaml
+++ b/kube-monitoring/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: kube-monitoring
 spec:
-  version: 15.0.0
+  version: 15.0.1
   displayName: Kubernetes monitoring
   description: Native deployment and management of Prometheus along with Kubernetes cluster monitoring components.
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kube-monitoring/README.md
@@ -53,6 +53,11 @@ spec:
       description: The storage class to use for the persistent volume.
       required: false
       type: string
+    - name: kubeMonitoring.prometheus.prometheusSpec.disableCompaction
+      description: Whether to disable local TSDB compaction on Prometheus.
+      default: true
+      required: false
+      type: bool
     - name: alerts.enabled
       description: Whether the Alerts Plugin is configured
       default: false


### PR DESCRIPTION
# Submit a pull request

## Pull Request Details

Adds `kubeMonitoring.prometheus.prometheusSpec.disableCompaction` to the kube-monitoring PluginDefinition with a default of `true`, making the workaround generic for all kube-monitoring Plugin users. The PluginDefinition patch version is bumped to `15.0.1`.

## Breaking Changes

None. The option remains overridable by individual Plugin deployments.

## Issues Fixed

1. https://github.com/prometheus-operator/prometheus-operator/issues/8763

## Other Relevant Information

Validation performed:
- `git diff --check`
- PluginDefinition YAML parsing, option type/default validation, and duplicate option-name check
- `helm lint kube-monitoring/charts`
- `helm template` with the option enabled, confirming `spec.disableCompaction: true` on the rendered Prometheus resource