### PR TITLE
feat(audit-logs): make ingester opensearch exporter sending_queue configurable

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.11
+version: 0.2.12
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -124,6 +124,12 @@ spec:
         mapping:
           {{- toYaml . | nindent 10 }}
 {{- end }}
+        sending_queue:
+          enabled: {{ dig "sendingQueue" "enabled" false $cfg.opensearch }}
+          block_on_overflow: true
+          wait_for_result: {{ dig "sendingQueue" "waitForResult" true $cfg.opensearch }}
+          num_consumers: {{ dig "sendingQueue" "numConsumers" 1 $cfg.opensearch }}
+          queue_size: {{ dig "sendingQueue" "queueSize" 10 $cfg.opensearch }}
         retry_on_failure:
           enabled: true
           initial_interval: 1s
@@ -143,6 +149,12 @@ spec:
         mapping:
           {{- toYaml . | nindent 10 }}
 {{- end }}
+        sending_queue:
+          enabled: {{ dig "sendingQueue" "enabled" false $cfg.opensearch }}
+          block_on_overflow: true
+          wait_for_result: {{ dig "sendingQueue" "waitForResult" true $cfg.opensearch }}
+          num_consumers: {{ dig "sendingQueue" "numConsumers" 1 $cfg.opensearch }}
+          queue_size: {{ dig "sendingQueue" "queueSize" 10 $cfg.opensearch }}
         retry_on_failure:
           enabled: true
           initial_interval: 1s

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -144,6 +144,7 @@ auditLogs:
     #       tls: { caSecret, caSecretKey, insecure }
     #       mapping: { mode: bodymap }          # optional, opensearchexporter mapping block (e.g. bodymap to write the parsed body as the document root)
     #       failover_username_a / failover_password_a / failover_username_b / failover_password_b
+    #       sendingQueue: { enabled, waitForResult, numConsumers, queueSize }  # optional; default disabled. waitForResult defaults true (at-least-once)
     # Each entry renders one OpenTelemetryCollector named "audit-ingester-<name>" with
     # group_id "audit-ingester-<name>" and indexes documents into OpenSearch index "<name>".
     # -- Map of ingest collectors keyed by name. Configured via PluginPreset.

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.11
+    version: 0.2.12
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.11
+        version: 0.2.12
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
## Pull Request Details

- Adds configurable `sending_queue` (enabled, waitForResult, numConsumers, queueSize) to the audit ingester's OpenSearch failover exporters, so the queue + parallel-sender throughput config can be set via values
- `waitForResult` defaults `true`: each enqueue blocks until OpenSearch confirms, preserving at-least-once (Kafka offset committed only after a confirmed write).

