### PR TITLE
fix syslog hostname handling for double header relay logs

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.58
+version: 0.4.59
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -230,8 +230,8 @@ transform/syslog_hostname_parsing:
     - context: log
       statements:
         # handle double header / relay host name
-        - 'set(log.attributes["sap.cc.relay.host.name"], log.attributes["sap_cc_relay_host_name"]) where log.attributes["sap_cc_relay_host_name"] != nil'
-        - 'delete_key(log.attributes, "sap_cc_relay_host_name") where log.attributes["sap_cc_relay_host_name"] != nil'
+        - 'set(log.attributes["syslog.host.name"], log.attributes["syslog_host_name"]) where log.attributes["syslog_host_name"] != nil'
+        - 'delete_key(log.attributes, "syslog_host_name") where log.attributes["syslog_host_name"] != nil'
         # Extract ESXi node name pattern: node### or nodeswift## followed by more hostname chars
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["hostname"], "(?P<node_nodename>node(\\d{3}|swift\\d{2})[a-zA-Z0-9.-]+)"), "upsert") where log.attributes["hostname"] != nil'
         # Fallback: try net.peer.name if hostname attribute is not set (common for RFC3164)

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -229,6 +229,9 @@ transform/syslog_hostname_parsing:
   log_statements:
     - context: log
       statements:
+        # handle double header / relay host name
+        - 'set(log.attributes["sap.cc.relay.host.name"], log.attributes["sap_cc_relay_host_name"]) where log.attributes["sap_cc_relay_host_name"] != nil'
+        - 'delete_key(log.attributes, "sap_cc_relay_host_name") where log.attributes["sap_cc_relay_host_name"] != nil'
         # Extract ESXi node name pattern: node### or nodeswift## followed by more hostname chars
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["hostname"], "(?P<node_nodename>node(\\d{3}|swift\\d{2})[a-zA-Z0-9.-]+)"), "upsert") where log.attributes["hostname"] != nil'
         # Fallback: try net.peer.name if hostname attribute is not set (common for RFC3164)

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -18,17 +18,68 @@ tcp_log/syslog:
     routes:
     - expr: 'attributes.syslogmsg != nil'
       output: syslog_deframe_promote
-    default: syslog_format_router
+    default: syslog_double_header_detect
   - type: move
     id: syslog_deframe_promote
     from: attributes.syslogmsg
     to: body
     on_error: send_quiet
+    output: syslog_double_header_detect
+
+  # ---------------------------------------------------------------------------
+  # Double-header deframing.
+  # Some relays prepend their OWN syslog header without removing the device's:
+  #   "<PRI>TS RELAY-HOST <PRI>TS DEVICE-HOST ... : message"
+  #   e.g. "<123>Sep 04 2026 10:07:34 neo-... <14>Sep  4 10:10:08 derotnp00112: ..."
+  # The if-guard requires a SECOND "<PRI>" followed by a real syslog timestamp
+  # (ISO 8601, RFC5424 version digit, or a month name), so stray "<n>" tokens in
+  # message payloads are NOT mistaken for a header. Single-header logs skip this
+  # entirely and reach syslog_format_router with body unchanged.
+  # On match: capture the OUTER (relay) hostname, promote the INNER (device)
+  # header to body for normal parsing (inner PRI/severity/facility win).
+  # ---------------------------------------------------------------------------
+  - type: regex_parser
+    id: syslog_double_header_detect
+    parse_from: body
+    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
+    regex: '^(?P<relay_priority><\d+>)(?P<relay_header>[^<]*?)\s+(?P<inner><\d+>.*)$'
+    on_error: send_quiet
+    output: syslog_double_header_check
+  - type: router
+    id: syslog_double_header_check
+    routes:
+    - expr: 'attributes.inner != nil and attributes.inner matches "^<\\d+>"'
+      output: syslog_double_header_capture_relay_host
+    default: syslog_format_router
+  - type: regex_parser
+    id: syslog_double_header_capture_relay_host
+    parse_from: attributes.relay_header
+    regex: '(?P<sap_cc_relay_host_name>\S+)\s*$'
+    on_error: send_quiet
+    output: syslog_double_header_promote_inner
+  - type: move
+    id: syslog_double_header_promote_inner
+    from: attributes.inner
+    to: body
+    on_error: send_quiet
+    output: syslog_double_header_cleanup_priority
+  - type: remove
+    id: syslog_double_header_cleanup_priority
+    field: attributes.relay_priority
+    on_error: send_quiet
+    output: syslog_double_header_cleanup_header
+  - type: remove
+    id: syslog_double_header_cleanup_header
+    field: attributes.relay_header
+    on_error: send_quiet
     output: syslog_format_router
