### PR TITLE
fix(gatekeeper): raise audit pod memory limit

### DIFF
--- a/gatekeeper/charts/Chart.yaml
+++ b/gatekeeper/charts/Chart.yaml
@@ -10,7 +10,7 @@ keywords:
   - opa
   - policy
   - admission-control
-version: 1.0.0
+version: 1.0.1
 appVersion: 3.22.2
 maintainers:
   - name: mikolajkucinski

--- a/gatekeeper/charts/values.yaml
+++ b/gatekeeper/charts/values.yaml
@@ -1,3 +1,8 @@
 # SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and Greenhouse contributors
 # SPDX-License-Identifier: Apache-2.0
 
+gatekeeper:
+  audit:
+    resources:
+      limits:
+        memory: 2Gi

--- a/gatekeeper/plugindefinition.yaml
+++ b/gatekeeper/plugindefinition.yaml
@@ -6,7 +6,7 @@ kind: PluginDefinition
 metadata:
   name: gatekeeper
 spec:
-  version: 1.0.0
+  version: 1.0.1
   displayName: OPA Gatekeeper
   description: |
     Policy controller for Kubernetes admission based on the Open Policy Agent
@@ -18,7 +18,7 @@ spec:
   helmChart:
     name: gatekeeper
     repository: oci://ghcr.io/cloudoperators/greenhouse-extensions/charts
-    version: 1.0.0
+    version: 1.0.1
   options:
     - name: gatekeeper.replicas
       displayName: Controller replicas


### PR DESCRIPTION
## Pull Request Details

The `gatekeeper-audit` pod ships with a **512Mi** memory limit from upstream. On clusters with many objects it gets OOMKilled mid audit becuase it reads the whole cluster inventory on every cycle so it crashloops and never writes violation status. Raise the audit memory limit to 2Gi so the audit can finish.

## Breaking Changes

None.

## Issues Fixed

None.

## Other Relevant Information

None.
