### PR TITLE
fix(logs,audit-logs): improves external-collector, fixes json array payload, stringify context and headers

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -70,7 +70,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.affinity | object | `{}` | Node affinity rules for the collector DaemonSet pods |
 | auditLogs.cluster | string | `nil` | Cluster label for Logging |
 | auditLogs.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | overrides the default image repository for the OpenTelemetry Collector image. |
-| auditLogs.collectorImage.tag | string | `"a8981ba"` | overrides the default image tag for the OpenTelemetry Collector image. |
+| auditLogs.collectorImage.tag | string | `"a62a383"` | overrides the default image tag for the OpenTelemetry Collector image. |
 | auditLogs.customLabels | string | `nil` | Custom labels to apply to all OpenTelemetry related resources |
 | auditLogs.elastic.enabled | bool | `false` | Activates the configuration for Elastic. |
 | auditLogs.elastic.endpoint | string | `nil` | Endpoint URL for Elastic |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.10
+version: 0.2.11
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/_field-normalisation-config.tpl
+++ b/audit-logs/charts/templates/_field-normalisation-config.tpl
@@ -50,5 +50,14 @@ transform/field-normalisation:
         - delete_matching_keys(log.attributes, "^process\\..*")
         - delete_matching_keys(log.attributes, "^prometheus\\..*")
         - delete_matching_keys(log.attributes, "^args\\..*")
-        
+        # stringify attributes.context.* map into single string, then drop all nested keys
+        - set(log.attributes["context_string"], String(log.attributes["context"]))
+          where log.attributes["context"] != nil
+        - delete_key(log.attributes, "context") where log.attributes["context"] != nil
+        - delete_matching_keys(log.attributes, "^context\\..*")
+        # stringify attributes.headers.* map into single string, then drop all nested keys
+        - set(log.attributes["headers_string"], String(log.attributes["headers"]))
+            where log.attributes["headers"] != nil
+        - delete_key(log.attributes, "headers") where log.attributes["headers"] != nil
+        - delete_matching_keys(log.attributes, "^headers\\..*")
 {{- end }}

--- a/audit-logs/charts/templates/_field-normalisation-config.tpl
+++ b/audit-logs/charts/templates/_field-normalisation-config.tpl
@@ -8,7 +8,6 @@ transform/field-normalisation:
         - delete_key(log.attributes["auditd"], "paths") where log.attributes["auditd"] != nil and log.attributes["auditd"]["paths"] != nil
         - set(log.attributes["auditd.data"], String(log.attributes["auditd"]["data"])) where log.attributes["auditd"] != nil and log.attributes["auditd"]["data"] != nil
         - delete_key(log.attributes["auditd"], "data") where log.attributes["auditd"] != nil and log.attributes["auditd"]["data"] != nil
-        #
         - set(log.attributes["audit_host"], String(log.attributes["host"])) where log.attributes["host"] != nil
         - delete_key(log.attributes, "host") where log.attributes["host"] != nil
         - set(log.attributes["audit_source_ips"], String(log.attributes["sourceIPs"])) where log.attributes["sourceIPs"] != nil
@@ -22,6 +21,7 @@ transform/field-normalisation:
         - set(log.attributes["audit_args"], String(log.attributes["args"])) where log.attributes["args"] != nil
         - delete_key(log.attributes, "args") where log.attributes["args"] != nil
         - set(log.attributes["audit_status"], String(log.attributes["status"])) where log.attributes["status"] != nil
+        - delete_key(log.attributes, "status") where log.attributes["status"] != nil
         - delete_key(log.attributes, "status") where log.attributes["status"] != nil
         - set(log.attributes["http_string"], String(log.attributes["log"]["http"])) where log.attributes["http_string"] == nil and log.attributes["log"] != nil and IsString(log.attributes["log"]) == false and log.attributes["log"]["http"] != nil
         - delete_key(log.attributes["log"], "http") where log.attributes["log"] != nil and IsString(log.attributes["log"]) == false and log.attributes["log"]["http"] != nil
@@ -41,6 +41,7 @@ transform/field-normalisation:
         - delete_key(log.attributes, "requestObject") where log.attributes["requestObject"] != nil
         - set(log.attributes["k8s_resp_payload"], String(log.attributes["responseObject"])) where log.attributes["responseObject"] != nil
         - delete_key(log.attributes, "responseObject") where log.attributes["responseObject"] != nil