+
   # Routes incoming syslog messages based on their header format:
   #   RFC 5424:              "<priority>VERSION timestamp ..." e.g. "<134>1 2026-07-10T09:32:35..."
   #   Cisco IOS:             "<priority>SEQ: HOSTNAME: Mmm dd HH:MM:SS[.ms]: %FACILITY-SEV-MNEMONIC: msg"
   #                          e.g. "<190>137967: eu-de-1-vp101a: Aug  3 13:03:58.869: %SYS-6-..."
+  #   Cisco NX-OS (year):    "<priority>HOSTNAME: YYYY Mmm _D HH:MM:SS[.ms] [TZ]: %FAC-SEV-MNEMONIC: msg"
+  #                          e.g. "<190>sw-idc-vxo-wdf4-735: 2026 Sep  4 11:55:21.803 met: %LLDP-6-..."
   #   RFC 3164 (1-digit day):"<priority>Mmm  D HH:MM:SS ..." zero-padded ("Aug 06") OR space-padded ("Aug  6"),
   #                          days 1-9 only (Fortinet / Cisco ACI). e.g. "<44>Aug 05 13:04:13 eu-de-1-fw401a CEF:0|..."
   #   RFC 3164 (2-digit day):"<priority>Mmm DD HH:MM:SS ..." days 10-31, handled by built-in parser.
@@ -43,6 +94,9 @@ tcp_log/syslog:
       output: syslog_5424_parser
     - expr: 'body matches "^<\\d+>\\d+: \\S+: (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
       output: syslog_cisco_parser
+    # Cisco NX-OS with leading year, no sequence number.
+    - expr: 'body matches "^<\\d+>\\S+: \\d{4} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
+      output: syslog_nxos_year_parser
     # Non-standard single-digit days: zero-padded ("Aug 06") OR space-padded ("Aug  6"),
     # days 1-9 only. Routed to the regex parser because the built-in RFC3164 parser
     # mishandles these Fortinet/Cisco-ACI style messages (e.g. CEF payloads),
@@ -93,6 +147,32 @@ tcp_log/syslog:
     id: syslog_3164_padded_cleanup
     field: attributes.timestamp
     output: add_format_rfc3164_padded
+
+  # Cisco NX-OS with leading year and optional timezone.
+  # Format: <pri>HOSTNAME: YYYY Mmm _D HH:MM:SS[.ms] [TZ]: %...: message
+  # The timezone (MET/met/UTC/...) is captured but dropped (Go's reference layout
+  # can't reliably parse arbitrary abbreviations); time is treated as UTC.
+  # NOTE: MET is UTC+1 - if TZ accuracy matters, this needs a mapping step.
+  - type: regex_parser
+    id: syslog_nxos_year_parser
+    regex: '^<(?P<priority>\d+)>(?P<hostname>\S+): (?P<timestamp>\d{4}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)(?:\s+\S+)?: (?P<message>.*)'
+    on_error: send_quiet
+    timestamp:
+      parse_from: attributes.timestamp
+      layout: '2006 Jan _2 15:04:05.999999999'
+      layout_type: gotime
+      location: UTC
+    output: syslog_nxos_year_cleanup_guard
+  - type: router
+    id: syslog_nxos_year_cleanup_guard
+    routes:
+    - expr: 'attributes.timestamp != nil'
+      output: syslog_nxos_year_cleanup
+    default: add_format_nxos_year_failed
+  - type: remove
+    id: syslog_nxos_year_cleanup
+    field: attributes.timestamp
+    output: add_format_nxos_year
 
   - type: regex_parser
     id: syslog_iso_parser
@@ -155,6 +235,16 @@ tcp_log/syslog:
     value: rfc3164_padded_failed
     output: add_log_type
   - type: add
+    id: add_format_nxos_year
+    field: attributes.syslog.format
+    value: cisco_nxos_year
+    output: add_log_type
+  - type: add
+    id: add_format_nxos_year_failed
+    field: attributes.syslog.format
+    value: cisco_nxos_year_failed
+    output: add_log_type
+  - type: add
     id: add_format_iso
     field: attributes.syslog.format
     value: rfc3164_iso8601
