### PR TITLE
feat(audit-logs): enable tls verification for kafka brokers

### DIFF
--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -90,14 +90,16 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.logsCollector.containerd.enabled | bool | `false` | Activates ingestion of container stdout/stderr logs from /var/log/pods |
 | auditLogs.logsCollector.enabled | bool | `true` | Activates the standard configuration for Logs. |
 | auditLogs.logsCollector.journald.enabled | bool | `false` | Activates ingestion of systemd journal logs |
-| auditLogs.logsCollector.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"protocol_version":"","tls":{"enabled":false,"insecure_skip_verify":false},"topic":""}` | Kafka exporter configuration for buffering audit logs |
+| auditLogs.logsCollector.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"protocol_version":"","tls":{"caSecret":"kafka-audit-cluster-ca-cert","caSecretKey":"ca.crt","enabled":false,"insecure_skip_verify":false},"topic":""}` | Kafka exporter configuration for buffering audit logs |
 | auditLogs.logsCollector.kafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
 | auditLogs.logsCollector.kafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
 | auditLogs.logsCollector.kafka.enabled | bool | `false` | Enable Kafka exporter for audit logs buffering. When enabled, audit logs are exported to Kafka instead of OpenSearch. |
 | auditLogs.logsCollector.kafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw, opensearch_log_encoding) |
 | auditLogs.logsCollector.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
 | auditLogs.logsCollector.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
-| auditLogs.logsCollector.kafka.tls | object | `{"enabled":false,"insecure_skip_verify":false}` | TLS settings for the Kafka exporter. Enable when the broker terminates TLS. |
+| auditLogs.logsCollector.kafka.tls | object | `{"caSecret":"kafka-audit-cluster-ca-cert","caSecretKey":"ca.crt","enabled":false,"insecure_skip_verify":false}` | TLS settings for the Kafka exporter. Enable when the broker terminates TLS. |
+| auditLogs.logsCollector.kafka.tls.caSecret | string | `"kafka-audit-cluster-ca-cert"` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. |
+| auditLogs.logsCollector.kafka.tls.caSecretKey | string | `"ca.crt"` | K8s secret key which holds the CA ertificate. |
 | auditLogs.logsCollector.kafka.tls.enabled | bool | `false` | Enable TLS on the connection to Kafka. |
 | auditLogs.logsCollector.kafka.tls.insecure_skip_verify | bool | `false` | Skip server certificate verification. Leave false for production. |
 | auditLogs.logsCollector.kafka.topic | string | `""` | Kafka topic name for audit logs |

--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -90,16 +90,16 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.logsCollector.containerd.enabled | bool | `false` | Activates ingestion of container stdout/stderr logs from /var/log/pods |
 | auditLogs.logsCollector.enabled | bool | `true` | Activates the standard configuration for Logs. |
 | auditLogs.logsCollector.journald.enabled | bool | `false` | Activates ingestion of systemd journal logs |
