### PR TITLE
feat(gardener-shoot-rules): add plugin for Gardener shoot control plane alert rules

### DIFF
--- a/gardener-shoot-rules/README.md
+++ b/gardener-shoot-rules/README.md
@@ -22,12 +22,6 @@ This plugin installs the same 54 shoot alert rules as a new `PrometheusRule` res
 
 ## Upgrading
 
-Rules are extracted from [gardener/gardener](https://github.com/gardener/gardener) source files. A Renovate comment in `Chart.yaml` tracks the upstream version. To regenerate after a Gardener upgrade:
+Rules are extracted from [gardener/gardener](https://github.com/gardener/gardener) source files. A Renovate comment in `Chart.yaml` tracks the upstream version tag.
 
-```bash
-# Example: upgrading from v1.148.3 to v1.150.0
-make generate GARDENER_VERSION=v1.150.0
-git diff charts/templates/prometheusrule-shoot.yaml
-```
-
-Requires Go ≥ 1.21 and a GitHub token (`gh auth token` or `GITHUB_TOKEN` env var).
+When Gardener upgrades, the rules in `charts/templates/prometheusrule-shoot.yaml` need to be manually re-extracted from the new version and the `version:` fields in `Chart.yaml` and `plugindefinition.yaml` bumped accordingly.

--- a/gardener-shoot-rules/README.md
+++ b/gardener-shoot-rules/README.md
@@ -1,0 +1,32 @@
+---
+title: Gardener Shoot Alert Rules
+---
+
+The **gardener-shoot-rules** plugin packages Gardener upstream shoot control plane alert rules for evaluation by `prometheus-metrics-gardener`.
+
+## Problem
+
+Gardenlet deploys PrometheusRules in shoot namespaces with the label `prometheus: shoot`. The `prometheus-metrics-gardener` instance uses `ruleSelector: NotIn [shoot]` to avoid 14× duplicate alerts from all shoot namespaces. A side effect is that shoot control plane alerts (`KubeEtcdMainDown`, `KubePodNotReadyControlPlane`, `KubeApiserverDown`, etc.) never fire on the central alertmanager.
+
+## Solution
+
+This plugin installs the same 54 shoot alert rules as a new `PrometheusRule` resource **without** the `prometheus: shoot` label. `prometheus-metrics-gardener` picks it up naturally, evaluates rules once against federated metrics, and routes alerts to alertmanager with the correct labels via `additionalRuleLabels`.
+
+## Options
+
+| Name | Type | Default | Description |
+|---|---|---|---|
+| `rules.create` | bool | `true` | Deploy the PrometheusRule resource |
+| `rules.additionalRuleLabels` | map | `{}` | Extra labels injected into every alert rule (e.g. `thanos-ruler`, `support_group`) |
+| `global.commonLabels` | map | `{}` | Labels added to the PrometheusRule metadata |
+
+## Upgrading
+
+Rules are extracted from [gardener/gardener](https://github.com/gardener/gardener) source files. A Renovate comment in `Chart.yaml` tracks the upstream version. To regenerate after a Gardener upgrade:
+
+```bash
+make generate GARDENER_VERSION=v1.150.0
+git diff charts/templates/prometheusrule-shoot.yaml
+```
+
+Requires Go ≥ 1.21 and a GitHub token (`gh auth token` or `GITHUB_TOKEN` env var).

--- a/gardener-shoot-rules/README.md
+++ b/gardener-shoot-rules/README.md
@@ -17,7 +17,7 @@ This plugin installs the same 54 shoot alert rules as a new `PrometheusRule` res
 | Name | Type | Default | Description |
 |---|---|---|---|
 | `rules.create` | bool | `true` | Deploy the PrometheusRule resource |
-| `rules.additionalRuleLabels` | map | `{}` | Extra labels injected into every alert rule (e.g. `thanos-ruler`, `support_group`) |
+| `rules.additionalRuleLabels` | map | `{}` | Extra labels injected into every alert rule (e.g. `thanos-ruler`, `support_group`). Note: keys that overlap with built-in rule labels (`service`, `severity`, `type`, `visibility`) will override those upstream values. |
 | `global.commonLabels` | map | `{}` | Labels added to the PrometheusRule metadata |
 
 ## Upgrading
@@ -25,6 +25,7 @@ This plugin installs the same 54 shoot alert rules as a new `PrometheusRule` res
 Rules are extracted from [gardener/gardener](https://github.com/gardener/gardener) source files. A Renovate comment in `Chart.yaml` tracks the upstream version. To regenerate after a Gardener upgrade:
 
 ```bash
+# Example: upgrading from v1.148.3 to v1.150.0
 make generate GARDENER_VERSION=v1.150.0
 git diff charts/templates/prometheusrule-shoot.yaml
 ```

--- a/gardener-shoot-rules/charts/Chart.yaml
+++ b/gardener-shoot-rules/charts/Chart.yaml
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: v2
+name: gardener-shoot-rules
+description: Packages Gardener upstream shoot PrometheusRules for prometheus-metrics-gardener evaluation.
+type: application
+# renovate: datasource=github-releases depName=gardener/gardener
+# Rules extracted from gardener/gardener v1.148.3
+version: 0.1.0

--- a/gardener-shoot-rules/charts/ci/test-values.yaml
+++ b/gardener-shoot-rules/charts/ci/test-values.yaml
@@ -6,4 +6,3 @@ rules:
   additionalRuleLabels:
     thanos-ruler: test-ruler
     support_group: test-group
-    service: metrics

--- a/gardener-shoot-rules/charts/ci/test-values.yaml
+++ b/gardener-shoot-rules/charts/ci/test-values.yaml
@@ -6,3 +6,4 @@ rules:
   additionalRuleLabels:
     thanos-ruler: test-ruler
     support_group: test-group
+    owning_service: metrics

--- a/gardener-shoot-rules/charts/ci/test-values.yaml
+++ b/gardener-shoot-rules/charts/ci/test-values.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+rules:
+  create: true
+  additionalRuleLabels:
+    thanos-ruler: test-ruler
+    support_group: test-group
+    service: metrics

--- a/gardener-shoot-rules/charts/templates/_helpers.tpl
+++ b/gardener-shoot-rules/charts/templates/_helpers.tpl
@@ -1,0 +1,13 @@
+{{/* vim: set filetype=mustache: */}}
+{{/* SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{- define "gardener-shoot-rules.labels" -}}
+plugindefinition: gardener-shoot-rules
+plugin: {{ $.Release.Name }}
+{{- if .Values.global.commonLabels }}
+{{ tpl (toYaml .Values.global.commonLabels) . }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+release: {{ $.Release.Name | quote }}
+{{- end -}}

--- a/gardener-shoot-rules/charts/templates/prometheusrule-shoot.yaml
+++ b/gardener-shoot-rules/charts/templates/prometheusrule-shoot.yaml
@@ -1,0 +1,897 @@
+{{/* SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors */}}
+{{/* SPDX-License-Identifier: Apache-2.0 */}}
+
+{{- if .Values.rules.create }}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ $.Release.Name }}-shoot-rules
+  namespace: {{ $.Release.Namespace }}
+  labels:
+    {{- include "gardener-shoot-rules.labels" . | nindent 4 }}
+spec:
+  groups:
+  # Rules extracted from gardener/gardener v1.148.3
+  - name: apiserver-connectivity-check.rules
+    rules:
+    - alert: ApiServerUnreachableViaKubernetesService
+      expr: >-
+        probe_success{job="blackbox-exporter-k8s-service-check"} == 0 or absent(probe_success{job="blackbox-exporter-k8s-service-check", instance="https://kubernetes.default.svc.cluster.local/healthz"})
+      for: 15m
+      labels:
+        service: apiserver-connectivity-check
+        severity: critical
+        type: shoot
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: The Api server has been unreachable for 15 minutes via the kubernetes service in the shoot.
+        summary: Api server unreachable via the kubernetes service.
+  - name: cloud-controller-manager.rules
+    rules:
+    - alert: CloudControllerManagerDown
+      expr: >-
+        absent(up{job="cloud-controller-manager"} == 1)
+      for: 15m
+      labels:
+        service: cloud-controller-manager
+        severity: critical
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          All infrastructure specific operations cannot be completed (e.g. creating loadbalancers or persistent volumes).
+        summary: Cloud controller manager is down.
+  - name: cluster-autoscaler.rules
+    rules:
+    - alert: ClusterAutoscalerDown
+      expr: >-
+        absent(up{job="cluster-autoscaler"} == 1)
+      for: 15m
+      labels:
+        service: cluster-autoscaler
+        severity: critical
+        type: seed
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'There is no running cluster autoscaler. Shoot''s Nodes wont be scaled dynamically, based on the load.'
+        summary: Cluster autoscaler is down
+  - name: coredns.rules
+    rules:
+    - alert: CoreDNSDown
+      expr: >-
+        absent(up{job="coredns"} == 1)
+      for: 20m
+      labels:
+        service: kube-dns
+        severity: critical
+        type: shoot
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: CoreDNS could not be found. Cluster DNS resolution will not work.
+        summary: CoreDNS is down
+  - name: kube-etcd3-events.rules
+    rules:
+    - alert: KubeEtcdEventsDown
+      expr: >-
+        sum(up{job="kube-etcd3-events"}) < 2
+      for: 15m
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd3 cluster events is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 events is down, the cluster is unreachable.
+        summary: Etcd3 events cluster down.
+    - alert: KubeEtcd3EventsNoLeader
+      expr: >-
+        sum(etcd_server_has_leader{job="kube-etcd3-events"}) < count(etcd_server_has_leader{job="kube-etcd3-events"})
+      for: 15m
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Etcd3 cluster events has no leader. Possible network partition in the etcd cluster.
+        summary: Etcd3 events has no leader.
+    - alert: KubeEtcd3EventsHighMemoryConsumption
+      expr: >-
+        sum(container_memory_working_set_bytes{pod="etcd-events-0",container="etcd"}) / sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{container="etcd", targetName="etcd-events", resource="memory"}) > .5
+      for: 15m
+      labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'Etcd3 events is consuming over 50% of the max allowed value specified by VPA.'
+        summary: Etcd3 events is consuming too much memory
+    - alert: KubeEtcd3EventsDbSizeLimitApproaching
+      expr: >-
+        (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-events"} > bool 7516193000) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-events"} <= bool 8589935000) == 2
+      labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd3 events DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
+        summary: Etcd3 events DB size is approaching its current practical limit.
+    - alert: KubeEtcd3EventsDbSizeLimitCrossed
+      expr: >-
+        etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-events"} > 8589935000
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd3 events DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
+        summary: Etcd3 events DB size has crossed its current practical limit.
+  - name: kube-etcd3-main.rules
+    rules:
+    - alert: KubeEtcdMainDown
+      expr: >-
+        sum(up{job="kube-etcd3-main"}) < 2
+      for: 5m
+      labels:
+        service: etcd
+        severity: blocker
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd3 cluster main is unavailable (due to possible quorum loss) or cannot be scraped. As long as etcd3 main is down, the cluster is unreachable.
+        summary: Etcd3 main cluster down.
+    - alert: KubeEtcd3MainNoLeader
+      expr: >-
+        sum(etcd_server_has_leader{job="kube-etcd3-main"}) < count(etcd_server_has_leader{job="kube-etcd3-main"})
+      for: 10m
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Etcd3 cluster main has no leader. Possible network partition in the etcd cluster.
+        summary: Etcd3 main has no leader.
+    - alert: KubeEtcd3MainHighMemoryConsumption
+      expr: >-
+        sum(container_memory_working_set_bytes{pod="etcd-main-0",container="etcd"}) / sum(kube_verticalpodautoscaler_spec_resourcepolicy_container_policies_maxallowed{container="etcd", targetName="etcd-main", resource="memory"}) > .5
+      for: 15m
+      labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'Etcd3 main is consuming over 50% of the max allowed value specified by VPA.'
+        summary: Etcd3 main is consuming too much memory
+    - alert: KubeEtcd3MainDbSizeLimitApproaching
+      expr: >-
+        (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"} > bool 7516193000) + (etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"} <= bool 8589935000) == 2
+      labels:
+        service: etcd
+        severity: warning
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd3 main DB size is approaching its current practical limit of 8GB. Etcd quota might need to be increased.
+        summary: Etcd3 main DB size is approaching its current practical limit.
+    - alert: KubeEtcd3MainDbSizeLimitCrossed
+      expr: >-
+        etcd_mvcc_db_total_size_in_bytes{job="kube-etcd3-main"} > 8589935000
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd3 main DB size has crossed its current practical limit of 8GB. Etcd quota must be increased to allow updates.
+        summary: Etcd3 main DB size has crossed its current practical limit.
+    - alert: KubeEtcdMainDeltaBackupFailed
+      expr: >-
+        ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-main",kind="Incr"} > bool 900) * etcdbr_snapshot_required{job="kube-etcd3-backup-restore-main",kind="Incr"}) * on (pod, role) etcd_server_is_leader{job="kube-etcd3-main"} > 0
+      for: 15m
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: No delta snapshot for the past 30 minutes have been taken by backup-restore leader.
+        summary: Etcd delta snapshot failure.
+    - alert: KubeEtcdMainFullBackupFailed
+      expr: >-
+        ((time() - etcdbr_snapshot_latest_timestamp{job="kube-etcd3-backup-restore-main",kind="Full"} > bool 86400) * etcdbr_snapshot_required{job="kube-etcd3-backup-restore-main",kind="Full"}) * on (pod, role) etcd_server_is_leader{job="kube-etcd3-main"} > 0
+      for: 15m
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: No full snapshot for at least last 24 hours have been taken by backup-restore leader.
+        summary: Etcd full snapshot failure.
+    - alert: KubeEtcdMainRestorationFailed
+      expr: >-
+        rate(etcdbr_restoration_duration_seconds_count{job="kube-etcd3-backup-restore-main",succeeded="false"}[2m]) > 0
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Etcd data restoration was triggered, but has failed.
+        summary: Etcd data restoration failure.
+    - alert: KubeEtcdMainBackupRestoreDown
+      expr: >-
+        (sum(up{job="kube-etcd3-main"}) - sum(up{job="kube-etcd3-backup-restore-main"}) > 0) or (rate(etcdbr_snapshotter_failure{job="kube-etcd3-backup-restore-main"}[5m]) > 0)
+      for: 10m
+      labels:
+        service: etcd
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Etcd backup restore main process down or snapshotter failed with error. Backups will not be triggered unless backup restore is brought back up. This is unsafe behaviour and may cause data loss.
+        summary: Etcd backup restore main process down or snapshotter failed with error
+  - name: kube-apiserver.rules
+    rules:
+    - alert: ApiServerNotReachable
+      expr: >-
+        probe_success{job="blackbox-apiserver"} == 0
+      for: 5m
+      labels:
+        service: kube-apiserver
+        severity: blocker
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          API server not reachable via external endpoint: {{`{{ $labels.instance }}`}}.
+        summary: API server not reachable (externally).
+    - alert: KubeApiserverDown
+      expr: >-
+        absent(up{job="kube-apiserver"} == 1)
+      for: 5m
+      labels:
+        service: kube-apiserver
+        severity: blocker
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: All API server replicas are down/unreachable, or all API server could not be found.
+        summary: API server unreachable.
+    - alert: KubeApiServerTooManyOpenFileDescriptors
+      expr: >-
+        100 * process_open_fds{job="kube-apiserver"} / process_max_fds > 50
+      for: 30m
+      labels:
+        service: kube-apiserver
+        severity: warning
+        type: seed
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          The API server ({{`{{ $labels.instance }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors.
+        summary: The API server has too many open file descriptors
+    - alert: KubeApiServerTooManyOpenFileDescriptors
+      expr: >-
+        100 * process_open_fds{job="kube-apiserver"} / process_max_fds{job="kube-apiserver"} > 80
+      for: 30m
+      labels:
+        service: kube-apiserver
+        severity: critical
+        type: seed
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          The API server ({{`{{ $labels.instance }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors.
+        summary: The API server has too many open file descriptors
+    - alert: KubeApiServerLatency
+      expr: >-
+        histogram_quantile(0.99, sum without (instance,resource,subresource) (rate(apiserver_request_duration_seconds_bucket{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
+      for: 30m
+      labels:
+        service: kube-apiserver
+        severity: warning
+        type: seed
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Kube API server latency for verb {{`{{ $labels.verb }}`}} is high. This could be because the shoot workers and the control plane are in different regions. 99th percentile of request latency is greater than 3 seconds.
+        summary: Kubernetes API server latency is high
+    - alert: KubeApiServerTooManyAuditlogFailures
+      expr: >-
+        sum(rate (apiserver_audit_error_total{plugin!="log",job="kube-apiserver"}[5m])) / sum(rate(apiserver_audit_event_total{job="kube-apiserver"}[5m])) > bool 0.02 == 1
+      for: 15m
+      labels:
+        service: auditlog
+        severity: warning
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'The API servers cumulative failure rate in logging audit events is greater than 2%.'
+        summary: The kubernetes API server has too many failed attempts to log audit events
+    - alert: ApiserverRequestsFailureRate
+      expr: >-
+        max(sum by(instance,resource,verb) (rate(apiserver_request_total{code=~"5.."}[10m])) / sum by(instance,resource,verb) (rate(apiserver_request_total[10m]))) * 100 > 10
+      for: 30m
+      labels:
+        service: kube-apiserver
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'The API Server requests failure rate exceeds 10%.'
+        summary: Kubernetes API server failure rate is high
+  - name: kube-controller-manager.rules
+    rules:
+    - alert: KubeControllerManagerDown
+      expr: >-
+        absent(up{job="kube-controller-manager"} == 1)
+      for: 15m
+      labels:
+        service: kube-controller-manager
+        severity: critical
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Deployments and replication controllers are not making progress.
+        summary: Kube Controller Manager is down.
+  - name: kube-kubelet.rules
+    rules:
+    - alert: KubeKubeletNodeDown
+      expr: >-
+        up{job="kube-kubelet", type="shoot"} == 0
+      for: 1h
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          The kubelet {{`{{ $labels.instance }}`}} has been unavailable/unreachable for more than 1 hour. Workloads on the affected node may not be schedulable.
+        summary: Kubelet unavailable
+    - alert: KubeletTooManyOpenFileDescriptorsShoot
+      expr: >-
+        100 * process_open_fds{job=~"^(?:kube-kubelet)$"} / process_max_fds{job=~"^(?:kube-kubelet)$"} > 50
+      for: 30m
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Shoot-kubelet ({{`{{ $labels.kubernetes_io_hostname }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors. Kubelet could be under heavy load.
+        summary: Shoot-kubelet has too many open file descriptors.
+    - alert: KubeletTooManyOpenFileDescriptorsShoot
+      expr: >-
+        100 * process_open_fds{job="kube-kubelet"} / process_max_fds{job="kube-kubelet"} > 80
+      for: 30m
+      labels:
+        service: kube-kubelet
+        severity: critical
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Shoot-kubelet ({{`{{ $labels.kubernetes_io_hostname }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors. Kubelet could be under heavy load.
+        summary: Shoot-kubelet has too many open file descriptors.
+    - alert: KubeletTooManyOpenFileDescriptorsSeed
+      expr: >-
+        100 * process_open_fds{job="kube-kubelet-seed"} / process_max_fds{job="kube-kubelet-seed"} > 80
+      for: 30m
+      labels:
+        service: kube-kubelet
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Seed-kubelet ({{`{{ $labels.kubernetes_io_hostname }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors. Kubelet could be under heavy load.
+        summary: Seed-kubelet has too many open file descriptors.
+    - alert: KubePersistentVolumeUsageCritical
+      expr: >-
+        100 * kubelet_volume_stats_available_bytes / kubelet_volume_stats_capacity_bytes < 5
+      for: 1h
+      labels:
+        service: kube-kubelet
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          The PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} is only {{`{{ printf "%0.2f" $value }}`}}% free.
+        summary: PersistentVolume almost full.
+    - alert: KubePersistentVolumeFullInFourDays
+      expr: |
+        100 * (
+          kubelet_volume_stats_available_bytes{type="seed", persistentvolumeclaim!~"vali-.*"}
+            /
+          kubelet_volume_stats_capacity_bytes{type="seed", persistentvolumeclaim!~"vali-.*"}
+        ) < 15
+        and
+        predict_linear(kubelet_volume_stats_available_bytes{type="seed", persistentvolumeclaim!~"vali-.*"}[30m], 4 * 24 * 3600) <= 0
+        
+      for: 1h
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Based on recent sampling, the PersistentVolume claimed by {{`{{ $labels.persistentvolumeclaim }}`}} is expected to fill up within four days. Currently {{`{{ printf "%0.2f" $value }}`}}% is available.
+        summary: PersistentVolume will be full in four days.
+  - name: kube-pods.rules
+    rules:
+    - alert: KubePodPendingShoot
+      expr: >-
+        (kube_pod_status_phase{phase="Pending", type="shoot"} == 1 and on(pod) kube_pod_labels{label_origin="gardener"})
+      for: 1h
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'Pod {{`{{ $labels.pod }}`}} is stuck in "Pending" state for more than 1 hour.'
+        summary: 'Shoot pod stuck in "Pending" state'
+    - alert: KubePodPendingControlPlane
+      expr: >-
+        kube_pod_status_phase{phase="Pending", type="seed"} == 1
+      for: 30m
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'Pod {{`{{ $labels.pod }}`}} is stuck in "Pending" state for more than 30 minutes.'
+        summary: 'Control plane pod stuck in "Pending" state'
+    - alert: KubePodNotReadyShoot
+      expr: >-
+        (kube_pod_status_ready{condition="true", type="shoot"} == 0 and on(pod) kube_pod_labels{label_origin="gardener"})
+      for: 1h
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Pod {{`{{ $labels.pod }}`}} is not ready for more than 1 hour.
+        summary: Shoot pod is in a not ready state
+    - alert: KubePodNotReadyControlPlane
+      expr: >-
+        (kube_pod_status_ready{condition="true", type="seed", pod!~"etcd-main-compactor(.+)"} == 0 and on (namespace, pod) kube_pod_status_phase{phase!="Succeeded"} == 1)
+      for: 30m
+      labels:
+        service: kube-kubelet
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Pod {{`{{ $labels.pod }}`}} is not ready for more than 30 minutes.
+        summary: Control plane pod is in a not ready state
+  - name: kube-scheduler.rules
+    rules:
+    - alert: KubeSchedulerDown
+      expr: >-
+        absent(up{job="kube-scheduler"} == 1)
+      for: 15m
+      labels:
+        service: kube-scheduler
+        severity: critical
+        type: seed
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: New pods are not being assigned to nodes.
+        summary: Kube Scheduler is down.
+  - name: kube-state-metrics.rules
+    rules:
+    - alert: KubeStateMetricsSeedDown
+      expr: >-
+        absent(count({exported_job="kube-state-metrics"}))
+      for: 15m
+      labels:
+        service: kube-state-metrics-seed
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Kube-state-metrics is scraped by the cache prometheus and federated by the control plane prometheus. Something is broken in that process.
+        summary: There are no kube-state-metrics metrics for the control plane
+    - alert: KubeStateMetricsShootDown
+      expr: >-
+        absent(up{job="kube-state-metrics", type="shoot"} == 1)
+      for: 15m
+      labels:
+        service: kube-state-metrics-shoot
+        severity: info
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          There are no running kube-state-metric pods for the shoot cluster. No kubernetes resource metrics can be scraped.
+        summary: Kube-state-metrics for shoot cluster metrics is down.
+    - alert: NoWorkerNodes
+      expr: >-
+        sum(kube_node_spec_unschedulable) == count(kube_node_info) or absent(kube_node_info)
+      for: 25m
+      labels:
+        service: nodes
+        severity: blocker
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          There are no worker nodes in the cluster or all of the worker nodes in the cluster are not schedulable.
+        summary: No nodes available. Possibly all workloads down.
+  - name: machine-controller-manager.rules
+    rules:
+    - alert: MachineControllerManagerDown
+      expr: >-
+        absent(up{job="machine-controller-manager"} == 1)
+      for: 15m
+      labels:
+        service: machine-controller-manager
+        severity: critical
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: There are no running machine controller manager instances. No shoot nodes can be created/maintained.
+        summary: Machine controller manager is down.
+  - name: node-exporter.rules
+    rules:
+    - alert: NodeExporterDown
+      expr: >-
+        absent(up{job="node-exporter"} == 1)
+      for: 1h
+      labels:
+        service: node-exporter
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: The NodeExporter has been down or unreachable from Prometheus for more than 1 hour.
+        summary: NodeExporter down or unreachable
+    - alert: K8SNodeOutOfDisk
+      expr: >-
+        kube_node_status_condition{condition="OutOfDisk", status="true"} == 1
+      for: 1h
+      labels:
+        service: node-exporter
+        severity: critical
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Node {{`{{$labels.node}}`}} has run out of disk space.
+        summary: Node ran out of disk space.
+    - alert: K8SNodeMemoryPressure
+      expr: >-
+        kube_node_status_condition{condition="MemoryPressure", status="true"} == 1
+      for: 1h
+      labels:
+        service: node-exporter
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Node {{`{{$labels.node}}`}} is under memory pressure.
+        summary: Node is under memory pressure.
+    - alert: K8SNodeDiskPressure
+      expr: >-
+        kube_node_status_condition{condition="DiskPressure", status="true"} == 1
+      for: 1h
+      labels:
+        service: node-exporter
+        severity: warning
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Node {{`{{$labels.node}}`}} is under disk pressure.
+        summary: Node is under disk pressure.
+    - alert: VMRootfsFull
+      expr: >-
+        node_filesystem_free{mountpoint="/"} < 1024
+      for: 1h
+      labels:
+        service: node-exporter
+        severity: critical
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Root filesystem device on instance {{`{{$labels.instance}}`}} is almost full.
+        summary: 'Node''s root filesystem is almost full'
+    - alert: VMConntrackTableFull
+      expr: >-
+        instance:conntrack_entries_usage:percent > 90
+      for: 1h
+      labels:
+        service: node-exporter
+        severity: critical
+        type: shoot
+        visibility: owner
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'The nf_conntrack table is {{`{{$value}}`}}% full.'
+        summary: Number of tracked connections is near the limit
+  - name: prometheus.rules
+    rules:
+    - alert: PrometheusCantScrape
+      expr: >-
+        scrape_samples_scraped == 0 and on(job) up{job!~".*shoot-etcd-druid"} == 1
+      for: 1h
+      labels:
+        service: prometheus
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          Prometheus failed to scrape metrics. Instance {{`{{ $labels.instance }}`}}, job {{`{{ $labels.job }}`}}.
+        summary: No metrics are scraped from any target.
+    - alert: PrometheusConfigurationFailure
+      expr: >-
+        prometheus_config_last_reload_successful == 0
+      for: 1h
+      labels:
+        service: prometheus
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: Latest Prometheus configuration is broken and Prometheus is using the previous one.
+        summary: Prometheus is misconfigured
+  - name: vpn.rules
+    rules:
+    - alert: VPNShootNoPods
+      expr: >-
+        kube_deployment_status_replicas_available{deployment="vpn-shoot"} == 0
+      for: 30m
+      labels:
+        service: vpn
+        severity: critical
+        type: shoot
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'vpn-shoot deployment in Shoot cluster has 0 available pods. VPN won''t work.'
+        summary: VPN Shoot deployment no pods
+    - alert: VPNHAShootNoPods
+      expr: >-
+        kube_statefulset_status_replicas_ready{statefulset="vpn-shoot"} == 0
+      for: 30m
+      labels:
+        service: vpn
+        severity: critical
+        type: shoot
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: 'vpn-shoot statefulset in HA Shoot cluster has 0 available pods. VPN won''t work.'
+        summary: VPN HA Shoot statefulset no pods
+    - alert: VPNProbeAPIServerProxyFailed
+      expr: >-
+        absent(probe_success{job="tunnel-probe-apiserver-proxy"}) == 1 or probe_success{job="tunnel-probe-apiserver-proxy"} == 0 or probe_http_status_code{job="tunnel-probe-apiserver-proxy"} != 200
+      for: 30m
+      labels:
+        service: vpn-test
+        severity: critical
+        type: shoot
+        visibility: all
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: >-
+          The API Server proxy functionality is not working. Probably the vpn connection from an API Server pod to the vpn-shoot endpoint on the Shoot workers does not work.
+        summary: API Server Proxy not usable
+  - name: vali.rules
+    rules:
+    - alert: ValiDown
+      expr: >-
+        absent(up{job="vali"} == 1)
+      for: 30m
+      labels:
+        service: logging
+        severity: warning
+        type: seed
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: There are no vali pods running. No logs will be collected.
+        summary: Vali is down
+  - name: verticalpodautoscaler.rules
+    rules:
+    - alert: VerticalPodAutoscalerCappedRecommendation
+      expr: |
+          count_over_time(
+            (
+                {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_uncappedtarget_.+"}
+              >
+                {__name__=~"kube_customresource_verticalpodautoscaler_status_recommendation_containerrecommendations_target_.+"}
+            )[5m:]
+          )
+        ==
+          5
+      labels:
+        severity: warning
+        type: shoot
+        visibility: operator
+        {{- with .Values.rules.additionalRuleLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      annotations:
+        description: |-
+          The following VPA from a shoot shows a
+          {{`{{- if eq .Labels.unit "core" }}`}} CPU {{`{{ else if eq .Labels.unit "byte" }}`}} memory {{`{{ end -}}`}}
+          uncapped target recommendation larger than the regular target recommendation:
+          - cluster = {{`{{ $externalLabels.cluster }}`}}
+          - namespace = {{`{{ $labels.namespace }}`}}
+          - vpa = {{`{{ $labels.verticalpodautoscaler }}`}}
+          - container = {{`{{ $labels.container }}`}}
+        summary: A VPA recommendation in a shoot is capped.
+{{- end }}

--- a/gardener-shoot-rules/charts/templates/prometheusrule-shoot.yaml
+++ b/gardener-shoot-rules/charts/templates/prometheusrule-shoot.yaml
@@ -363,7 +363,7 @@ spec:
         summary: The API server has too many open file descriptors
     - alert: KubeApiServerLatency
       expr: >-
-        histogram_quantile(0.99, sum without (instance,resource,subresource) (rate(apiserver_request_duration_seconds_bucket{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|WATCHLIST|WATCH|PROXY proxy"}[5m]))) > 3
+        histogram_quantile(0.99, sum without (instance,resource,subresource) (rate(apiserver_request_duration_seconds_bucket{subresource!~"log|portforward|exec|proxy|attach",verb!~"CONNECT|WATCHLIST|WATCH|PROXY|proxy"}[5m]))) > 3
       for: 30m
       labels:
         service: kube-apiserver

--- a/gardener-shoot-rules/charts/templates/prometheusrule-shoot.yaml
+++ b/gardener-shoot-rules/charts/templates/prometheusrule-shoot.yaml
@@ -345,7 +345,7 @@ spec:
         description: >-
           The API server ({{`{{ $labels.instance }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors.
         summary: The API server has too many open file descriptors
-    - alert: KubeApiServerTooManyOpenFileDescriptors
+    - alert: KubeApiServerTooManyOpenFileDescriptorsCritical
       expr: >-
         100 * process_open_fds{job="kube-apiserver"} / process_max_fds{job="kube-apiserver"} > 80
       for: 30m
@@ -458,7 +458,7 @@ spec:
         description: >-
           Shoot-kubelet ({{`{{ $labels.kubernetes_io_hostname }}`}}) is using {{`{{ $value }}`}}% of the available file/socket descriptors. Kubelet could be under heavy load.
         summary: Shoot-kubelet has too many open file descriptors.
-    - alert: KubeletTooManyOpenFileDescriptorsShoot
+    - alert: KubeletTooManyOpenFileDescriptorsShootCritical
       expr: >-
         100 * process_open_fds{job="kube-kubelet"} / process_max_fds{job="kube-kubelet"} > 80
       for: 30m

--- a/gardener-shoot-rules/charts/values.yaml
+++ b/gardener-shoot-rules/charts/values.yaml
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+global:
+  commonLabels: {}
+
+rules:
+  create: true
+  additionalRuleLabels: {}

--- a/gardener-shoot-rules/plugindefinition.yaml
+++ b/gardener-shoot-rules/plugindefinition.yaml
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: gardener-shoot-rules
+spec:
+  version: 0.1.0
+  displayName: Gardener Shoot Alert Rules
+  description: >
+    PrometheusRules for Gardener shoot control plane monitoring.
+    Packages upstream Gardener shoot alert rules for evaluation by prometheus-metrics-gardener,
+    enabling shoot control plane alerts (KubeEtcdMainDown, KubePodNotReadyControlPlane etc.)
+    to reach the central alertmanager with proper support_group relabeling
+    without requiring alertmanager-seed on managed seeds.
+  helmChart:
+    name: gardener-shoot-rules
+    repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
+    version: 0.1.0
+  options:
+    - name: global.commonLabels
+      description: Labels added to all PrometheusRule resources.
+      required: false
+      type: map
+    - name: rules.create
+      description: Whether to deploy the shoot PrometheusRules.
+      required: false
+      type: bool
+      default: true
+    - name: rules.additionalRuleLabels
+      description: Extra labels added to every alert rule (e.g. thanos-ruler, support_group).
+      required: false
+      type: map

--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -25,4 +25,5 @@ resources:
   - teams2slack/plugindefinition.yaml
   - thanos/plugindefinition.yaml
   - trust-manager/plugindefinition.yaml
+  - gardener-shoot-rules/plugindefinition.yaml
   - netapp-monitoring/plugindefinition.yaml


### PR DESCRIPTION
## Summary

- Adds new `gardener-shoot-rules` PluginDefinition and Helm chart packaging 54 Gardener shoot control plane PrometheusRules
- Rules are deployed **without** the `prometheus: shoot` label so `prometheus-metrics-gardener` evaluates them (bypassing the `ruleSelector: NotIn [shoot]` that suppresses gardenlet-deployed rules)
- Exposes `rules.additionalRuleLabels` option for injecting `thanos-ruler`, `support_group`, and `service` labels per cluster via PluginPreset
- Rules extracted from `gardener/gardener v1.148.3`

## Motivation

Gardenlet deploys PrometheusRules with `prometheus: shoot` in shoot namespaces. The central `prometheus-metrics-gardener` excludes these via `ruleSelector: NotIn [shoot]` to avoid 14× duplicate alerts — but this also silences all shoot control plane alerts (KubeEtcdMainDown, KubeApiserverDown, KubePodNotReadyControlPlane, etc.) on the central alertmanager. This plugin fixes that gap.

## Test plan

- [ ] `helm template . --values charts/ci/test-values.yaml` renders without errors
- [ ] PrometheusRule has no `prometheus: shoot` label
- [ ] All 54 alert rules present across 18 groups
- [ ] `additionalRuleLabels` correctly injected into each rule