### PR TITLE
fix(audit-logs): fix plugindefinition - set kafka.tls as a map

### DIFF
--- a/audit-logs/charts/Chart.yaml
+++ b/audit-logs/charts/Chart.yaml
@@ -6,7 +6,7 @@ name: audit-logs
 description: OpenTelemetry Collector Helm chart for audit-logs
 icon: https://raw.githubusercontent.com/cncf/artwork/a718fa97fffec1b9fd14147682e9e3ac0c8817cb/projects/opentelemetry/icon/color/opentelemetry-icon-color.png
 type: application
-version: 0.2.17
+version: 0.2.18
 maintainers:
 - name: olandr
 - name: kuckkuck

--- a/audit-logs/plugindefinition.yaml
+++ b/audit-logs/plugindefinition.yaml
@@ -6,14 +6,14 @@ kind: PluginDefinition
 metadata:
     name: audit-logs
 spec:
-    version: 0.2.17
+    version: 0.2.18
     displayName: OpenTelemetry for Audit Logs
     description: Audit Logs relevant Observability framework for instrumenting, generating, collecting, and exporting telemetry data such as traces, metrics, and logs.
     icon: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/audit-logs/logo.png
     helmChart:
         name: 'audit-logs'
         repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-        version: 0.2.17
+        version: 0.2.18
     options:
         - name: auditLogs.region
           description: Region label for logging
@@ -136,16 +136,10 @@ spec:
           description: Max producer message size in bytes before compression (Kafka exporter default 1000000). Raise to match the Kafka topic/broker max.message.bytes.
           required: false
           type: int
-        - name: auditLogs.logsCollector.kafka.tls.enabled
-          default: false
-          description: Enable TLS on the connection to Kafka
+        - name: auditLogs.logsCollector.kafka.tls
+          description: Configure TLS on the connection to Kafka
           required: false
-          type: bool
-        - name: auditLogs.logsCollector.kafka.tls.insecure_skip_verify
-          default: false
-          description: Skip server certificate verification (leave false for production)
-          required: false
-          type: bool
+          type: map
         - name: auditLogs.ingesterCollector.enabled
           default: false
           description: Top-level toggle for the Kafka -> OpenSearch audit ingest collectors


### PR DESCRIPTION
There is a problem when in pluginpreset user sets `auditLogs.logsCollector.kafka.tls` insead of `auditLogs.logsCollector.kafka.tls.enabled`.
In final plugin we get 2 values:  
```
- name: auditLogs.logsCollector.kafka.tls
   value:
     enabled: true
- name: auditLogs.logsCollector.kafka.tls.enabled
  value: false
```

and the final render to helm release on target cluster sets `auditLogs.logsCollector.kafka.tls.enabled: false` instead of true.

Signed-off-by: Zuzanna Tomaszewska <zuzanna.tomaszewska@sap.com>
