### PR TITLE
feat(logs): audit topic routed to audit kafka

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -92,6 +92,20 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | commonLabels | object | `{}` | common labels to apply to all resources. |
 | customCRDs.enabled | bool | `true` | The required CRDs used by this dependency are version-controlled in this repository under ./charts/crds. |
 | extraManifests | list | `[]` | Extra Kubernetes manifests to include in the Helm release. Each entry is rendered as-is (map) or with `tpl` (string). Useful for ConfigMaps that satisfy cluster admission policies. |
+| openTelemetry.auditKafka | object | See values.yaml | Audit Kafka exporter configuration shared by all collectors |
+| openTelemetry.auditKafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
+| openTelemetry.auditKafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
+| openTelemetry.auditKafka.enabled | bool | `false` | Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering) |
+| openTelemetry.auditKafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw) |
+| openTelemetry.auditKafka.max_fetch_size | int | `1048576` | Consumer max bytes per fetch request (ingester). Match producer max_message_bytes for large records. |
+| openTelemetry.auditKafka.max_message_bytes | int | `1048576` | Max producer message size in bytes before compression. Raise to match the Kafka topic/broker max.message.bytes. |
+| openTelemetry.auditKafka.max_partition_fetch_size | int | `1048576` | Consumer max bytes fetched per partition (ingester). Match producer max_message_bytes for large records. |
+| openTelemetry.auditKafka.producer | object | `{"flushMaxMessages":10000,"linger":"10ms"}` | Producer batching (raise linger to build larger batches per broker request) |
+| openTelemetry.auditKafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
+| openTelemetry.auditKafka.sendingQueue | object | `{"enabled":true,"numConsumers":1,"queueSize":1000}` | Producer sending queue size |
+| openTelemetry.auditKafka.sendingQueue.numConsumers | int | `1` | Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput. |
+| openTelemetry.auditKafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
+| openTelemetry.auditKafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
 | openTelemetry.collectorImage | object | `{"repository":"ghcr.io/cloudoperators/opentelemetry-collector-contrib","tag":"a8981ba"}` | OpenTelemetry Collector image configuration |
 | openTelemetry.collectorImage.repository | string | `"ghcr.io/cloudoperators/opentelemetry-collector-contrib"` | Image repository for OpenTelemetry Collector |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.46
+version: 0.4.47
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.51
+version: 0.4.52
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.49
+version: 0.4.50
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.50
+version: 0.4.51
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-audit-exporter.tpl
+++ b/logs/charts/templates/_external-audit-exporter.tpl
@@ -67,7 +67,7 @@ opensearch/failover_a_syslog_audit:
   http:
     auth:
       authenticator: basicauth/syslog_audit_failover_a
-    endpoint: {{ required "openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint is required when kafka is disabled" .Values.openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint }}
+    endpoint: {{ required "openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint is required when audit kafka is disabled" .Values.openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint }}
   logs_index: audit-datastream
   retry_on_failure:
     enabled: true
@@ -79,7 +79,7 @@ opensearch/failover_b_syslog_audit:
   http:
     auth:
       authenticator: basicauth/syslog_audit_failover_b
-    endpoint: {{ required "openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint is required when kafka is disabled" .Values.openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint }}
+    endpoint: {{ required "openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint is required when audit kafka is disabled" .Values.openTelemetry.externalCollector.syslogConfig.openSearchLogs.auditEndpoint }}
   logs_index: audit-datastream
   retry_on_failure:
     enabled: true
@@ -95,7 +95,7 @@ kafka/syslog_audit:
 {{- end }}
   protocol_version: {{ .Values.openTelemetry.auditKafka.protocol_version }}
   logs:
-    topic: {{ required "openTelemetry.externalCollector.syslogConfig.auditKafkaTopic is required when kafka is enabled" .Values.openTelemetry.externalCollector.syslogConfig.auditKafkaTopic }}
+    topic: {{ required "openTelemetry.externalCollector.syslogConfig.auditKafkaTopic is required when audit kafka is enabled" .Values.openTelemetry.externalCollector.syslogConfig.auditKafkaTopic }}
     encoding: {{ .Values.openTelemetry.auditKafka.encoding }}
   producer:
     compression: {{ .Values.openTelemetry.auditKafka.compression }}

