### PR TITLE
feat(ingress-nginx): expose controller image options in PluginDefinition

### DIFF
--- a/ingress-nginx/plugindefinition.yaml
+++ b/ingress-nginx/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: ingress-nginx
 spec:
-  version: 1.3.0
+  version: 1.4.0
   displayName: Ingress NGINX
   description: Ingress NGINX controller for Kubernetes
   docMarkDownUrl: https://raw.githubusercontent.com/cloudoperators/greenhouse-extensions/main/ingress-nginx/README.md
@@ -78,3 +78,27 @@ spec:
       description: Additional labels to add service monitor
       required: false
       type: map
+    - name: controller.image.registry
+      description: Registry for the ingress-nginx controller image
+      required: false
+      type: string
+    - name: controller.image.image
+      description: Image name for the ingress-nginx controller
+      default: "ingress-nginx/controller"
+      required: false
+      type: string
+    - name: controller.image.tag
+      description: Image tag for the ingress-nginx controller
+      default: "v1.15.1"
+      required: false
+      type: string
+    - name: controller.image.digest
+      description: Image digest for the ingress-nginx controller
+      default: "sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1"
+      required: false
+      type: string
+    - name: controller.image.digestChroot
+      description: Image digest for the chroot variant of the ingress-nginx controller
+      default: "sha256:af31d00c9d82c612896b380a9003bd36843b7647b98e4588251c66325317bc72"
+      required: false
+      type: string


### PR DESCRIPTION
## Pull Request Details

The ingress-nginx PluginDefinition currently hard-codes the controller image, making it impossible to deploy the plugin with a custom or hardened image without forking the chart. This PR exposes the five image-related Helm values as configurable options:

- `controller.image.registry` — container registry (no default; upstream `values.yaml` leaves this commented out, so the chart resolves it internally)
- `controller.image.image` — image name
- `controller.image.tag` — image tag
- `controller.image.digest` — image digest for the standard variant
- `controller.image.digestChroot` — image digest for the chroot variant

**Motivation:** We need to substitute a hardened, CVE-patched image built from the [chainguard-forks/ingress-nginx](https://github.com/chainguard-forks/ingress-nginx) fork. Without these options exposed in the PluginDefinition, operators cannot override the image via a Greenhouse Plugin resource.

All default values are taken verbatim from the official Helm chart release [helm-chart-4.15.1](https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.15.1):

| Option | Default |
|---|---|
| `controller.image.image` | `ingress-nginx/controller` |
| `controller.image.tag` | `v1.15.1` |
| `controller.image.digest` | `sha256:594ceea76b01c592858f803f9ff4d2cb40542cae2060410b2c95f75907d659e1` |
| `controller.image.digestChroot` | `sha256:af31d00c9d82c612896b380a9003bd36843b7647b98e4588251c66325317bc72` |
| `controller.image.registry` | _(none — not set by default in chart)_ |

PluginDefinition version bumped `1.3.0 → 1.4.0`.

## Breaking Changes

None. All new options are optional with defaults matching the existing chart behaviour, so existing Plugin resources continue to work without changes.

## Issues Fixed

None.

## Other Relevant Information

- Upstream chart source used for defaults: https://github.com/kubernetes/ingress-nginx/releases/tag/helm-chart-4.15.1
- The `registry` field is intentionally left without a default — it is commented out in the upstream `values.yaml` and the chart handles its absence internally.