+        - delete_key(log.attributes, "syslog_timestamp") where log.attributes["syslog_timestamp"] != nil and time_unix_nano != 0
         - delete_matching_keys(log.attributes, "^requestObject\\..*")
         - delete_matching_keys(log.attributes, "^responseObject\\..*")
         - delete_matching_keys(log.attributes, "^user\\..*")
@@ -50,14 +51,16 @@ transform/field-normalisation:
         - delete_matching_keys(log.attributes, "^process\\..*")
         - delete_matching_keys(log.attributes, "^prometheus\\..*")
         - delete_matching_keys(log.attributes, "^args\\..*")
-        # stringify attributes.context.* map into single string, then drop all nested keys
-        - set(log.attributes["context_string"], String(log.attributes["context"]))
-          where log.attributes["context"] != nil
+        - set(log.attributes["context_string"], String(log.attributes["context"])) where log.attributes["context"] != nil
         - delete_key(log.attributes, "context") where log.attributes["context"] != nil
         - delete_matching_keys(log.attributes, "^context\\..*")
-        # stringify attributes.headers.* map into single string, then drop all nested keys
-        - set(log.attributes["headers_string"], String(log.attributes["headers"]))
-            where log.attributes["headers"] != nil
+        - set(log.attributes["headers_string"], String(log.attributes["headers"])) where log.attributes["headers"] != nil
         - delete_key(log.attributes, "headers") where log.attributes["headers"] != nil
         - delete_matching_keys(log.attributes, "^headers\\..*")
+        - set(log.attributes["tags_string"], String(log.attributes["tags"])) where log.attributes["tags"] != nil
+        - delete_key(log.attributes, "tags") where log.attributes["tags"] != nil
+        - delete_matching_keys(log.attributes, "^tags\\..*")
+        - set(log.attributes["tenant_ids_string"], String(log.attributes["tenant_ids"])) where log.attributes["tags"] != nil
+        - delete_key(log.attributes, "tenant_ids") where log.attributes["tenant_ids"] != nil
+        - delete_matching_keys(log.attributes, "^tenant_ids\\..*")
 {{- end }}

--- a/audit-logs/charts/templates/_field-normalisation-config.tpl
+++ b/audit-logs/charts/templates/_field-normalisation-config.tpl
@@ -22,7 +22,6 @@ transform/field-normalisation:
         - delete_key(log.attributes, "args") where log.attributes["args"] != nil
         - set(log.attributes["audit_status"], String(log.attributes["status"])) where log.attributes["status"] != nil
         - delete_key(log.attributes, "status") where log.attributes["status"] != nil
-        - delete_key(log.attributes, "status") where log.attributes["status"] != nil
         - set(log.attributes["http_string"], String(log.attributes["log"]["http"])) where log.attributes["http_string"] == nil and log.attributes["log"] != nil and IsString(log.attributes["log"]) == false and log.attributes["log"]["http"] != nil
         - delete_key(log.attributes["log"], "http") where log.attributes["log"] != nil and IsString(log.attributes["log"]) == false and log.attributes["log"]["http"] != nil
         - set(log.attributes["http_string"], String(log.attributes["log.http"])) where log.attributes["http_string"] == nil and log.attributes["log.http"] != nil

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -87,16 +87,6 @@ spec:
         spike_limit_percentage: 30
       # Used to handle external http poison messages in kafka.
 {{- include "field_normalisation.transform" . | nindent 6 }}
-      # Used to handle external http poison messages in kafka.
-      transform/parse_batch:
-        error_mode: ignore
-        log_statements:
-          - context: log
-            statements:
-              - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body, "^[\\[{]")
-      # Used to handle external http poison messages in kafka.
-      unroll:
-        recursive: true
       attributes/cluster:
         actions:
           - action: insert
@@ -193,7 +183,7 @@ spec:
       pipelines:
         logs/{{ $name }}:
           receivers: [kafka/{{ $name }}]
-          processors: [memory_limiter, transform/parse_batch, unroll, transform/field-normalisation, attributes/cluster{{- range $cfg.extraProcessors }}, {{ .name }}{{- end }}]
+          processors: [memory_limiter, transform/field-normalisation, attributes/cluster{{- range $cfg.extraProcessors }}, {{ .name }}{{- end }}]
           exporters: [failover/opensearch_{{ $name }}]
         logs/{{ $name }}_failover_a:
           receivers: [failover/opensearch_{{ $name }}]

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -85,7 +85,19 @@ spec:
         check_interval: 5s
         limit_percentage: 80
         spike_limit_percentage: 30