--- a/logs/charts/templates/_external-audit-exporter.tpl
+++ b/logs/charts/templates/_external-audit-exporter.tpl
@@ -24,7 +24,7 @@ SPDX-License-Identifier: Apache-2.0
 
 {{/* Processors that inject the audit failover username per endpoint (non-Kafka only). */}}
 {{- define "external_audit_only.processors" }}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 attributes/syslog_audit_failover_username_a:
   actions:
     - action: insert
@@ -40,7 +40,7 @@ attributes/syslog_audit_failover_username_b:
 
 {{/* basicauth extensions for the audit failover endpoints (map form, non-Kafka only). */}}
 {{- define "external_audit_only.extensions" }}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 basicauth/syslog_audit_failover_a:
   client_auth:
     username: ${audit_failover_username_a}
@@ -54,7 +54,7 @@ basicauth/syslog_audit_failover_b:
 
 {{/* service.extensions list fragment for the audit basicauth extensions (non-Kafka only). */}}
 {{- define "external_audit_only.serviceExtensions" }}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 - basicauth/syslog_audit_failover_a
 - basicauth/syslog_audit_failover_b
 {{- end }}
@@ -62,7 +62,7 @@ basicauth/syslog_audit_failover_b:
 
 {{/* Audit exporters: OpenSearch failover pair (non-Kafka) or kafka/syslog_audit (Kafka). */}}
 {{- define "external_audit_only.exporter" }}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 opensearch/failover_a_syslog_audit:
   http:
     auth:
@@ -90,23 +90,23 @@ opensearch/failover_b_syslog_audit:
 {{- else }}
 kafka/syslog_audit:
   brokers:
-{{- range .Values.openTelemetry.kafka.brokers }}
+{{- range .Values.openTelemetry.auditKafka.brokers }}
     - {{ . }}
 {{- end }}
-  protocol_version: {{ .Values.openTelemetry.kafka.protocol_version }}
+  protocol_version: {{ .Values.openTelemetry.auditKafka.protocol_version }}
   logs:
     topic: {{ required "openTelemetry.externalCollector.syslogConfig.auditKafkaTopic is required when kafka is enabled" .Values.openTelemetry.externalCollector.syslogConfig.auditKafkaTopic }}
-    encoding: {{ .Values.openTelemetry.kafka.encoding }}
+    encoding: {{ .Values.openTelemetry.auditKafka.encoding }}
   producer:
-    compression: {{ .Values.openTelemetry.kafka.compression }}
-    max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
-    flush_max_messages: {{ .Values.openTelemetry.kafka.producer.flushMaxMessages | int64 }}
-    linger: {{ .Values.openTelemetry.kafka.producer.linger | quote }}
+    compression: {{ .Values.openTelemetry.auditKafka.compression }}
+    max_message_bytes: {{ .Values.openTelemetry.auditKafka.max_message_bytes | int64 }}
+    flush_max_messages: {{ .Values.openTelemetry.auditKafka.producer.flushMaxMessages | int64 }}
+    linger: {{ .Values.openTelemetry.auditKafka.producer.linger | quote }}
   sending_queue:
-    enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
-    num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
-    queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
-{{- if .Values.openTelemetry.kafka.tls.enabled }}
+    enabled: {{ .Values.openTelemetry.auditKafka.sendingQueue.enabled }}
+    num_consumers: {{ .Values.openTelemetry.auditKafka.sendingQueue.numConsumers | default 1 | int64 }}
+    queue_size: {{ .Values.openTelemetry.auditKafka.sendingQueue.queueSize | int64 }}
+{{- if .Values.openTelemetry.auditKafka.tls.enabled }}
   tls:
     insecure: false
 {{- end }}
@@ -115,7 +115,7 @@ kafka/syslog_audit:
 
 {{/* Failover connector for the audit OpenSearch pair (non-Kafka only). */}}
 {{- define "external_audit_only.connectors" }}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 failover/opensearch_syslog_audit:
   priority_levels:
     - [logs/failover_a_syslog_audit]