@@ -189,6 +279,43 @@ udp_log/syslog:
   add_attributes: true
   async: {}
   operators:
+  # Double-header deframing (UDP). See tcp_log/syslog for full explanation.
+  - type: regex_parser
+    id: syslog_udp_double_header_detect
+    parse_from: body
+    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
+    regex: '^(?P<relay_priority><\d+>)(?P<relay_header>[^<]*?)\s+(?P<inner><\d+>.*)$'
+    on_error: send_quiet
+    output: syslog_udp_double_header_check
+  - type: router
+    id: syslog_udp_double_header_check
+    routes:
+    - expr: 'attributes.inner != nil and attributes.inner matches "^<\\d+>"'
+      output: syslog_udp_double_header_capture_relay_host
+    default: syslog_udp_format_router
+  - type: regex_parser
+    id: syslog_udp_double_header_capture_relay_host
+    parse_from: attributes.relay_header
+    regex: '(?P<sap_cc_relay_host_name>\S+)\s*$'
+    on_error: send_quiet
+    output: syslog_udp_double_header_promote_inner
+  - type: move
+    id: syslog_udp_double_header_promote_inner
+    from: attributes.inner
+    to: body
+    on_error: send_quiet
+    output: syslog_udp_double_header_cleanup_priority
+  - type: remove
+    id: syslog_udp_double_header_cleanup_priority
+    field: attributes.relay_priority
+    on_error: send_quiet
+    output: syslog_udp_double_header_cleanup_header
+  - type: remove
+    id: syslog_udp_double_header_cleanup_header
+    field: attributes.relay_header
+    on_error: send_quiet
+    output: syslog_udp_format_router
+
   # Same routing logic as tcp_log/syslog. See comments above for format details.
   - type: router
     id: syslog_udp_format_router
@@ -197,6 +324,8 @@ udp_log/syslog:
       output: syslog_udp_5424_parser
     - expr: 'body matches "^<\\d+>\\d+: \\S+: (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
       output: syslog_udp_cisco_parser
+    - expr: 'body matches "^<\\d+>\\S+: \\d{4} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
+      output: syslog_udp_nxos_year_parser
     - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]| [1-9]) "'
       output: syslog_udp_3164_padded_parser
     - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
@@ -235,6 +364,28 @@ udp_log/syslog:
     id: syslog_udp_3164_padded_cleanup
     field: attributes.timestamp
     output: add_udp_format_rfc3164_padded
+
+  # Cisco NX-OS with leading year (UDP).
+  - type: regex_parser
+    id: syslog_udp_nxos_year_parser
+    regex: '^<(?P<priority>\d+)>(?P<hostname>\S+): (?P<timestamp>\d{4}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)(?:\s+\S+)?: (?P<message>.*)'
+    on_error: send_quiet
+    timestamp:
+      parse_from: attributes.timestamp
+      layout: '2006 Jan _2 15:04:05.999999999'
+      layout_type: gotime
+      location: UTC
+    output: syslog_udp_nxos_year_cleanup_guard
+  - type: router
+    id: syslog_udp_nxos_year_cleanup_guard
+    routes:
+    - expr: 'attributes.timestamp != nil'
+      output: syslog_udp_nxos_year_cleanup
+    default: add_udp_format_nxos_year_failed
+  - type: remove
+    id: syslog_udp_nxos_year_cleanup
+    field: attributes.timestamp
+    output: add_udp_format_nxos_year
 
   - type: regex_parser
     id: syslog_udp_iso_parser
@@ -297,6 +448,16 @@ udp_log/syslog:
     value: rfc3164_padded_failed
     output: add_udp_log_type
   - type: add
+    id: add_udp_format_nxos_year
+    field: attributes.syslog.format
+    value: cisco_nxos_year
+    output: add_udp_log_type
+  - type: add
+    id: add_udp_format_nxos_year_failed
+    field: attributes.syslog.format
+    value: cisco_nxos_year_failed
+    output: add_udp_log_type
+  - type: add
     id: add_udp_format_iso
     field: attributes.syslog.format
     value: rfc3164_iso8601
@@ -349,7 +510,45 @@ tcp_log/syslog_tls:
     from: attributes.syslogmsg
     to: body
     on_error: send_quiet