+      # Used to handle external http poison messages in kafka.
 {{- include "field_normalisation.transform" . | nindent 6 }}
+      # Used to handle external http poison messages in kafka.
+      transform/parse_batch:
+        error_mode: ignore
+        log_statements:
+        - context: log
+          statements:
+          - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body,
+            "^\\[")
+      # Used to handle external http poison messages in kafka.
+      unroll:
+        recursive: true
       attributes/cluster:
         actions:
           - action: insert
@@ -182,7 +194,7 @@ spec:
       pipelines:
         logs/{{ $name }}:
           receivers: [kafka/{{ $name }}]
-          processors: [memory_limiter, transform/field-normalisation, attributes/cluster{{- range $cfg.extraProcessors }}, {{ .name }}{{- end }}]
+          processors: [memory_limiter, transform/parse_batch, unroll, transform/field-normalisation, attributes/cluster{{- range $cfg.extraProcessors }}, {{ .name }}{{- end }}]
           exporters: [failover/opensearch_{{ $name }}]
         logs/{{ $name }}_failover_a:
           receivers: [failover/opensearch_{{ $name }}]

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -91,10 +91,9 @@ spec:
       transform/parse_batch:
         error_mode: ignore
         log_statements:
-        - context: log
-          statements:
-          - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body,
-            "^\\[")
+          - context: log
+            statements:
+              - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body, "^[\\[{]")
       # Used to handle external http poison messages in kafka.
       unroll:
         recursive: true

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -34,7 +34,7 @@ auditLogs:
     # -- overrides the default image repository for the OpenTelemetry Collector image.
     repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib
     # -- overrides the default image tag for the OpenTelemetry Collector image.
-    tag: "a8981ba"
+    tag: "a62a383"
 
   # -- Custom labels to apply to all OpenTelemetry related resources
   customLabels:

