### PR TITLE
fix(logs): fix parsing errors from #1974 for devices

### DIFF
--- a/logs/charts/Chart.yaml
+++ b/logs/charts/Chart.yaml
@@ -4,7 +4,7 @@
 apiVersion: v2
 appVersion: 0.152.0
 name: logs
-version: 0.4.60
+version: 0.4.61
 description: OpenTelemetry Operator Helm chart for Kubernetes
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -325,7 +325,7 @@ transform/syslog_audit_classification:
         # Mark as audit if the log has a known audit source (e.g. ESXi, NSX-T, VCSA)
         - 'set(log.attributes["audit_relevant"], "true") where log.attributes["sap.cc.audit.source"] != nil'
         # Mark network logs as audit-relevant
-        - 'set(log.attributes["audit_relevant"], "true") where log.attributes["device.manufacturer"] != nil and IsMatch(log.attributes["device.manufacturer"], "(Cisco|Check Point|Fortinet|Palo Alto Networks|Trend Micro|Tufin|Radware|F5|VMware)")'
+        - 'set(log.attributes["audit_relevant"], "true") where log.attributes["device.manufacturer"] != nil and IsMatch(log.attributes["device.manufacturer"], "(Cisco|Check Point|Fortinet|Palo Alto Networks|Trend Micro|Tufin|Radware|F5)")'
 # Uses observedTimestamp as fallback when no timestamp could be parsed from the log body
 # (e.g. unknown format logs that end up with @timestamp = 1970-01-01T00:00:00Z)
 transform/syslog_observed_timestamp_fallback:

--- a/logs/charts/templates/_syslog-audit-filter-config.tpl
+++ b/logs/charts/templates/_syslog-audit-filter-config.tpl
@@ -263,7 +263,7 @@ transform/syslog_nsxt:
       conditions:
         - 'log.attributes["sap.cc.audit.source"] == "NSX-T"'
       statements:
-        - 'set(resource.attributes["device.manufacturer"], "VMware")'
+        - 'set(log.attributes["device.manufacturer"], "VMware")'
         # Extract NSX-T transport-node FQDN (shape: node###-bb###.<domain>).
         # Handles both message encodings: free-text "Transport node X (" and JSON "transport_node_name":"X".
         - 'merge_maps(log.attributes, ExtractPatterns(log.attributes["message"], "(?P<fqdn>node\\d{3}-bb\\d{3}\\.\\S+?)(?:[\\s\\)\"]|$)"), "upsert") where log.attributes["fqdn"] == nil and IsString(log.attributes["message"])'
@@ -284,7 +284,7 @@ transform/syslog_esxi_vm_events:
       conditions:
         - 'log.attributes["sap.cc.audit.source"] == "ESXi"'
       statements:
-        - 'set(resource.attributes["device.manufacturer"], "VMware")'
+        - 'set(log.attributes["device.manufacturer"], "VMware")'
         # Parse VM reconfigure/error events
         - 'merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["message"], "Event %{NONNEGINT:event_id} : (?:Reconfigured|Error message on) %{DATA:cloud_instance_name} \\(%{UUID:cloud_instance_id}\\)%{GREEDYDATA}", true), "upsert") where IsString(log.attributes["message"])'
 
@@ -302,7 +302,7 @@ transform/syslog_esxi_sshd:
         - 'log.attributes["appname"] == "sshd"'
         - 'IsString(log.attributes["message"]) and IsMatch(log.attributes["message"], ".*Accepted keyboard-interactive/pam for root from.*")'
       statements:
-        - 'set(resource.attributes["device.manufacturer"], "VMware")'
+        - 'set(log.attributes["device.manufacturer"], "VMware")'
         - 'merge_maps(log.attributes, ExtractGrokPatterns(log.attributes["message"], "%{WORD:sshd_application}\\[%{NUMBER:sshd_process_id}\\]: %{WORD:sshd_status} %{DATA:sshd_auth_method} for %{USERNAME:sshd_user} from %{IP:sshd_ip} port %{NUMBER:sshd_port} %{WORD:sshd_protocol}", true), "upsert") where IsString(log.attributes["message"])'
 
 {{/*
@@ -325,7 +325,7 @@ transform/syslog_audit_classification:
         # Mark as audit if the log has a known audit source (e.g. ESXi, NSX-T, VCSA)
         - 'set(log.attributes["audit_relevant"], "true") where log.attributes["sap.cc.audit.source"] != nil'
         # Mark network logs as audit-relevant
-        - 'set(log.attributes["audit_relevant"], "true") where IsMatch(device.manufacturer, "(Cisco|Check Point|Fortinet|Palo Alto Networks|Trend Micro|Tufin|Radware|F5)")'
+        - 'set(log.attributes["audit_relevant"], "true") where log.attributes["device.manufacturer"] != nil and IsMatch(log.attributes["device.manufacturer"], "(Cisco|Check Point|Fortinet|Palo Alto Networks|Trend Micro|Tufin|Radware|F5|VMware)")'
 # Uses observedTimestamp as fallback when no timestamp could be parsed from the log body
 # (e.g. unknown format logs that end up with @timestamp = 1970-01-01T00:00:00Z)
 transform/syslog_observed_timestamp_fallback:

--- a/logs/plugindefinition.yaml
+++ b/logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
   name: logs
 spec:
-  version: 0.15.60
+  version: 0.15.61
   displayName: Logs
   description: Observability framework for instrumenting, generating, collecting, and exporting logs.
   icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/logs/logo.png
   helmChart:
     name: logs
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 0.4.60
+    version: 0.4.61
   options:
     - default: true
       description: Set to true to enable the installation of the OpenTelemetry Operator.


### PR DESCRIPTION
fixing error
`error while parsing arguments for call to "IsMatch": invalid argument at position 0: segment "device" from path "log.device.manufacturer" is not a valid path nor a valid OTTL keyword for the log context - review`