+    output: syslog_tls_double_header_detect
+
+  # Double-header deframing (TLS). See tcp_log/syslog for full explanation.
+  - type: regex_parser
+    id: syslog_tls_double_header_detect
+    parse_from: body
+    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
+    regex: '^(?P<relay_priority><\d+>)(?P<relay_header>[^<]*?)\s+(?P<inner><\d+>.*)$'
+    on_error: send_quiet
+    output: syslog_tls_double_header_check
+  - type: router
+    id: syslog_tls_double_header_check
+    routes:
+    - expr: 'attributes.inner != nil and attributes.inner matches "^<\\d+>"'
+      output: syslog_tls_double_header_capture_relay_host
+    default: syslog_tls_format_router
+  - type: regex_parser
+    id: syslog_tls_double_header_capture_relay_host
+    parse_from: attributes.relay_header
+    regex: '(?P<sap_cc_relay_host_name>\S+)\s*$'
+    on_error: send_quiet
+    output: syslog_tls_double_header_promote_inner
+  - type: move
+    id: syslog_tls_double_header_promote_inner
+    from: attributes.inner
+    to: body
+    on_error: send_quiet
+    output: syslog_tls_double_header_cleanup_priority
+  - type: remove
+    id: syslog_tls_double_header_cleanup_priority
+    field: attributes.relay_priority
+    on_error: send_quiet
+    output: syslog_tls_double_header_cleanup_header
+  - type: remove
+    id: syslog_tls_double_header_cleanup_header
+    field: attributes.relay_header
+    on_error: send_quiet
     output: syslog_tls_format_router
+
   # Same routing logic as tcp_log/syslog. See comments above for format details.
   - type: router
     id: syslog_tls_format_router
@@ -358,6 +557,8 @@ tcp_log/syslog_tls:
       output: syslog_tls_5424_parser
     - expr: 'body matches "^<\\d+>\\d+: \\S+: (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
       output: syslog_tls_cisco_parser
+    - expr: 'body matches "^<\\d+>\\S+: \\d{4} (Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
+      output: syslog_tls_nxos_year_parser
     - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) (0[1-9]| [1-9]) "'
       output: syslog_tls_3164_padded_parser
     - expr: 'body matches "^<\\d+>(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)"'
@@ -397,6 +598,28 @@ tcp_log/syslog_tls:
     id: syslog_tls_3164_padded_cleanup
     field: attributes.timestamp
     output: add_tls_format_rfc3164_padded
+
+  # Cisco NX-OS with leading year (TLS).
+  - type: regex_parser
+    id: syslog_tls_nxos_year_parser
+    regex: '^<(?P<priority>\d+)>(?P<hostname>\S+): (?P<timestamp>\d{4}\s+(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec)\s+\d{1,2}\s+\d{2}:\d{2}:\d{2}(?:\.\d+)?)(?:\s+\S+)?: (?P<message>.*)'
+    on_error: send_quiet
+    timestamp:
+      parse_from: attributes.timestamp
+      layout: '2006 Jan _2 15:04:05.999999999'
+      layout_type: gotime
+      location: UTC
+    output: syslog_tls_nxos_year_cleanup_guard
+  - type: router
+    id: syslog_tls_nxos_year_cleanup_guard
+    routes:
+    - expr: 'attributes.timestamp != nil'
+      output: syslog_tls_nxos_year_cleanup
+    default: add_tls_format_nxos_year_failed
+  - type: remove
+    id: syslog_tls_nxos_year_cleanup
+    field: attributes.timestamp
+    output: add_tls_format_nxos_year
 
   - type: regex_parser
     id: syslog_tls_iso_parser
@@ -457,6 +680,16 @@ tcp_log/syslog_tls:
     id: add_tls_format_rfc3164_padded_failed
     field: attributes.syslog.format
     value: rfc3164_padded_failed
+    output: add_tls_log_type
+  - type: add
+    id: add_tls_format_nxos_year
+    field: attributes.syslog.format
+    value: cisco_nxos_year
+    output: add_tls_log_type
+  - type: add
+    id: add_tls_format_nxos_year_failed
+    field: attributes.syslog.format
+    value: cisco_nxos_year_failed
     output: add_tls_log_type
   - type: add
     id: add_tls_format_iso

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -54,7 +54,7 @@ tcp_log/syslog:
   - type: regex_parser
     id: syslog_double_header_capture_relay_host
     parse_from: attributes.relay_header
-    regex: '(?P<sap_cc_relay_host_name>\S+)\s*$'
+    regex: '(?P< syslog_host_name>\S+)\s*$'
     on_error: send_quiet
     output: syslog_double_header_promote_inner
   - type: move