@@ -132,7 +132,7 @@ failover/opensearch_syslog_audit:
 
 {{/* Downstream failover pipelines so the connector has routes (non-Kafka only). */}}
 {{- define "external_audit_only.pipeline" }}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 logs/failover_a_syslog_audit:
   receivers: [failover/opensearch_syslog_audit]
   processors: [attributes/syslog_audit_failover_username_a]

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -62,26 +62,26 @@ transform/external-http:
 
 {{/* HTTP path Kafka exporter (its own topic, separate from syslog audit). */}}
 {{- define "external_http.exporter" }}
-{{- if .Values.openTelemetry.kafka.enabled }}
+{{- if .Values.openTelemetry.auditKafka.enabled }}
 kafka/external_http:
   brokers:
-{{- range .Values.openTelemetry.kafka.brokers }}
+{{- range .Values.openTelemetry.auditKafka.brokers }}
     - {{ . }}
 {{- end }}
-  protocol_version: {{ .Values.openTelemetry.kafka.protocol_version }}
+  protocol_version: {{ .Values.openTelemetry.auditKafka.protocol_version }}
   logs:
     topic: {{ required "openTelemetry.externalCollector.externalHttpConfig.kafkaTopic is required when kafka is enabled" .Values.openTelemetry.externalCollector.externalHttpConfig.kafkaTopic }}
-    encoding: {{ .Values.openTelemetry.kafka.encoding }}
+    encoding: {{ .Values.openTelemetry.auditKafka.encoding }}
   producer:
-    compression: {{ .Values.openTelemetry.kafka.compression }}
-    max_message_bytes: {{ .Values.openTelemetry.kafka.max_message_bytes | int64 }}
-    flush_max_messages: {{ .Values.openTelemetry.kafka.producer.flushMaxMessages | int64 }}
-    linger: {{ .Values.openTelemetry.kafka.producer.linger | quote }}
+    compression: {{ .Values.openTelemetry.auditKafka.compression }}
+    max_message_bytes: {{ .Values.openTelemetry.auditKafka.max_message_bytes | int64 }}
+    flush_max_messages: {{ .Values.openTelemetry.auditKafka.producer.flushMaxMessages | int64 }}
+    linger: {{ .Values.openTelemetry.auditKafka.producer.linger | quote }}
   sending_queue:
-    enabled: {{ .Values.openTelemetry.kafka.sendingQueue.enabled }}
-    num_consumers: {{ .Values.openTelemetry.kafka.sendingQueue.numConsumers | default 1 | int64 }}
-    queue_size: {{ .Values.openTelemetry.kafka.sendingQueue.queueSize | int64 }}
-{{- if .Values.openTelemetry.kafka.tls.enabled }}
+    enabled: {{ .Values.openTelemetry.auditKafka.sendingQueue.enabled }}
+    num_consumers: {{ .Values.openTelemetry.auditKafka.sendingQueue.numConsumers | default 1 | int64 }}
+    queue_size: {{ .Values.openTelemetry.auditKafka.sendingQueue.queueSize | int64 }}
+{{- if .Values.openTelemetry.auditKafka.tls.enabled }}
   tls:
     insecure: false
 {{- end }}
@@ -96,7 +96,7 @@ logs/external-http:
     - transform/truncate_message
     - attributes/cluster
     - batch
-{{- if .Values.openTelemetry.kafka.enabled }}
+{{- if .Values.openTelemetry.auditKafka.enabled }}
   exporters: [kafka/external_http]
 {{- else }}
   exporters: [failover/opensearch_syslog_audit]

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -69,7 +69,7 @@ kafka/external_http:
 {{- end }}
   protocol_version: {{ .Values.openTelemetry.auditKafka.protocol_version }}
   logs:
-    topic: {{ required "openTelemetry.externalCollector.externalHttpConfig.kafkaTopic is required when kafka is enabled" .Values.openTelemetry.externalCollector.externalHttpConfig.kafkaTopic }}
+    topic: {{ required "openTelemetry.externalCollector.externalHttpConfig.kafkaTopic is required when audit kafka is enabled" .Values.openTelemetry.externalCollector.externalHttpConfig.kafkaTopic }}
     encoding: {{ .Values.openTelemetry.auditKafka.encoding }}
   producer:
     compression: {{ .Values.openTelemetry.auditKafka.compression }}

