### PR TITLE
fix(logs): renames fields to be _string

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.54
+version: 0.4.55
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -56,7 +56,7 @@ transform/external-http:
         - set(log.attributes["host_string"], String(log.attributes["host"])) where log.attributes["host"] != nil
         - delete_key(log.attributes, "host") where log.attributes["host"] != nil
         - delete_matching_keys(log.attributes, "^host\\..*")
-        - set(log.attributes["source_ips_string"], String(log.attributes["sourceIPs"])) where log.attributes["sourceIPs"] != nil
+        - set(log.attributes["sourceIPs_string"], String(log.attributes["sourceIPs"])) where log.attributes["sourceIPs"] != nil
         - delete_key(log.attributes, "sourceIPs") where log.attributes["sourceIPs"] != nil
         - delete_matching_keys(log.attributes, "^sourceIPs\\..*")
         - set(log.attributes["event_category_string"], String(log.attributes["event.category"])) where log.attributes["event.category"] != nil

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -33,7 +33,7 @@ transform/external-http:
         - set(log.attributes["forwarded_by"], {{ .Values.openTelemetry.externalCollector.externalHttpConfig.forwardedBy | quote }}) where log.attributes["forwarded_by"] == nil
         - delete_matching_keys(log.attributes, "^\\.*$")
         # Field normalisation: reduce OpenSearch bloat by stringifying complex objects
-        - set(log.attributes["audit_status"], String(log.attributes["status"])) where log.attributes["status"] != nil
+        - set(log.attributes["status_string"], String(log.attributes["status"])) where log.attributes["status"] != nil
         - delete_key(log.attributes, "status") where log.attributes["status"] != nil
         - set(log.attributes["http_string"], String(log.attributes["log"]["http"])) where log.attributes["http_string"] == nil and log.attributes["log"] != nil and IsString(log.attributes["log"]) == false and log.attributes["log"]["http"] != nil
         - delete_key(log.attributes["log"], "http") where log.attributes["log"] != nil and IsString(log.attributes["log"]) == false and log.attributes["log"]["http"] != nil
@@ -53,31 +53,31 @@ transform/external-http:
         - delete_key(log.attributes, "objectRef") where log.attributes["objectRef"] != nil
         - delete_key(log.attributes, "syslog_timestamp") where log.attributes["syslog_timestamp"] != nil and log.time_unix_nano != 0
         # Stringify with delete_matching_keys to remove all nested/flattened subfields
-        - set(log.attributes["audit_host"], String(log.attributes["host"])) where log.attributes["host"] != nil
+        - set(log.attributes["host_string"], String(log.attributes["host"])) where log.attributes["host"] != nil
         - delete_key(log.attributes, "host") where log.attributes["host"] != nil
         - delete_matching_keys(log.attributes, "^host\\..*")
-        - set(log.attributes["audit_source_ips"], String(log.attributes["sourceIPs"])) where log.attributes["sourceIPs"] != nil
+        - set(log.attributes["source_ips_string"], String(log.attributes["sourceIPs"])) where log.attributes["sourceIPs"] != nil
         - delete_key(log.attributes, "sourceIPs") where log.attributes["sourceIPs"] != nil
         - delete_matching_keys(log.attributes, "^sourceIPs\\..*")
-        - set(log.attributes["audit_event_category"], String(log.attributes["event.category"])) where log.attributes["event.category"] != nil
+        - set(log.attributes["event_category_string"], String(log.attributes["event.category"])) where log.attributes["event.category"] != nil
         - delete_key(log.attributes, "event.category") where log.attributes["event.category"] != nil
         - delete_matching_keys(log.attributes, "^event\\..*")
-        - set(log.attributes["audit_process"], String(log.attributes["process"])) where log.attributes["process"] != nil
+        - set(log.attributes["process_string"], String(log.attributes["process"])) where log.attributes["process"] != nil
         - delete_key(log.attributes, "process") where log.attributes["process"] != nil
         - delete_matching_keys(log.attributes, "^process\\..*")
-        - set(log.attributes["audit_prometheus"], String(log.attributes["prometheus"])) where log.attributes["prometheus"] != nil
+        - set(log.attributes["prometheus_string"], String(log.attributes["prometheus"])) where log.attributes["prometheus"] != nil
         - delete_key(log.attributes, "prometheus") where log.attributes["prometheus"] != nil
         - delete_matching_keys(log.attributes, "^prometheus\\..*")
-        - set(log.attributes["audit_args"], String(log.attributes["args"])) where log.attributes["args"] != nil
+        - set(log.attributes["args_string"], String(log.attributes["args"])) where log.attributes["args"] != nil
         - delete_key(log.attributes, "args") where log.attributes["args"] != nil
         - delete_matching_keys(log.attributes, "^args\\..*")
         - set(log.attributes["user_string"], String(log.attributes["user"])) where log.attributes["user"] != nil
         - delete_key(log.attributes, "user") where log.attributes["user"] != nil
         - delete_matching_keys(log.attributes, "^user\\..*")
