### PR TITLE
fix(audit-logs): adds transform/truncate_message processor to audit-logs-collector

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -82,7 +82,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.ingesterCollector.image.repository | string | `""` | Image repository override; falls back to auditLogs.collectorImage.repository. |
 | auditLogs.ingesterCollector.image.tag | string | `""` | Image tag override; falls back to auditLogs.collectorImage.tag. |
 | auditLogs.ingesterCollector.prometheus.podMonitor.enabled | bool | `true` | Render a PodMonitor per enabled ingest collector. |
-| auditLogs.ingesterCollector.replicas | int | `1` | Replica count per ingest collector Deployment. |
+| auditLogs.ingesterCollector.replicas | int | `3` | Replica count per ingest collector Deployment. |
 | auditLogs.ingesterCollector.resources | object | `{}` | Pod resources per ingest collector Deployment. |
 | auditLogs.logsCollector.auditd.enabled | bool | `true` | Activates the ingestion of auditd logs. |
 | auditLogs.logsCollector.auditd.initImage | object | `{"repository":"alpine","tag":"latest"}` | Init container image used to stop the host auditd service. |
@@ -102,6 +102,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.logsCollector.kafka.tls.insecure_skip_verify | bool | `false` | Skip server certificate verification. Leave false for production. |
 | auditLogs.logsCollector.kafka.topic | string | `""` | Kafka topic name for audit logs |
 | auditLogs.logsCollector.kubeApiAudit.enabled | bool | `false` | Activates export for kube-apiserver audit logs |
+| auditLogs.logsCollector.maxMessageLength | int | `32000` | Max characters for the log body in the truncate_message processor. Keep below the Lucene 32766-byte term limit so OpenSearch never permanently rejects a document. |
 | auditLogs.nodeSelector | object | `{}` |  |
 | auditLogs.openSearchLogs.endpoint | string | `nil` | Endpoint URL for OpenSearch |
 | auditLogs.openSearchLogs.failover_password_a | string | `nil` | Password for OpenSearch endpoint |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.15
+version: 0.2.16
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -178,6 +178,14 @@ spec:
             statements:
             - set(attributes["log_message"], attributes["log"]) where IsString(attributes["log"])
             - delete_key(attributes, "log") where IsString(attributes["log"]) 
+      transform/truncate_message:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - "truncate_all(log.attributes, 32000)"
+              - "truncate_all(resource.attributes, 32000)"
+              - 'set(log.body, Substring(log.body, 0, {{ .Values.auditLogs.logsCollector.maxMessageLength | int64 }})) where log.body != nil and Len(log.body) > {{ .Values.auditLogs.logsCollector.maxMessageLength | int64 }}'
 
 {{- if .Values.auditLogs.elastic.enabled }}
     {{- include "es.labels" . | nindent 6 -}}
@@ -661,7 +669,7 @@ spec:
       pipelines:
         logs/default:
           receivers: [routing]
-          processors: [transform/fix_log_attribute, batch]
+          processors: [transform/fix_log_attribute, transform/truncate_message, batch]
 {{- if .Values.auditLogs.logsCollector.kafka.enabled }}
           exporters: [kafka]
 {{- else }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -86,6 +86,9 @@ auditLogs:
         enabled: false
         # -- Skip server certificate verification. Leave false for production.
         insecure_skip_verify: false
+    # -- Max characters for the log body in the truncate_message processor. Keep below the
+    # Lucene 32766-byte term limit so OpenSearch never permanently rejects a document.
+    maxMessageLength: 32000
   openSearchLogs:
     # -- Endpoint URL for OpenSearch
     endpoint:
@@ -119,7 +122,7 @@ auditLogs:
     # -- Enable the ingest collectors block.
     enabled: false
     # -- Replica count per ingest collector Deployment.
-    replicas: 1
+    replicas: 3
     image:
       # -- Image repository override; falls back to auditLogs.collectorImage.repository.
       repository: ""

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -152,7 +152,7 @@ spec:
           required: false
           type: bool
         - name: auditLogs.ingesterCollector.replicas
-          default: 1
+          default: 3
           description: Replica count per ingest collector Deployment
           required: false
           type: int

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.15
+    version: 0.2.16
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.15
+        version: 0.2.16
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION

## Pull Request Details

The external-collector already applies transform/truncate_message on its
path; this change closes the gap for the DaemonSet path by wiring the
same processor into the audit-logs-collector.

Changes:

Changes:
- Add transform/truncate_message processor definition to audit-logs-collector.yaml
- Wire transform/truncate_message into logs/route_default before the batch processor
- increase replicas of ingester to 3
- Add logsCollector.maxMessageLength: 32000 to values.yaml
- Bump chart version 0.2.15 -> 0.2.16
- Bump plugindefinition 0.2.15 -> 0.2.16