--- a/logs/charts/templates/_helpers.tpl
+++ b/logs/charts/templates/_helpers.tpl
@@ -13,7 +13,7 @@ receiver has its own kafka/external_http exporter and does not need these.
 Usage: {{- if eq (include "externalCollector.auditEnabled" .) "true" }}
 */}}
 {{- define "externalCollector.auditEnabled" -}}
-{{- if or .Values.openTelemetry.externalCollector.syslogConfig.enabled .Values.openTelemetry.externalCollector.syslogTLSConfig.enabled (and .Values.openTelemetry.externalCollector.externalHttpConfig.enabled (not .Values.openTelemetry.kafka.enabled)) -}}
+{{- if or .Values.openTelemetry.externalCollector.syslogConfig.enabled .Values.openTelemetry.externalCollector.syslogTLSConfig.enabled (and .Values.openTelemetry.externalCollector.externalHttpConfig.enabled (not .Values.openTelemetry.auditKafka.enabled)) -}}
 true
 {{- end -}}
 {{- end -}}

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -338,7 +338,7 @@ transform/syslog_observed_timestamp_fallback:
   Audit logs go to audit-datastream, non-audit logs go to logs-datastream
   ============================================================================
 */}}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 routing/syslog_audit:
   default_pipelines: [logs/syslog_non_audit]
   error_mode: ignore
@@ -429,7 +429,7 @@ kafka/syslog_non_audit:
   Non-audit logs → logs-datastream
   ============================================================================
 */}}
-{{- if not .Values.openTelemetry.kafka.enabled }}
+{{- if not .Values.openTelemetry.auditKafka.enabled }}
 logs/failover_a_syslog_non_audit:
   receivers: [failover/opensearch_syslog_non_audit]
   processors: [attributes/failover_username_a]
@@ -445,7 +445,7 @@ logs/failover_b_syslog_non_audit:
 logs/syslog_audit:
   receivers: [routing/syslog_audit]
   processors: [batch]
-{{- if .Values.openTelemetry.kafka.enabled }}
+{{- if .Values.openTelemetry.auditKafka.enabled }}
   exporters: [kafka/syslog_audit]
 {{- else }}
   exporters: [failover/opensearch_syslog_audit]

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -104,6 +104,39 @@ openTelemetry:
     tls:
       # -- Enable TLS for Kafka connections
       enabled: false
+  # -- Audit Kafka exporter configuration shared by all collectors
+  # @default -- See values.yaml
+  auditKafka:
+    # -- Enable Kafka exporter (replaces OpenSearch failover with Kafka buffering)
+    enabled: false
+    # -- Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"])
+    brokers: []
+    # -- Kafka protocol version (e.g., "3.9.0")
+    protocol_version: ""
+    # -- Message encoding format (otlp_json, otlp_proto, raw)
+    encoding: ""
+    # -- Compression type (none, gzip, snappy, lz4, zstd)
+    compression: ""
+    # -- Max producer message size in bytes before compression. Raise to match the Kafka topic/broker max.message.bytes.
+    max_message_bytes: 1048576
+    # -- Consumer max bytes per fetch request (ingester). Match producer max_message_bytes for large records.
+    max_fetch_size: 1048576
+    # -- Consumer max bytes fetched per partition (ingester). Match producer max_message_bytes for large records.
+    max_partition_fetch_size: 1048576
+    # -- Producer sending queue size
+    sendingQueue:
+      enabled: true
+      queueSize: 1000
+      # -- Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput.
+      numConsumers: 1
+    # -- Producer batching (raise linger to build larger batches per broker request)
+    producer:
+      flushMaxMessages: 10000
+      linger: 10ms
+    # -- TLS configuration for Kafka connections
+    tls:
+      # -- Enable TLS for Kafka connections
+      enabled: false
   logsCollector:
     # -- Activates the standard configuration for Logs.
     enabled: true

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.51
+  version: 0.15.52
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.51
+    version: 0.4.52
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.49
+  version: 0.15.50
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.49
+    version: 0.4.50
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.50
+  version: 0.15.51
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.50
+    version: 0.4.51
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.46
+  version: 0.15.47
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.46
+    version: 0.4.47
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

Adding new values.yaml section with `auditKafka` settings. Since now we handle audit relevant topics in separate kafka instance.
