### PR TITLE
feat(gpu-operator): adds nvidia gpu operator plugin

### DIFF
--- a/kustomization.yaml
+++ b/kustomization.yaml
@@ -26,3 +26,4 @@ resources:
   - thanos/plugindefinition.yaml
   - trust-manager/plugindefinition.yaml
   - netapp-monitoring/plugindefinition.yaml
+  - nvidia-gpu-operator/plugindefinition.yaml

--- a/nvidia-gpu-operator/README.md
+++ b/nvidia-gpu-operator/README.md
@@ -1,0 +1,7 @@
+---
+title: NVIDIA GPU Operator
+---
+
+This Plugin provides the [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator) which automates the management of NVIDIA software components needed to provision GPUs in Kubernetes clusters.
+
+The bundled [node-feature-discovery](https://github.com/kubernetes-sigs/node-feature-discovery) subchart is enabled by default and can be disabled via `nfd.enabled` if NFD is already installed separately.

--- a/nvidia-gpu-operator/plugindefinition.yaml
+++ b/nvidia-gpu-operator/plugindefinition.yaml
@@ -1,0 +1,24 @@
+# SPDX-FileCopyrightText: 2025 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: nvidia-gpu-operator
+spec:
+  version: 1.0.0
+  displayName: NVIDIA GPU Operator
+  description: The NVIDIA GPU Operator automates the management of NVIDIA software components in Kubernetes, including drivers, container runtime, device plugin, and monitoring. Includes node-feature-discovery as a bundled subchart.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/nvidia-gpu-operator/README.md
+  icon: https://assets.nvidiagrid.net/ngc/logos/GPUoperator.png
+  helmChart:
+    # renovate depName=nvcr.io/nvidia/cloud-native-charts/gpu-operator
+    name: gpu-operator
+    repository: oci://nvcr.io/nvidia/cloud-native-charts
+    version: v26.7.0
+  options:
+    - name: nfd.enabled
+      description: Enable the bundled node-feature-discovery subchart. Disable if NFD is already installed separately.
+      default: true
+      required: false
+      type: bool


### PR DESCRIPTION
## Pull Request Details

Adds a new Greenhouse Plugin for the [NVIDIA GPU Operator](https://github.com/NVIDIA/gpu-operator), which automates the management of NVIDIA software components in Kubernetes clusters (drivers, container runtime, device plugin, monitoring).

- Helm chart is pulled from the `nvcr.io/nvidia/cloud-native-charts` OCI registry (pinned to `v26.7.0`, kept up to date via Renovate)
- The bundled `node-feature-discovery` subchart is enabled by default and can be disabled via the `nfd.enabled` option if NFD is already installed separately

## Breaking Changes

None. This is a purely additive change (new plugin).

## Issues Fixed

None.

## Other Relevant Information

The plugin directory is named `nvidia-gpu-operator` (rather than `gpu-operator`) to disambiguate from other vendors' GPU Operators (e.g. AMD). The `helmChart.name` remains `gpu-operator` as that is the chart's actual name in the OCI registry.