-| auditLogs.logsCollector.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"protocol_version":"","tls":{"caSecret":"kafka-audit-cluster-ca-cert","caSecretKey":"ca.crt","enabled":false,"insecure_skip_verify":false},"topic":""}` | Kafka exporter configuration for buffering audit logs |
+| auditLogs.logsCollector.kafka | object | `{"brokers":[],"compression":"","enabled":false,"encoding":"","max_message_bytes":1000000,"protocol_version":"","tls":{"caSecret":"","caSecretKey":"","enabled":false,"insecure_skip_verify":false},"topic":""}` | Kafka exporter configuration for buffering audit logs |
 | auditLogs.logsCollector.kafka.brokers | list | `[]` | Kafka broker addresses (e.g., ["kafka-bootstrap.kafka.svc.cluster.local:9092"]) |
 | auditLogs.logsCollector.kafka.compression | string | `""` | Compression type (none, gzip, snappy, lz4, zstd) |
 | auditLogs.logsCollector.kafka.enabled | bool | `false` | Enable Kafka exporter for audit logs buffering. When enabled, audit logs are exported to Kafka instead of OpenSearch. |
 | auditLogs.logsCollector.kafka.encoding | string | `""` | Message encoding format (otlp_json, otlp_proto, raw, opensearch_log_encoding) |
 | auditLogs.logsCollector.kafka.max_message_bytes | int | `1000000` | Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes. |
 | auditLogs.logsCollector.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
-| auditLogs.logsCollector.kafka.tls | object | `{"caSecret":"kafka-audit-cluster-ca-cert","caSecretKey":"ca.crt","enabled":false,"insecure_skip_verify":false}` | TLS settings for the Kafka exporter. Enable when the broker terminates TLS. |
-| auditLogs.logsCollector.kafka.tls.caSecret | string | `"kafka-audit-cluster-ca-cert"` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. |
-| auditLogs.logsCollector.kafka.tls.caSecretKey | string | `"ca.crt"` | K8s secret key which holds the CA ertificate. |
+| auditLogs.logsCollector.kafka.tls | object | `{"caSecret":"","caSecretKey":"","enabled":false,"insecure_skip_verify":false}` | TLS settings for the Kafka exporter. Enable when the broker terminates TLS. |
+| auditLogs.logsCollector.kafka.tls.caSecret | string | `""` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert) |
+| auditLogs.logsCollector.kafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA ertificate. (e.g. ca.crt) |
 | auditLogs.logsCollector.kafka.tls.enabled | bool | `false` | Enable TLS on the connection to Kafka. |
 | auditLogs.logsCollector.kafka.tls.insecure_skip_verify | bool | `false` | Skip server certificate verification. Leave false for production. |
 | auditLogs.logsCollector.kafka.topic | string | `""` | Kafka topic name for audit logs |

--- a/audit-logs/README.md
+++ b/audit-logs/README.md
@@ -99,7 +99,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | auditLogs.logsCollector.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
 | auditLogs.logsCollector.kafka.tls | object | `{"caSecret":"","caSecretKey":"","enabled":false,"insecure_skip_verify":false}` | TLS settings for the Kafka exporter. Enable when the broker terminates TLS. |
 | auditLogs.logsCollector.kafka.tls.caSecret | string | `""` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert) |
-| auditLogs.logsCollector.kafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA ertificate. (e.g. ca.crt) |
+| auditLogs.logsCollector.kafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA certificate. (e.g. ca.crt) |
 | auditLogs.logsCollector.kafka.tls.enabled | bool | `false` | Enable TLS on the connection to Kafka. |
 | auditLogs.logsCollector.kafka.tls.insecure_skip_verify | bool | `false` | Skip server certificate verification. Leave false for production. |
 | auditLogs.logsCollector.kafka.topic | string | `""` | Kafka topic name for audit logs |

--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.16
+version: 0.2.17
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -84,6 +84,11 @@ spec:
   - mountPath: /var/log
     name: varlog
     readOnly: true
+{{- if and .Values.auditLogs.logsCollector.kafka.enabled .Values.auditLogs.logsCollector.kafka.tls.enabled }}
+  - name: kafka-ca
+    mountPath: /etc/ssl/kafka
+    readOnly: true
+{{- end }}
 {{- if .Values.auditLogs.elastic.enabled }}
   {{- include "es.volumeMounts" . | nindent 2 }}
 {{- end }}
@@ -94,6 +99,11 @@ spec:
   - name: varlog
     hostPath:
       path: /var/log
+{{- if and .Values.auditLogs.logsCollector.kafka.enabled .Values.auditLogs.logsCollector.kafka.tls.enabled }}
+  - name: kafka-ca
+    secret:
+      secretName: {{ .Values.auditLogs.logsCollector.kafka.tls.caSecret | quote }}
+{{- end }}
 {{- if .Values.auditLogs.elastic.enabled }}
   {{- include "es.volumes" . | nindent 2 }}
 {{- end }}
@@ -577,6 +587,7 @@ spec:
         tls:
           insecure: false
           insecure_skip_verify: {{ .Values.auditLogs.logsCollector.kafka.tls.insecure_skip_verify }}
+          ca_file: /etc/ssl/kafka/{{ .Values.auditLogs.logsCollector.kafka.tls.caSecretKey }}
 {{- end }}
         logs:
           topic: {{ .Values.auditLogs.logsCollector.kafka.topic }}

--- a/audit-logs/charts/templates/audit-logs-collector.yaml
+++ b/audit-logs/charts/templates/audit-logs-collector.yaml
@@ -84,7 +84,7 @@ spec:
   - mountPath: /var/log
     name: varlog
     readOnly: true
-{{- if and .Values.auditLogs.logsCollector.kafka.enabled .Values.auditLogs.logsCollector.kafka.tls.enabled }}
+{{- if and .Values.auditLogs.logsCollector.kafka.enabled .Values.auditLogs.logsCollector.kafka.tls.enabled (not (empty .Values.auditLogs.logsCollector.kafka.tls.caSecret)) }}
   - name: kafka-ca
     mountPath: /etc/ssl/kafka
     readOnly: true
@@ -99,7 +99,7 @@ spec:
   - name: varlog
     hostPath:
       path: /var/log
-{{- if and .Values.auditLogs.logsCollector.kafka.enabled .Values.auditLogs.logsCollector.kafka.tls.enabled }}
+{{- if and .Values.auditLogs.logsCollector.kafka.enabled .Values.auditLogs.logsCollector.kafka.tls.enabled (not (empty .Values.auditLogs.logsCollector.kafka.tls.caSecret)) }}
   - name: kafka-ca
     secret:
       secretName: {{ .Values.auditLogs.logsCollector.kafka.tls.caSecret | quote }}
@@ -587,7 +587,9 @@ spec:
         tls:
           insecure: false
           insecure_skip_verify: {{ .Values.auditLogs.logsCollector.kafka.tls.insecure_skip_verify }}
+{{- if and (not (empty .Values.auditLogs.logsCollector.kafka.tls.caSecret)) (not (empty .Values.auditLogs.logsCollector.kafka.tls.caSecretKey)) }}
           ca_file: /etc/ssl/kafka/{{ .Values.auditLogs.logsCollector.kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
         logs:
           topic: {{ .Values.auditLogs.logsCollector.kafka.topic }}

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -41,20 +41,30 @@ spec:
     - name: prometheus
       port: 8888
 {{- end }}
+{{- $kafka := $root.Values.auditLogs.logsCollector.kafka -}}
+{{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) -}}
+{{- $kafka = $cfg.kafka -}}
+{{- end }}
   image: {{ (default (dict) $cfg.image).repository | default $root.Values.auditLogs.ingesterCollector.image.repository | default $root.Values.auditLogs.collectorImage.repository }}:{{ (default (dict) $cfg.image).tag | default $root.Values.auditLogs.ingesterCollector.image.tag | default $root.Values.auditLogs.collectorImage.tag }}
   volumeMounts:
     - name: opensearch-ca
       mountPath: /etc/ssl/opensearch
       readOnly: true
+{{- if (dig "tls" "enabled" false $kafka) }}
+    - name: kafka-ca
+      mountPath: /etc/ssl/kafka
+      readOnly: true
+{{- end }}
   volumes:
     - name: opensearch-ca
       secret:
         secretName: {{ $cfg.opensearch.tls.caSecret | quote }}
-  config:
-{{- $kafka := $root.Values.auditLogs.logsCollector.kafka -}}
-{{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) -}}
-{{- $kafka = $cfg.kafka -}}
+{{- if (dig "tls" "enabled" false $kafka) }}
+    - name: kafka-ca
+      secret:
+        secretName: {{ dig "tls" "caSecret" "" $kafka | quote }}
 {{- end }}
+  config:
     receivers:
       kafka/{{ $name }}:
         brokers:
@@ -80,6 +90,12 @@ spec:
           initial_interval: 1s
           max_interval: 30s
           max_elapsed_time: 3m
+{{- if (dig "tls" "enabled" false $kafka) }}
+        tls:
+          insecure: false
+          insecure_skip_verify: {{ dig "tls" "insecure_skip_verify" false $kafka }}
+          ca_file: /etc/ssl/kafka/{{ dig "tls" "caSecretKey" "" $kafka }}
+{{- end }}
     processors:
       memory_limiter:
         check_interval: 5s

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -50,7 +50,7 @@ spec:
     - name: opensearch-ca
       mountPath: /etc/ssl/opensearch
       readOnly: true
-{{- if (dig "tls" "enabled" false $kafka) }}
+{{- if and (dig "tls" "enabled" false $kafka) (not (empty $kafka.tls.caSecret)) }}
     - name: kafka-ca
       mountPath: /etc/ssl/kafka
       readOnly: true
@@ -59,7 +59,7 @@ spec:
     - name: opensearch-ca
       secret:
         secretName: {{ $cfg.opensearch.tls.caSecret | quote }}
-{{- if (dig "tls" "enabled" false $kafka) }}
+{{- if and (dig "tls" "enabled" false $kafka) (not (empty $kafka.tls.caSecret)) }}
     - name: kafka-ca
       secret:
         secretName: {{ dig "tls" "caSecret" "" $kafka | quote }}
@@ -95,6 +95,9 @@ spec:
           insecure: false
           insecure_skip_verify: {{ dig "tls" "insecure_skip_verify" false $kafka }}
           ca_file: /etc/ssl/kafka/{{ dig "tls" "caSecretKey" "" $kafka }}
+{{- if and (not (empty $kafka.tls.caSecret)) (not (empty $kafka.tls.caSecretKey)) }}
+          ca_file: /etc/ssl/kafka/{{ $kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
     processors:
       memory_limiter:

--- a/audit-logs/charts/templates/ingester-collector.yaml
+++ b/audit-logs/charts/templates/ingester-collector.yaml
@@ -94,7 +94,6 @@ spec:
         tls:
           insecure: false
           insecure_skip_verify: {{ dig "tls" "insecure_skip_verify" false $kafka }}
-          ca_file: /etc/ssl/kafka/{{ dig "tls" "caSecretKey" "" $kafka }}
 {{- if and (not (empty $kafka.tls.caSecret)) (not (empty $kafka.tls.caSecretKey)) }}
           ca_file: /etc/ssl/kafka/{{ $kafka.tls.caSecretKey }}
 {{- end }}

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -86,10 +86,10 @@ auditLogs:
         enabled: false
         # -- Skip server certificate verification. Leave false for production.
         insecure_skip_verify: false
-        # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers.
-        caSecret: kafka-audit-cluster-ca-cert
-        # -- K8s secret key which holds the CA ertificate.
-        caSecretKey: ca.crt
+        # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert)
+        caSecret: ""
+        # -- K8s secret key which holds the CA ertificate. (e.g. ca.crt)
+        caSecretKey: ""
     # -- Max characters for the log body in the truncate_message processor. Keep below the
     # Lucene 32766-byte term limit so OpenSearch never permanently rejects a document.
     maxMessageLength: 32000

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -88,7 +88,7 @@ auditLogs:
         insecure_skip_verify: false
         # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert)
         caSecret: ""
-        # -- K8s secret key which holds the CA ertificate. (e.g. ca.crt)
+        # -- K8s secret key which holds the CA certificate. (e.g. ca.crt)
         caSecretKey: ""
     # -- Max characters for the log body in the truncate_message processor. Keep below the
     # Lucene 32766-byte term limit so OpenSearch never permanently rejects a document.
@@ -145,7 +145,7 @@ auditLogs:
     #     initialOffset: latest | earliest      # optional, defaults to latest
     #     replicas: <int>                        # optional; per-collector replica count, falls back to ingesterCollector.replicas
     #     extraProcessors: <list>               # optional, ordered list of {name, config} entries; each is added to processors: and appended to the pipeline in this order
-    #     kafka: { brokers, protocol_version, encoding, tls}  # optional override of auditLogs.logsCollector.kafka
+    #     kafka: { brokers, protocol_version, encoding, tls }  # optional override of auditLogs.logsCollector.kafka (only applied when kafka.brokers is non-empty)
     #     opensearch:
     #       endpoint: <url>
     #       tls: { caSecret, caSecretKey, insecure }

--- a/audit-logs/charts/values.yaml
+++ b/audit-logs/charts/values.yaml
@@ -86,6 +86,10 @@ auditLogs:
         enabled: false
         # -- Skip server certificate verification. Leave false for production.
         insecure_skip_verify: false
+        # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers.
+        caSecret: kafka-audit-cluster-ca-cert
+        # -- K8s secret key which holds the CA ertificate.
+        caSecretKey: ca.crt
     # -- Max characters for the log body in the truncate_message processor. Keep below the
     # Lucene 32766-byte term limit so OpenSearch never permanently rejects a document.
     maxMessageLength: 32000
@@ -141,7 +145,7 @@ auditLogs:
     #     initialOffset: latest | earliest      # optional, defaults to latest
     #     replicas: <int>                        # optional; per-collector replica count, falls back to ingesterCollector.replicas
     #     extraProcessors: <list>               # optional, ordered list of {name, config} entries; each is added to processors: and appended to the pipeline in this order
-    #     kafka: { brokers, protocol_version, encoding }  # optional override of auditLogs.logsCollector.kafka
+    #     kafka: { brokers, protocol_version, encoding, tls}  # optional override of auditLogs.logsCollector.kafka
     #     opensearch:
     #       endpoint: <url>
     #       tls: { caSecret, caSecretKey, insecure }

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.16
+    version: 0.2.17
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.16
+        version: 0.2.17
     options:
         - name: auditLogs.region
           description: Region label for logging


### PR DESCRIPTION
Enable TLS verification. Otel collector can mount kafka brokers CA cert to do the cert check.