@@ -296,7 +296,7 @@ udp_log/syslog:
   - type: regex_parser
     id: syslog_udp_double_header_capture_relay_host
     parse_from: attributes.relay_header
-    regex: '(?P<sap_cc_relay_host_name>\S+)\s*$'
+    regex: '(?P< syslog_host_name>\S+)\s*$'
     on_error: send_quiet
     output: syslog_udp_double_header_promote_inner
   - type: move
@@ -529,7 +529,7 @@ tcp_log/syslog_tls:
   - type: regex_parser
     id: syslog_tls_double_header_capture_relay_host
     parse_from: attributes.relay_header
-    regex: '(?P<sap_cc_relay_host_name>\S+)\s*$'
+    regex: '(?P< syslog_host_name>\S+)\s*$'
     on_error: send_quiet
     output: syslog_tls_double_header_promote_inner
   - type: move

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -41,7 +41,7 @@ tcp_log/syslog:
   - type: regex_parser
     id: syslog_double_header_detect
     parse_from: body
-    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
+    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |\\d+: |\\S+: \\d{4} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
     regex: '^(?P<relay_priority><\d+>)(?P<relay_header>[^<]*?)\s+(?P<inner><\d+>.*)$'
     on_error: send_quiet
     output: syslog_double_header_check
@@ -283,7 +283,7 @@ udp_log/syslog:
   - type: regex_parser
     id: syslog_udp_double_header_detect
     parse_from: body
-    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
+    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |\\d+: |\\S+: \\d{4} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
     regex: '^(?P<relay_priority><\d+>)(?P<relay_header>[^<]*?)\s+(?P<inner><\d+>.*)$'
     on_error: send_quiet
     output: syslog_udp_double_header_check
@@ -516,7 +516,7 @@ tcp_log/syslog_tls:
   - type: regex_parser
     id: syslog_tls_double_header_detect
     parse_from: body
-    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
+    if: 'body matches "^<\\d+>[^<]*<\\d+>(?:\\d{4}-\\d{2}-\\d{2}T|\\d+ |\\d+: |\\S+: \\d{4} (?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) |(?:Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) )"'
     regex: '^(?P<relay_priority><\d+>)(?P<relay_header>[^<]*?)\s+(?P<inner><\d+>.*)$'
     on_error: send_quiet
     output: syslog_tls_double_header_check

--- a/logs/charts/templates/_syslog-config.tpl
+++ b/logs/charts/templates/_syslog-config.tpl
@@ -54,7 +54,7 @@ tcp_log/syslog:
   - type: regex_parser
     id: syslog_double_header_capture_relay_host
     parse_from: attributes.relay_header
-    regex: '(?P< syslog_host_name>\S+)\s*$'
+    regex: '(?P<syslog_host_name>\S+)\s*$'
     on_error: send_quiet
     output: syslog_double_header_promote_inner
   - type: move
@@ -296,7 +296,7 @@ udp_log/syslog:
   - type: regex_parser
     id: syslog_udp_double_header_capture_relay_host
     parse_from: attributes.relay_header
-    regex: '(?P< syslog_host_name>\S+)\s*$'
+    regex: '(?P<syslog_host_name>\S+)\s*$'
     on_error: send_quiet
     output: syslog_udp_double_header_promote_inner
   - type: move
@@ -529,7 +529,7 @@ tcp_log/syslog_tls:
   - type: regex_parser
     id: syslog_tls_double_header_capture_relay_host
     parse_from: attributes.relay_header
-    regex: '(?P< syslog_host_name>\S+)\s*$'
+    regex: '(?P<syslog_host_name>\S+)\s*$'
     on_error: send_quiet
     output: syslog_tls_double_header_promote_inner
   - type: move

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.58
+  version: 0.15.59
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.58
+    version: 0.4.59
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
# Pull Request

## Pull Request Details

Fixes syslog hostname handling for double-header relay logs.

## Breaking Changes

For double-header logs, the relay hostname is now stored in attributes.syslog.host.name instead of resource.host.name. resource.host.name now correctly reflects the originating device.

## Issues Fixed

Relays prepend their own header, causing resource.host.name to reflect the relay instead of the device. Added double-header deframing (capture relay host, promote inner device header) and a Cisco NX-OS year-format parser. Applied to TCP, UDP, and TLS receivers.