### PR TITLE
fix(logs): adds transform/truncate_message processor to log-collector

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -164,7 +164,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.ingesterCollector.image.repository | string | `""` | Image repository override; falls back to openTelemetry.collectorImage.repository. |
 | openTelemetry.ingesterCollector.image.tag | string | `""` | Image tag override; falls back to openTelemetry.collectorImage.tag. |
 | openTelemetry.ingesterCollector.prometheus.podMonitor.enabled | bool | `true` | Render a PodMonitor per enabled ingest collector. |
-| openTelemetry.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
+| openTelemetry.ingesterCollector.replicas | int | `3` | Replica count per ingest collector Deployment. |
 | openTelemetry.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
 | openTelemetry.kafka | object | See values.yaml | Kafka exporter configuration shared by all collectors |
 | openTelemetry.kafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
@@ -193,6 +193,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.logsCollector.kafkaStorageTopic | string | `""` | Kafka topic name for storage logs — swift, ceph (e.g., "logs-storage") |
 | openTelemetry.logsCollector.kafkaTopic | string | `""` | Kafka topic name for general logs (e.g., "logs") |
 | openTelemetry.logsCollector.kvmConfig | object | `{"enabled":false}` | Activates the configuration for KVM logs (requires logsCollector to be enabled). |
+| openTelemetry.logsCollector.maxMessageLength | int | `32000` | Max characters for the log body in the truncate_message processor. Keep below the Lucene 32766-byte term limit so OpenSearch never permanently rejects a document. |
 | openTelemetry.logsCollector.openstackConfig | object | `{"enabled":false}` | Activates the configuration for OpenStack logs (requires logsCollector to be enabled). |
 | openTelemetry.metricsCollector | object | `{"affinity":{},"enabled":false}` | Activates the standard configuration for metrics. |
 | openTelemetry.metricsCollector.affinity | object | `{}` | Pod affinity rules for the metrics collector CR |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.57
+version: 0.4.58
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -94,6 +94,14 @@ spec:
             statements:
               - set(log.attributes["log_message"], log.attributes["log"]) where log.attributes["log"] != nil
               - delete_key(log.attributes, "log") where log.attributes["log"] != nil
+      transform/truncate_message:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - "truncate_all(log.attributes, 32000)"
+              - "truncate_all(resource.attributes, 32000)"
+              - 'set(log.body, Substring(log.body, 0, {{ .Values.openTelemetry.logsCollector.maxMessageLength | int64 }})) where log.body != nil and Len(log.body) > {{ .Values.openTelemetry.logsCollector.maxMessageLength | int64 }}'
       attributes/cluster:
         actions:
           - action: insert
@@ -427,7 +435,7 @@ spec:
       pipelines:
         logs/route_default:
           receivers: [routing]
-          processors: [transform/fix_log_attribute, batch]
+          processors: [transform/fix_log_attribute, transform/truncate_message, batch]
 {{- if .Values.openTelemetry.kafka.enabled }}
           exporters: [kafka]
 {{- else }}
@@ -443,7 +451,7 @@ spec:
 {{- end }}
         logs/route_cronus:
           receivers: [routing]
-          processors: [transform/fix_log_attribute, batch]
+          processors: [transform/fix_log_attribute, transform/truncate_message, batch]
 {{- if .Values.openTelemetry.kafka.enabled }}
           exporters: [kafka]
 {{- else }}
@@ -477,7 +485,7 @@ spec:
 {{- if or .Values.openTelemetry.logsCollector.openstackConfig.enabled (and .Values.openTelemetry.logsCollector.cephConfig.enabled .Values.openTelemetry.logsCollector.containerdConfig.enabled) }}
         logs/route_storage:
           receivers: [routing]
-          processors: [transform/fix_log_attribute, batch]
+          processors: [transform/fix_log_attribute, transform/truncate_message, batch]
 {{- if .Values.openTelemetry.kafka.enabled }}
           exporters: [kafka/storage]
 {{- else }}

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -167,6 +167,9 @@ openTelemetry:
     kafkaTopic: ""
     # -- Kafka topic name for storage logs — swift, ceph (e.g., "logs-storage")
     kafkaStorageTopic: ""
+    # -- Max characters for the log body in the truncate_message processor. Keep below the
+    # Lucene 32766-byte term limit so OpenSearch never permanently rejects a document.
+    maxMessageLength: 32000
     # -- Activates the journald receiver (requires logsCollector to be enabled).
     journaldConfig:
       enabled: true
@@ -301,7 +304,7 @@ openTelemetry:
     # -- Pod affinity rules for the ingester collector CRs
     affinity: {}
     # -- Replica count per ingest collector Deployment.
-    replicas: 1
+    replicas: 3
     image:
       # -- Image repository override; falls back to openTelemetry.collectorImage.repository.
       repository: ""

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -85,7 +85,7 @@ spec:
       name: openTelemetry.ingesterCollector.enabled
       required: false
       type: bool
-    - default: 1
+    - default: 3
       description: Replica count per ingest collector Deployment
       name: openTelemetry.ingesterCollector.replicas
       required: false

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.57
+  version: 0.15.58
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.57
+    version: 0.4.58
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
## Pull Request Details

The external-collector already applies transform/truncate_message on its
path; this change closes the gap for the DaemonSet path by wiring the
same processor into all three routing pipelines (route_default,
route_cronus, route_storage) immediately before the batch processor.

Changes:
- Add transform/truncate_message processor definition to logs-collector.yaml
- Wire transform/truncate_message into logs/route_default, logs/route_cronus,
  and logs/route_storage before the batch processor
- increase replicas of ingester to 3
- Add logsCollector.maxMessageLength: 32000 to values.yaml
- Bump chart version 0.4.57 -> 0.4.58
- Bump plugindefinition 0.15.57 -> 0.15.58