### PR TITLE
chore: bump repo-guard to v5.9.1

### DIFF
--- a/repo-guard/plugindefinition.yaml
+++ b/repo-guard/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: ClusterPluginDefinition
 metadata:
   name: repo-guard
 spec:
-  version: "5.9.0"
+  version: "5.9.1"
   displayName: Repo Guard
   description: Repo Guard automates GitHub organization management using Kubernetes Custom Resources (CRDs)
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/repo-guard/refs/heads/main/README.md
   helmChart:
     name: repo-guard
     repository: oci://ghcr.io/cloudoperators/charts
-    version: 5.9.0
+    version: 5.9.1
   options:
     - name: manager
       description: Manager configuration


### PR DESCRIPTION
Bumps repo-guard chart to v5.9.1. Release notes: https://github.com/cloudoperators/repo-guard/releases/tag/v5.9.1