-        - set(log.attributes["k8s_req_payload"], String(log.attributes["requestObject"])) where log.attributes["requestObject"] != nil
+        - set(log.attributes["request_object_string"], String(log.attributes["requestObject"])) where log.attributes["requestObject"] != nil
         - delete_key(log.attributes, "requestObject") where log.attributes["requestObject"] != nil
         - delete_matching_keys(log.attributes, "^requestObject\\..*")
-        - set(log.attributes["k8s_resp_payload"], String(log.attributes["responseObject"])) where log.attributes["responseObject"] != nil
+        - set(log.attributes["response_object_string"], String(log.attributes["responseObject"])) where log.attributes["responseObject"] != nil
         - delete_key(log.attributes, "responseObject") where log.attributes["responseObject"] != nil
         - delete_matching_keys(log.attributes, "^responseObject\\..*")
         - set(log.attributes["context_string"], String(log.attributes["context"])) where log.attributes["context"] != nil

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -101,6 +101,36 @@ transform/external-http:
         - set(log.attributes["changes_string"], String(log.attributes["changes"])) where log.attributes["changes"] != nil
         - delete_key(log.attributes, "changes") where log.attributes["changes"] != nil
         - delete_matching_keys(log.attributes, "^changes\\..*")
+        - set(log.attributes["summary_fields_string"], String(log.attributes["summary_fields"])) where log.attributes["summary_fields"] != nil
+        - delete_key(log.attributes, "summary_fields") where log.attributes["summary_fields"] != nil
+        - delete_matching_keys(log.attributes, "^summary_fields\\..*")
+        - set(log.attributes["git_string"], String(log.attributes["git"])) where log.attributes["git"] != nil
+        - delete_key(log.attributes, "git") where log.attributes["git"] != nil
+        - delete_matching_keys(log.attributes, "^git\\..*")
+        - set(log.attributes["annotations_string"], String(log.attributes["annotations"])) where log.attributes["annotations"] != nil
+        - delete_key(log.attributes, "annotations") where log.attributes["annotations"] != nil
+        - delete_matching_keys(log.attributes, "^annotations\\..*")
+        - set(log.attributes["details_string"], String(log.attributes["Details"])) where log.attributes["Details"] != nil
+        - delete_key(log.attributes, "Details") where log.attributes["Details"] != nil
+        - delete_matching_keys(log.attributes, "^Details\\..*")
+        - set(log.attributes["event_data_string"], String(log.attributes["event_data"])) where log.attributes["event_data"] != nil
+        - delete_key(log.attributes, "event_data") where log.attributes["event_data"] != nil
+        - delete_matching_keys(log.attributes, "^event_data\\..*")
+        - set(log.attributes["output_fields_string"], String(log.attributes["output_fields"])) where log.attributes["output_fields"] != nil
+        - delete_key(log.attributes, "output_fields") where log.attributes["output_fields"] != nil
+        - delete_matching_keys(log.attributes, "^output_fields\\..*")
+        - set(log.attributes["auth_string"], String(log.attributes["auth"])) where log.attributes["auth"] != nil
+        - delete_key(log.attributes, "auth") where log.attributes["auth"] != nil
+        - delete_matching_keys(log.attributes, "^auth\\..*")
+        - set(log.attributes["response_status_string"], String(log.attributes["responseStatus"])) where log.attributes["responseStatus"] != nil
+        - delete_key(log.attributes, "responseStatus") where log.attributes["responseStatus"] != nil
+        - delete_matching_keys(log.attributes, "^responseStatus\\..*")
+        - set(log.attributes["initiator_string"], String(log.attributes["initiator"])) where log.attributes["initiator"] != nil
+        - delete_key(log.attributes, "initiator") where log.attributes["initiator"] != nil
+        - delete_matching_keys(log.attributes, "^initiator\\..*")
+        - set(log.attributes["target_string"], String(log.attributes["target"])) where log.attributes["target"] != nil
+        - delete_key(log.attributes, "target") where log.attributes["target"] != nil
+        - delete_matching_keys(log.attributes, "^target\\..*")
 {{- end }}
 
 {{/* HTTP path Kafka exporter (its own topic, separate from syslog audit). */}}

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.54
+  version: 0.15.55
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.54
+    version: 0.4.55
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
- Added 10 new triplets ( set  +  delete_key  +  delete_matching_keys ) for:  summary_fields ,  git ,  annotations , Details ,  event_data ,  output_fields ,  auth ,  responseStatus ,  initiator ,  target .
- All now follow  {original}_string  pattern.

---------

Signed-off-by: Simon Olander <simon.olander@sap.com>