### PR TITLE
feat(logs): enable mount of kafka CA cert

### DIFF
--- a/logs/README.md
+++ b/logs/README.md
@@ -106,7 +106,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.auditKafka.sendingQueue.numConsumers | int | `1` | Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput. |
 | openTelemetry.auditKafka.tls | object | `{"caSecret":"","caSecretKey":"","enabled":false}` | TLS configuration for Kafka connections |
 | openTelemetry.auditKafka.tls.caSecret | string | `""` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert) |
-| openTelemetry.auditKafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA ertificate. (e.g. ca.crt) |
+| openTelemetry.auditKafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA certificate. (e.g. ca.crt) |
 | openTelemetry.auditKafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
 | openTelemetry.collectorImage | object | `{"repository":"ghcr.io/cloudoperators/opentelemetry-collector-contrib","tag":"a62a383"}` | OpenTelemetry Collector image configuration |

--- a/logs/README.md
+++ b/logs/README.md
@@ -104,7 +104,9 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.auditKafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
 | openTelemetry.auditKafka.sendingQueue | object | `{"enabled":true,"numConsumers":1,"queueSize":1000}` | Producer sending queue size |
 | openTelemetry.auditKafka.sendingQueue.numConsumers | int | `1` | Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput. |
-| openTelemetry.auditKafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
+| openTelemetry.auditKafka.tls | object | `{"caSecret":"","caSecretKey":"","enabled":false}` | TLS configuration for Kafka connections |
+| openTelemetry.auditKafka.tls.caSecret | string | `""` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert) |
+| openTelemetry.auditKafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA ertificate. (e.g. ca.crt) |
 | openTelemetry.auditKafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.cluster | string | `nil` | Cluster label for Logging |
 | openTelemetry.collectorImage | object | `{"repository":"ghcr.io/cloudoperators/opentelemetry-collector-contrib","tag":"a62a383"}` | OpenTelemetry Collector image configuration |
@@ -178,7 +180,9 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.kafka.protocol_version | string | `""` | Kafka protocol version (e.g., "3.9.0") |
 | openTelemetry.kafka.sendingQueue | object | `{"enabled":true,"numConsumers":1,"queueSize":1000}` | Producer sending queue size |
 | openTelemetry.kafka.sendingQueue.numConsumers | int | `1` | Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput. |
-| openTelemetry.kafka.tls | object | `{"enabled":false}` | TLS configuration for Kafka connections |
+| openTelemetry.kafka.tls | object | `{"caSecret":"","caSecretKey":"","enabled":false}` | TLS configuration for Kafka connections |
+| openTelemetry.kafka.tls.caSecret | string | `""` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-cluster-ca-cert) |
+| openTelemetry.kafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA ertificate. (e.g. ca.crt) |
 | openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.affinity | object | See values.yaml | Pod affinity rules for the logs collector CR |
 | openTelemetry.logsCollector.batch | object | `{"sendBatchMaxSize":5000,"sendBatchSize":100,"timeout":"30s"}` | Batch processor settings for the logs collector. |

--- a/logs/README.md
+++ b/logs/README.md
@@ -182,7 +182,7 @@ The **Logs** Plugin comes with a [Failover Connector](https://github.com/open-te
 | openTelemetry.kafka.sendingQueue.numConsumers | int | `1` | Parallel export workers draining the queue to Kafka. Raise toward the topic partition count for higher throughput. |
 | openTelemetry.kafka.tls | object | `{"caSecret":"","caSecretKey":"","enabled":false}` | TLS configuration for Kafka connections |
 | openTelemetry.kafka.tls.caSecret | string | `""` | K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-cluster-ca-cert) |
-| openTelemetry.kafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA ertificate. (e.g. ca.crt) |
+| openTelemetry.kafka.tls.caSecretKey | string | `""` | K8s secret key which holds the CA certificate. (e.g. ca.crt) |
 | openTelemetry.kafka.tls.enabled | bool | `false` | Enable TLS for Kafka connections |
 | openTelemetry.logsCollector.affinity | object | See values.yaml | Pod affinity rules for the logs collector CR |
 | openTelemetry.logsCollector.batch | object | `{"sendBatchMaxSize":5000,"sendBatchSize":100,"timeout":"30s"}` | Batch processor settings for the logs collector. |

--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.59
+version: 0.4.60
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_external-audit-exporter.tpl
+++ b/logs/charts/templates/_external-audit-exporter.tpl
@@ -109,6 +109,9 @@ kafka/syslog_audit:
 {{- if .Values.openTelemetry.auditKafka.tls.enabled }}
   tls:
     insecure: false
