### PR TITLE
fix(opensearch): raise OpenSearchIndexSizeTooLarge to 600GB critical

### DIFF
--- a/opensearch/chart/Chart.yaml
+++ b/opensearch/chart/Chart.yaml
@@ -3,7 +3,7 @@
 
 apiVersion: v2
 name: opensearch
-version: 0.2.20
+version: 0.2.21
 description: A Helm chart for the OpenSearch operator and cluster
 type: application
 maintainers:

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -31,16 +31,16 @@ groups:
           description: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
 
       - alert: OpenSearchIndexSizeTooLarge
-        expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"} / (1024^3)) > 200) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"}[15m]) > 1)
+        expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"} / (1024^3)) > 600) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"}[15m]) > 1)
         for: 30m
         labels:
-          severity: warning
+          severity: critical
           component: opensearch
           playbook: {{ .Values.cluster.playbooksUrls.opensearchIndexSizeTooLarge }}
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
           summary: "Index size of {{`{{ $labels.index }}`}} has exceeded the threshold."
-          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 200 GB in size and is still actively receiving data. Please check the rollover status."
+          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 600 GB in size and is still actively receiving data. Please check the rollover status."
 
       - alert: OpenSearchDashboardsUnavailable
         expr: (sum by (deployment) (kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"})) == 0 and (sum by (deployment) (kube_deployment_spec_replicas{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"}) > 0)

--- a/opensearch/chart/alerts/opensearch-cluster.yaml
+++ b/opensearch/chart/alerts/opensearch-cluster.yaml
@@ -31,7 +31,15 @@ groups:
           description: "OpenSearch cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} is in YELLOW status for more than 120 minutes"
 
       - alert: OpenSearchIndexSizeTooLarge
-        expr: (max by (opensearch_org_opensearch_cluster, index) (opensearch_index_store_size_bytes{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"} / (1024^3)) > 600) and on(opensearch_org_opensearch_cluster, index) (rate(opensearch_index_doc_number{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"}[15m]) > 1)
+        expr: |
+          (
+            max by (opensearch_org_opensearch_cluster, index) (
+              opensearch_index_store_size_bytes{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"} / (1024^3)
+            ) > 600
+          )
+          and on(opensearch_org_opensearch_cluster, index) (
+            rate(opensearch_index_doc_number{namespace="{{ .Release.Namespace }}", context="primaries", index=~".ds.*"}[15m]) > 1
+          )
         for: 30m
         labels:
           severity: critical
@@ -40,7 +48,7 @@ groups:
           {{- include "opensearch-alert-labels" . | nindent 10 }}
         annotations:
           summary: "Index size of {{`{{ $labels.index }}`}} has exceeded the threshold."
-          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 600 GB in size and is still actively receiving data. Please check the rollover status."
+          description: "The index {{`{{ $labels.index }}`}} in cluster {{`{{ $labels.opensearch_org_opensearch_cluster }}`}} has exceeded 600 GiB in size and is still actively receiving data. Please check the rollover status."
 
       - alert: OpenSearchDashboardsUnavailable
         expr: (sum by (deployment) (kube_deployment_status_replicas_available{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"})) == 0 and (sum by (deployment) (kube_deployment_spec_replicas{namespace="{{ .Release.Namespace }}", deployment=~"opensearch-.*-dashboards"}) > 0)

--- a/opensearch/plugindefinition.yaml
+++ b/opensearch/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: opensearch
 spec:
-  version: 0.2.20
+  version: 0.2.21
   displayName: OpenSearch
   description: Creates and manages an OpenSearch environment with automated deployment, provisioning, and orchestration of clusters and dashboards using the OpenSearch Operator.
   icon: 'https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/opensearch/logo.png'
   helmChart:
     name: opensearch
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.2.20
+    version: 0.2.21
   options:
     - name: queryExporter.enabled
       description: "Enable the OpenSearch query exporter for custom Prometheus metrics from OpenSearch queries"


### PR DESCRIPTION
## Pull Request Details

Raise `OpenSearchIndexSizeTooLarge` threshold from 200 GB to 600 GB and severity warning to critical. Datastreams roll on `min_primary_shard_size: 40gb`. With 10 primary shards, healthy active indices normally reach ~400 GB primary, so the 200 GB threshold fired on normal operation.
