### PR TITLE
feat: add kgateway-crds and kgateway PluginDefinitions

### DIFF
--- a/kgateway-crds/README.md
+++ b/kgateway-crds/README.md
@@ -1,0 +1,23 @@
+<!--
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# kgateway-crds
+
+Installs the Custom Resource Definitions (CRDs) required by the [kgateway](https://kgateway.dev/) controller.
+
+## Prerequisites
+
+1. `k8s-gateway-api` plugin (Kubernetes Gateway API CRDs)
+
+## Installation order
+
+```
+k8s-gateway-api  →  kgateway-crds  →  kgateway
+```
+
+## Links
+
+- [kgateway documentation](https://kgateway.dev/docs/envoy/latest/)
+- [Install guide](https://kgateway.dev/docs/envoy/latest/install/helm/)

--- a/kgateway-crds/plugindefinition.yaml
+++ b/kgateway-crds/plugindefinition.yaml
@@ -1,0 +1,19 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: kgateway-crds
+spec:
+  version: 2.4.3
+  displayName: KGateway CRDs
+  description: >-
+    Installs the Custom Resource Definitions required by the kgateway controller.
+    Install this before the kgateway plugin. Requires the k8s-gateway-api
+    plugin (Gateway API CRDs) to be installed first.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kgateway-crds/README.md
+  helmChart:
+    name: kgateway-crds
+    repository: oci://cr.kgateway.dev/kgateway-dev/charts
+    version: v2.4.3

--- a/kgateway/README.md
+++ b/kgateway/README.md
@@ -11,7 +11,6 @@ Deploys the [kgateway](https://kgateway.dev/) control plane — a Kubernetes-nat
 
 - **Gateway API native** — full support for HTTPRoute, TCPRoute, and other Gateway API resources
 - **Envoy-based** — high-performance data plane powered by Envoy proxy
-- **AI extensions** — built-in support for AI traffic management
 - **Advanced traffic management** — retries, timeouts, traffic splitting, and header manipulation
 
 ## Prerequisites

--- a/kgateway/README.md
+++ b/kgateway/README.md
@@ -1,0 +1,38 @@
+<!--
+SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+SPDX-License-Identifier: Apache-2.0
+-->
+
+# kgateway
+
+Deploys the [kgateway](https://kgateway.dev/) control plane — a Kubernetes-native API gateway built on Envoy and the Gateway API. Originally created by Solo.io as Gloo.
+
+## Features
+
+- **Gateway API native** — full support for HTTPRoute, TCPRoute, and other Gateway API resources
+- **Envoy-based** — high-performance data plane powered by Envoy proxy
+- **AI extensions** — built-in support for AI traffic management
+- **Advanced traffic management** — retries, timeouts, traffic splitting, and header manipulation
+
+## Prerequisites
+
+1. `k8s-gateway-api` plugin (Kubernetes Gateway API CRDs)
+2. `kgateway-crds` plugin (kgateway CRDs)
+
+## Installation order
+
+```
+k8s-gateway-api  →  kgateway-crds  →  kgateway
+```
+
+## Configuration
+
+| Option | Description | Default |
+|---|---|---|
+| `image.registry` | Global container image registry. Override with a mirror registry if the cluster cannot reach `cr.kgateway.dev` directly. | `cr.kgateway.dev/kgateway-dev` |
+| `controller.replicaCount` | Number of kgateway controller replicas. | `1` |
+
+## Links
+
+- [kgateway documentation](https://kgateway.dev/docs/envoy/latest/)
+- [Install guide](https://kgateway.dev/docs/envoy/latest/install/helm/)

--- a/kgateway/plugindefinition.yaml
+++ b/kgateway/plugindefinition.yaml
@@ -1,0 +1,33 @@
+# SPDX-FileCopyrightText: 2024 SAP SE or an SAP affiliate company and Greenhouse contributors
+# SPDX-License-Identifier: Apache-2.0
+
+apiVersion: greenhouse.sap/v1alpha1
+kind: PluginDefinition
+metadata:
+  name: kgateway
+spec:
+  version: 2.4.3
+  displayName: KGateway
+  description: >-
+    Kubernetes-native API gateway built on Envoy and the Gateway API. Originally
+    created by Solo.io as Gloo. Supports HTTPRoute, TCPRoute, and advanced traffic
+    management including AI extensions. Requires the kgateway-crds and
+    k8s-gateway-api plugins to be installed first.
+  docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/kgateway/README.md
+  helmChart:
+    name: kgateway
+    repository: oci://cr.kgateway.dev/kgateway-dev/charts
+    version: v2.4.3
+  options:
+    - name: image.registry
+      description: >-
+        Global container image registry. Override with a mirror registry if the
+        cluster cannot reach cr.kgateway.dev directly.
+      default: "cr.kgateway.dev/kgateway-dev"
+      required: false
+      type: string
+    - name: controller.replicaCount
+      description: Number of kgateway controller replicas.
+      default: 1
+      required: false
+      type: int


### PR DESCRIPTION
## Summary

Adds two PluginDefinitions for [kgateway](https://kgateway.dev/) — a Kubernetes-native API gateway built on Envoy and the Gateway API (originally created by Solo.io as Gloo):

- **`kgateway-crds`** — installs the kgateway CRDs from `oci://cr.kgateway.dev/kgateway-dev/charts/kgateway-crds:v2.4.3`
- **`kgateway`** — deploys the kgateway control plane from `oci://cr.kgateway.dev/kgateway-dev/charts/kgateway:v2.4.3`



## Installation order

```
k8s-gateway-api  →  kgateway-crds  →  kgateway
```