+{{- if and (not (empty .Values.openTelemetry.auditKafka.tls.caSecret)) (not (empty .Values.openTelemetry.auditKafka.tls.caSecretKey)) }}
+    ca_file: /etc/ssl/audit-kafka/{{ .Values.openTelemetry.auditKafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/logs/charts/templates/_external-http-config.tpl
+++ b/logs/charts/templates/_external-http-config.tpl
@@ -169,6 +169,9 @@ kafka/external_http:
 {{- if .Values.openTelemetry.auditKafka.tls.enabled }}
   tls:
     insecure: false
+{{- if and (not (empty .Values.openTelemetry.auditKafka.tls.caSecret)) (not (empty .Values.openTelemetry.auditKafka.tls.caSecretKey)) }}
+    ca_file: /etc/ssl/audit-kafka/{{ .Values.openTelemetry.auditKafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -420,6 +420,9 @@ kafka/syslog_non_audit:
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
   tls:
     insecure: false
+{{- if and (not (empty .Values.openTelemetry.kafka.tls.caSecret)) (not (empty .Values.openTelemetry.kafka.tls.caSecretKey)) }}
+    ca_file: /etc/ssl/kafka/{{ .Values.openTelemetry.kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/logs/charts/templates/external-collector.yaml
+++ b/logs/charts/templates/external-collector.yaml
@@ -97,10 +97,30 @@ spec:
   - mountPath: /etc/ssl/syslog-tls
     name: syslog-tls
     readOnly: true
+{{- if and .Values.openTelemetry.kafka.enabled .Values.openTelemetry.kafka.tls.enabled (not (empty .Values.openTelemetry.kafka.tls.caSecret)) }}
+  - name: kafka-ca
+    mountPath: /etc/ssl/kafka
+    readOnly: true
+{{- end }}
+{{- if and .Values.openTelemetry.auditKafka.enabled .Values.openTelemetry.auditKafka.tls.enabled (not (empty .Values.openTelemetry.auditKafka.tls.caSecret)) }}
+  - name: audit-kafka-ca
+    mountPath: /etc/ssl/audit-kafka
+    readOnly: true
+{{- end }}
   volumes:
   - name: syslog-tls
     secret:
       secretName: logs-syslog-tls
+{{- if and .Values.openTelemetry.kafka.enabled .Values.openTelemetry.kafka.tls.enabled (not (empty .Values.openTelemetry.kafka.tls.caSecret)) }}
+  - name: kafka-ca
+    secret:
+      secretName: {{ .Values.openTelemetry.kafka.tls.caSecret | quote }}
+{{- end }}
+{{- if and .Values.openTelemetry.auditKafka.enabled .Values.openTelemetry.auditKafka.tls.enabled (not (empty .Values.openTelemetry.auditKafka.tls.caSecret)) }}
+  - name: audit-kafka-ca
+    secret:
+      secretName: {{ .Values.openTelemetry.auditKafka.tls.caSecret | quote }}
+{{- end }}
 {{- end }}
   config:
     receivers:
@@ -201,6 +221,9 @@ spec:
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
+{{- if and (not (empty .Values.openTelemetry.kafka.tls.caSecret)) (not (empty .Values.openTelemetry.kafka.tls.caSecretKey)) }}
+          ca_file: /etc/ssl/kafka/{{ .Values.openTelemetry.kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
 {{- if .Values.openTelemetry.externalCollector.tracesConfig.enabled }}
       kafka/traces:
@@ -221,6 +244,9 @@ spec:
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
+{{- if and (not (empty .Values.openTelemetry.kafka.tls.caSecret)) (not (empty .Values.openTelemetry.kafka.tls.caSecretKey)) }}
+          ca_file: /etc/ssl/kafka/{{ .Values.openTelemetry.kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -54,7 +54,7 @@ spec:
 {{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) }}
 {{- $kafka = $cfg.kafka }}
 {{- end }}
-{{- $kafkaCASecret := dig "tls" "caSecret" "" $kafka }}
+{{- $kafkaCASecret := $kafka.tls.caSecret }}
 {{- $shouldMountKafkaCASecret := and $kafka.tls $kafka.tls.enabled (not (empty $kafkaCASecret)) (not (empty ($kafka.tls.caSecretKey))) }}
   volumeMounts:
     - name: opensearch-ca

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -50,19 +50,31 @@ spec:
       port: 8888
 {{- end }}
   image: {{ (default (dict) $cfg.image).repository | default $root.Values.openTelemetry.ingesterCollector.image.repository | default $root.Values.openTelemetry.collectorImage.repository }}:{{ (default (dict) $cfg.image).tag | default $root.Values.openTelemetry.ingesterCollector.image.tag | default $root.Values.openTelemetry.collectorImage.tag }}
-  volumeMounts:
-    - name: opensearch-ca
-      mountPath: /etc/ssl/opensearch
-      readOnly: true
-  volumes:
-    - name: opensearch-ca
-      secret:
-        secretName: {{ $cfg.opensearch.tls.caSecret | quote }}
-  config:
 {{- $kafka := $root.Values.openTelemetry.kafka -}}
 {{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) -}}
 {{- $kafka = $cfg.kafka -}}
 {{- end }}
+{{- $kafkaCASecret := dig "tls" "caSecret" "" $kafka -}}
+{{- $shouldMountKafkaCASecret := and (or (default false (dig "tls" "enabled" false $kafka)) $root.Values.openTelemetry.kafka.tls.enabled) (not (empty $kafkaCASecret)) -}}
+  volumeMounts:
+    - name: opensearch-ca
+      mountPath: /etc/ssl/opensearch
+      readOnly: true
+{{- if $shouldMountKafkaCASecret }}
+    - name: kafka-ca
+      mountPath: /etc/ssl/kafka
+      readOnly: true
+{{- end }}
+  volumes:
+    - name: opensearch-ca
+      secret:
+        secretName: {{ $cfg.opensearch.tls.caSecret | quote }}
+{{- if $shouldMountKafkaCASecret }}
+    - name: kafka-ca
+      secret:
+        secretName: {{ $kafkaCASecret | quote }}
+{{- end }}
+  config:
     receivers:
       kafka/{{ $name }}:
         brokers:
@@ -73,6 +85,9 @@ spec:
 {{- if or (default false (dig "tls" "enabled" false $kafka)) $root.Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
+{{- if $shouldMountKafkaCASecret }}
+          ca_file: /etc/ssl/kafka/{{ dig "tls" "caSecretKey" "" $kafka }}
+{{- end }}
 {{- end }}
         logs:
           topics:

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -50,12 +50,12 @@ spec:
       port: 8888
 {{- end }}
   image: {{ (default (dict) $cfg.image).repository | default $root.Values.openTelemetry.ingesterCollector.image.repository | default $root.Values.openTelemetry.collectorImage.repository }}:{{ (default (dict) $cfg.image).tag | default $root.Values.openTelemetry.ingesterCollector.image.tag | default $root.Values.openTelemetry.collectorImage.tag }}
-{{- $kafka := $root.Values.openTelemetry.kafka -}}
-{{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) -}}
-{{- $kafka = $cfg.kafka -}}
+{{- $kafka := $root.Values.openTelemetry.kafka }}
+{{- if and $cfg.kafka (gt (len (default (list) $cfg.kafka.brokers)) 0) }}
+{{- $kafka = $cfg.kafka }}
 {{- end }}
-{{- $kafkaCASecret := dig "tls" "caSecret" "" $kafka -}}
-{{- $shouldMountKafkaCASecret := and (or (default false (dig "tls" "enabled" false $kafka)) $root.Values.openTelemetry.kafka.tls.enabled) (not (empty $kafkaCASecret)) (not (empty (dig "tls" "caSecretKey" "" $kafka))) -}}
+{{- $kafkaCASecret := dig "tls" "caSecret" "" $kafka }}
+{{- $shouldMountKafkaCASecret := and $kafka.tls $kafka.tls.enabled (not (empty $kafkaCASecret)) (not (empty ($kafka.tls.caSecretKey))) }}
   volumeMounts:
     - name: opensearch-ca
       mountPath: /etc/ssl/opensearch
@@ -86,7 +86,7 @@ spec:
         tls:
           insecure: false
 {{- if $shouldMountKafkaCASecret }}
-          ca_file: /etc/ssl/kafka/{{ dig "tls" "caSecretKey" "" $kafka }}
+          ca_file: /etc/ssl/kafka/{{ $kafka.tls.caSecretKey }}
 {{- end }}
 {{- end }}
         logs:

--- a/logs/charts/templates/ingester-collector.yaml
+++ b/logs/charts/templates/ingester-collector.yaml
@@ -55,7 +55,7 @@ spec:
 {{- $kafka = $cfg.kafka -}}
 {{- end }}
 {{- $kafkaCASecret := dig "tls" "caSecret" "" $kafka -}}
-{{- $shouldMountKafkaCASecret := and (or (default false (dig "tls" "enabled" false $kafka)) $root.Values.openTelemetry.kafka.tls.enabled) (not (empty $kafkaCASecret)) -}}
+{{- $shouldMountKafkaCASecret := and (or (default false (dig "tls" "enabled" false $kafka)) $root.Values.openTelemetry.kafka.tls.enabled) (not (empty $kafkaCASecret)) (not (empty (dig "tls" "caSecretKey" "" $kafka))) -}}
   volumeMounts:
     - name: opensearch-ca
       mountPath: /etc/ssl/opensearch

--- a/logs/charts/templates/logs-collector.yaml
+++ b/logs/charts/templates/logs-collector.yaml
@@ -61,10 +61,20 @@ spec:
   - mountPath: /var/log
     name: varlog
     readOnly: true
+{{- if and .Values.openTelemetry.kafka.enabled .Values.openTelemetry.kafka.tls.enabled (not (empty .Values.openTelemetry.kafka.tls.caSecret)) }}
+  - name: kafka-ca
+    mountPath: /etc/ssl/kafka
+    readOnly: true
+{{- end }}
   volumes:
   - name: varlog
     hostPath:
       path: /var/log
+{{- if and .Values.openTelemetry.kafka.enabled .Values.openTelemetry.kafka.tls.enabled (not (empty .Values.openTelemetry.kafka.tls.caSecret)) }}
+  - name: kafka-ca
+    secret:
+      secretName: {{ .Values.openTelemetry.kafka.tls.caSecret | quote }}
+{{- end }}
   config:
     receivers:
 {{- if .Values.openTelemetry.logsCollector.journaldConfig.enabled }}
@@ -258,6 +268,9 @@ spec:
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
+{{- if and (not (empty .Values.openTelemetry.kafka.tls.caSecret)) (not (empty .Values.openTelemetry.kafka.tls.caSecretKey)) }}
+          ca_file: /etc/ssl/kafka/{{ .Values.openTelemetry.kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
       kafka/storage:
         brokers:
@@ -278,6 +291,9 @@ spec:
 {{- if .Values.openTelemetry.kafka.tls.enabled }}
         tls:
           insecure: false
+{{- if and (not (empty .Values.openTelemetry.kafka.tls.caSecret)) (not (empty .Values.openTelemetry.kafka.tls.caSecretKey)) }}
+          ca_file: /etc/ssl/kafka/{{ .Values.openTelemetry.kafka.tls.caSecretKey }}
+{{- end }}
 {{- end }}
 {{- else }}
       opensearch/failover_a:

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -143,7 +143,7 @@ openTelemetry:
       enabled: false
       # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert)
       caSecret: ""
-      # -- K8s secret key which holds the CA ertificate. (e.g. ca.crt)
+      # -- K8s secret key which holds the CA certificate. (e.g. ca.crt)
       caSecretKey: ""
   logsCollector:
     # -- Activates the standard configuration for Logs.

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -104,6 +104,10 @@ openTelemetry:
     tls:
       # -- Enable TLS for Kafka connections
       enabled: false
+      # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-cluster-ca-cert)
+      caSecret: ""
+      # -- K8s secret key which holds the CA ertificate. (e.g. ca.crt)
+      caSecretKey: ""
   # -- Audit Kafka exporter configuration shared by all collectors
   # @default -- See values.yaml
   auditKafka:
@@ -137,6 +141,10 @@ openTelemetry:
     tls:
       # -- Enable TLS for Kafka connections
       enabled: false
+      # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-audit-cluster-ca-cert)
+      caSecret: ""
+      # -- K8s secret key which holds the CA ertificate. (e.g. ca.crt)
+      caSecretKey: ""
   logsCollector:
     # -- Activates the standard configuration for Logs.
     enabled: true

--- a/logs/charts/values.yaml
+++ b/logs/charts/values.yaml
@@ -106,7 +106,7 @@ openTelemetry:
       enabled: false
       # -- K8s secret name containing CA certificate that can be used to verify the identity of the Kafka brokers. (e.g. kafka-cluster-ca-cert)
       caSecret: ""
-      # -- K8s secret key which holds the CA ertificate. (e.g. ca.crt)
+      # -- K8s secret key which holds the CA certificate. (e.g. ca.crt)
       caSecretKey: ""
   # -- Audit Kafka exporter configuration shared by all collectors
   # @default -- See values.yaml

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.59
+  version: 0.15.60
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.59
+    version: 0.4.60
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
Enable to mount kafka brokers CA cert in otel collector so that we can verify TLS connection for internal traffic.