--- a/audit-logs/charts/vendor/README.md
+++ b/audit-logs/charts/vendor/README.md
@@ -1,0 +1,83 @@
+---
+title: Audit Logs Plugin
+---
+
+Learn more about the **Audit Logs** Plugin. Use it to enable the ingestion, collection and export of telemetry signals (logs and metrics) for your Greenhouse cluster.
+
+The main terminologies used in this document can be found in [core-concepts](https://cloudoperators.github.io/greenhouse/docs/getting-started/core-concepts).
+
+## Overview
+
+OpenTelemetry is an observability framework and toolkit for creating and managing telemetry data such as metrics, logs and traces. Unlike other observability tools, OpenTelemetry is vendor and tool agnostic, meaning it can be used with a variety of observability backends, including open source tools such as _OpenSearch_ and _Prometheus_.
+
+The focus of the Plugin is to provide easy-to-use configurations for common use cases of receiving, processing and exporting telemetry data in Kubernetes. The storage and visualization of the same is intentionally left to other tools.
+
+Components included in this Plugin:
+
+- [Collector](https://github.com/open-telemetry/opentelemetry-collector)
+- [Receivers](https://github.com/open-telemetry/opentelemetry-collector/blob/main/receiver/README.md)
+    - [Filelog Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/filelogreceiver)
+    - [k8sevents Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/k8seventsreceiver)
+    - [journald Receiver](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/journaldreceiver)
+    - [prometheus/internal](https://opentelemetry.io/docs/collector/internal-telemetry/)
+- [Connector](https://opentelemetry.io/docs/collector/building/connector/)
+- [OpenSearch Exporter](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/opensearchexporter)
+
+## Architecture
+
+![OpenTelemetry Architecture](img/otel-arch.png)
+
+## Note
+
+It is the intention to add more configuration over time and contributions of your very own configuration is highly appreciated. If you discover bugs or want to add functionality to the Plugin, feel free to create a pull request.
+
+## Quick Start
+
+This guide provides a quick and straightforward way to use **OpenTelemetry** for Logs as a Greenhouse Plugin on your Kubernetes cluster.
+
+**Prerequisites**
+
+- A running and Greenhouse-onboarded Kubernetes cluster. If you don't have one, follow the [Cluster onboarding](https://cloudoperators.github.io/greenhouse/docs/user-guides/cluster/onboarding) guide.
+- For logs, a OpenSearch instance to store. If you don't have one, reach out to your observability team to get access to one.
+- We recommend a running cert-manager in the cluster before installing the **Logs** Plugin
+- To gather metrics, you **must** have a Prometheus instance in the onboarded cluster for storage and for managing Prometheus specific CRDs. If you don not have an instance, install the [kube-monitoring](https://cloudoperators.github.io/greenhouse/docs/reference/catalog/kube-monitoring) Plugin first.
+- The **Audit Logs** Plugin currently requires the OpenTelemetry Operator bundled in the **Logs Plugin** to be installed in the same cluster beforehand. This is a technical limitation of the **Audit Logs** Plugin and will be removed in future releases.
+
+**Step 1:**
+
+You can install the `Logs` package in your cluster by installing it with [Helm](https://helm.sh/docs/helm/helm_install) manually or let the Greenhouse platform lifecycle do it for you automatically. For the latter, you can either:
+  1. Go to Greenhouse dashboard and select the **Logs** Plugin from the catalog. Specify the cluster and required option values.
+  2. Create and specify a `Plugin` resource in your Greenhouse central cluster according to the [examples](#examples).
+
+**Step 2:**
+
+The package will deploy the OpenTelemetry collectors and auto-instrumentation of the workload. By default, the package will include a configuration for collecting metrics and logs. The log-collector is currently processing data from the [preconfigured receivers](#Overview):
+- Files via the Filelog Receiver
+- Kubernetes Events from the Kubernetes API server
+- Journald events from systemd journal
+- its own metrics
+
+Based on the backend selection the telemetry data will be exporter to the backend.
+
+## Failover Connector
+
+The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/connector/failoverconnector) for OpenSearch for two users. The connector will periodically try to establish a stable connection for the prefered user (`failover_username_a`) and in case of a failed try, the connector will try to establish a connection with the fallback user (`failover_username_b`). This feature can be used to secure the shipping of logs in case of expiring credentials or password rotation.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| iasApi.fileName | string | `"ias_api.log"` |  |
+| iasApi.interval | int | `5` |  |
+| iasChangelog.fileName | string | `"ias_changelog.log"` |  |
+| iasChangelog.interval | int | `30` |  |
+| image.repository | string | `""` |  |
+| image.tag | string | `""` |  |
+| logDir | string | `"/audit-poller"` |  |
+| logLevel | string | `"info"` |  |
+| metricsPort | int | `9298` |  |
+| persistence.enabled | bool | `false` |  |
+
+### Examples
+
+TBD

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.10
+    version: 0.2.11
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.10
+        version: 0.2.11
     options:
         - name: auditLogs.region
           description: Region label for logging

--- a/logs/README.md
+++ b/logs/README.md
@@ -93,9 +93,9 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | customCRDs.enabled | bool | `true` | The required CRDs used by this dependency are version-controlled in this repository under ./charts/crds. |
 | extraManifests | list | `[]` | Extra Kubernetes manifests to include in the Helm release. Each entry is rendered as-is (map) or with `tpl` (string). Useful for ConfigMaps that satisfy cluster admission policies. |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
-| openTelemetry.collectorImage | object | `{"repository":"ghcr.io/cloudoperators/opentelemetry-collector-contrib","tag":"a8981ba"}` | OpenTelemetry Collector image configuration |
+| openTelemetry.collectorImage | object | `{"repository":"ghcr.io/cloudoperators/opentelemetry-collector-contrib","tag":"a62a383"}` | OpenTelemetry Collector image configuration |
 | openTelemetry.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | Image repository for OpenTelemetry Collector |
-| openTelemetry.collectorImage.tag | string | `"a8981ba"` | Image tag for OpenTelemetry Collector |
+| openTelemetry.collectorImage.tag | string | `"a62a383"` | Image tag for OpenTelemetry Collector |
 | openTelemetry.customLabels | object | `{}` | custom Labels applied to servicemonitor, secrets and collectors |
 | openTelemetry.externalCollector | object | See values.yaml | Standalone external OTel Collector as StatefulSet. |
 | openTelemetry.externalCollector.affinity | object | `{}` | Pod affinity rules for the external collector CR |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.47
+version: 0.4.48
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -23,7 +23,7 @@ transform/external-http:
     - context: log
       statements:
         - set(log.time_unix_nano, log.observed_time_unix_nano)
-        - merge_maps(log.attributes, ParseJSON(log.body), "upsert") where IsMatch(log.body, "^\\{")
+        - merge_maps(log.attributes, log.body, "upsert") where IsMap(log.body)
         # Auditbeat sends auditd.paths (variable-length array of objects) and
         # auditd.data (open-ended map). Left as nested objects they cause
         # unbounded OpenSearch field-mapping growth (paths.0.*, paths.1.*, ...),
@@ -57,7 +57,16 @@ transform/external-http:
         - set(log.attributes["event.category"], log.attributes["event"]["category"]) where log.attributes["event.category"] == nil and log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and IsString(log.attributes["event"]["category"])
         - set(log.attributes["event.category"], String(log.attributes["event"]["category"])) where log.attributes["event.category"] == nil and log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and not IsString(log.attributes["event"]["category"])
         - delete_key(log.attributes, "event") where log.attributes["event"] != nil
-        
+    
+transform/parse_batch:
+  error_mode: ignore
+  log_statements:
+  - context: log
+    statements:
+    - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body,
+      "^\\[")
+unroll:
+  recursive: true
 {{- end }}
 
 {{/* HTTP path Kafka exporter (its own topic, separate from syslog audit). */}}
@@ -92,6 +101,8 @@ kafka/external_http:
 logs/external-http:
   receivers: [webhookevent/external-http]
   processors:
+    - transform/parse_batch
+    - unroll
     - transform/external-http
     - transform/truncate_message
     - attributes/cluster

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -57,15 +57,6 @@ transform/external-http:
         - set(log.attributes["event.category"], log.attributes["event"]["category"]) where log.attributes["event.category"] == nil and log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and IsString(log.attributes["event"]["category"])
         - set(log.attributes["event.category"], String(log.attributes["event"]["category"])) where log.attributes["event.category"] == nil and log.attributes["event"] != nil and log.attributes["event"]["category"] != nil and not IsString(log.attributes["event"]["category"])
         - delete_key(log.attributes, "event") where log.attributes["event"] != nil
-    
-transform/parse_batch:
-  error_mode: ignore
-  log_statements:
-    - context: log
-      statements:
-        - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body, "^[\\[{]")
-unroll:
-  recursive: true
 {{- end }}
 
 {{/* HTTP path Kafka exporter (its own topic, separate from syslog audit). */}}
@@ -101,7 +92,6 @@ logs/external-http:
   receivers: [webhookevent/external-http]
   processors:
     - memory_limiter
-    - transform/parse_batch
     - transform/external-http
     - transform/truncate_message
     - attributes/cluster

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -65,8 +65,6 @@ transform/parse_batch:
     statements:
     - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body,
       "^\\[")
-unroll:
-  recursive: true
 {{- end }}
 
 {{/* HTTP path Kafka exporter (its own topic, separate from syslog audit). */}}
@@ -101,12 +99,11 @@ kafka/external_http:
 logs/external-http:
   receivers: [webhookevent/external-http]
   processors:
+    - memory_limiter
     - transform/parse_batch
-    - unroll
     - transform/external-http
     - transform/truncate_message
     - attributes/cluster
-    - batch
 {{- if .Values.openTelemetry.kafka.enabled }}
   exporters: [kafka/external_http]
 {{- else }}

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -61,10 +61,11 @@ transform/external-http:
 transform/parse_batch:
   error_mode: ignore
   log_statements:
-  - context: log
-    statements:
-    - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body,
-      "^\\[")
+    - context: log
+      statements:
+        - set(log.body, ParseJSON(log.body)) where IsString(log.body) and IsMatch(log.body, "^[\\[{]")
+unroll:
+  recursive: true
 {{- end }}
 
 {{/* HTTP path Kafka exporter (its own topic, separate from syslog audit). */}}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -51,7 +51,7 @@ openTelemetry:
     # -- Image repository for OpenTelemetry Collector
     repository: ghcr.io/cloudoperators/opentelemetry-collector-contrib
     # -- Image tag for OpenTelemetry Collector
-    tag: "a8981ba"
+    tag: "a62a383"
 
   # -- custom Labels applied to servicemonitor, secrets and collectors
   customLabels: {}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.47
+  version: 0.15.48
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.47
+    version: 0.4.48
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
This seems to resolve the issue of logstash sending json_batches. It is a bit of a carousell of batching->mapping->expanding->batching in the pipeline, but this successfully explodes the json_batch into single log records. then sent to a sink. the ingester on the other hand has a similar setup simply because the kafka (in this case) has a particular posion of lag with json_batch arrays still. once lag is terminated this could be removed on the ingester side

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>